### PR TITLE
aluminium fixes

### DIFF
--- a/kubejs/data/modern_industrialization/recipe/materials/aluminum/macerator/ore_to_raw.json
+++ b/kubejs/data/modern_industrialization/recipe/materials/aluminum/macerator/ore_to_raw.json
@@ -1,0 +1,17 @@
+{
+    "type": "modern_industrialization:macerator",
+    "duration": 200,
+    "eu": 2,
+    "item_inputs": [
+      {
+        "amount": 1,
+        "tag": "c:ores/aluminum"
+      }
+    ],
+    "item_outputs": [
+      {
+        "amount": 3,
+        "item": "alltheores:raw_aluminum"
+      }
+    ]
+}

--- a/kubejs/data/modern_industrialization/recipe/materials/aluminum/macerator/raw_to_clump.json
+++ b/kubejs/data/modern_industrialization/recipe/materials/aluminum/macerator/raw_to_clump.json
@@ -10,8 +10,13 @@
   ],
   "item_outputs": [
     {
-      "amount": 3,
+      "amount": 1,
       "item": "alltheores:aluminum_clump"
+    },
+    {
+      "amount": 1,
+      "item": "alltheores:aluminum_clump",
+      "probability": 0.5
     }
   ]
 }

--- a/kubejs/server_scripts/mods/Modern Industrialization/Aluminum.js
+++ b/kubejs/server_scripts/mods/Modern Industrialization/Aluminum.js
@@ -2,7 +2,9 @@
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
 
 ServerEvents.recipes(event => {
-  event.remove({ id: /alltheores:.*aluminum.*/})
+  event.remove({ id: /alltheores:.*aluminum_ingot_from.*/, not: {id: 'alltheores:aluminum_ingot_from_block'}})
+  event.remove({ id: /alltheores:.*aluminum_dust_from.*/})
+  event.remove({ id: /alltheores:mek_processing\/aluminum.*/})
   event.remove({id: /xycraft_world:.*aluminum.*/})
   event.remove({id: /.*bauxite.*/})
 })

--- a/kubejs/server_scripts/mods/Xycraft/Xycraft_Machines.js
+++ b/kubejs/server_scripts/mods/Xycraft/Xycraft_Machines.js
@@ -3,55 +3,10 @@
 
 ServerEvents.recipes(allthemods => {
 
-  allthemods.remove({ id: 'xycraft_machines:shaped/void_container' })
-  allthemods.remove({ id: 'xycraft_machines:shaped/machine_base' })
-  allthemods.remove({ id: 'xycraft_machines:shaped/machine_base_flipped' })
-  allthemods.remove({ id: 'xycraft_machines:shaped/illumination_field' })
-  allthemods.remove({ id: 'xycraft_machines:shaped/hydro_pump' })
-  allthemods.remove({ id: 'xycraft_machines:shaped/hover_pack' })
-  allthemods.remove({ id: 'xycraft_machines:shaped/foil' })
-  allthemods.remove({ id: 'xycraft_machines:shaped/extractor' })
-
-  allthemods.shaped( 'xycraft_machines:void_container', ['A A','AXA','KKK'], {
-    A: '#c:nuggets/osmium',
-    K: 'xycraft_world:kivi',
-    X: 'xycraft_world:xychorium_gem_dark'
-  }).id('allthemods:xycraft_machines/void_container')
-  allthemods.shaped( 'xycraft_machines:machine_base', ['AK','KA'], {
-    A: '#c:ingots/osmium',
-    K: 'xycraft_world:kivi'
-  }).id('allthemods:xycraft_machines/machine_base')
-  allthemods.shaped( 'xycraft_machines:machine_base', ['KA','AK'], {
-    A: '#c:ingots/osmium',
-    K: 'xycraft_world:kivi'
-  }).id('allthemods:xycraft_machines/machine_base_flipped')
-  allthemods.shaped( 'xycraft_machines:illumination_field', ['AAA','ALA','AAA'], {
-    A: '#xycraft:plates/osmium',
-    L: 'xycraft_machines:light_field'
-  }).id('allthemods:xycraft_machines/illumination_field')
-  allthemods.shaped( 'xycraft_machines:hydro_pump', ['AWA','AIA'], {
-    A: '#c:nuggets/osmium',
-    I: 'xycraft_machines:port_fluid',
-    W: 'xycraft_machines:water_block'
-  }).id('allthemods:xycraft_machines/hydro_pump')
-  allthemods.shaped( 'xycraft_machines:hover_pack', ['A A','AIA','LXL'], {
-    A: '#xycraft:plates/osmium',
-    I: '#c:ingots/iron',
-    L: '#c:leathers',
-    X: '#c:gems/xychorium'
-    }).id('allthemods:xycraft_machines/hover_pack')
-  allthemods.shaped( 'xycraft_machines:foil', ['ANA','AGA','ANA'], {
-    A: '#c:ingots/osmium',
-    G: '#c:glass_blocks/cheap',
-    N: '#c:nuggets/osmium'
-  }).id('allthemods:xycraft_machines/foil')
-  allthemods.shaped( 'xycraft_machines:extractor', ['KIK','APA','ADA'], {
-    A: '#c:ingots/osmium',
-    D: 'minecraft:pointed_dripstone',
-    I: '#xycraft:port',
-    K: 'xycraft_world:kivi',
-    P: 'minecraft:piston'
-  }).id('allthemods:xycraft_machines/extractor')
+  allthemods.replaceInput({mod: 'xycraft_machines'}, '#c:ingots/aluminum', '#c:ingots/osmium')
+  allthemods.replaceInput({mod: 'xycraft_machines'}, '#c:nuggets/aluminum', '#c:nuggets/osmium')
+  allthemods.replaceInput({mod: 'xycraft_machines'}, '#xycraft:plates/aluminum', '#c:plates/osmium')
+  allthemods.replaceInput({mod: 'xycraft_world'}, '#c:nuggets/aluminum', '#c:nuggets/osmium')
 
 })
 

--- a/kubejs/server_scripts/mods/Xycraft/Xycraft_Machines.js
+++ b/kubejs/server_scripts/mods/Xycraft/Xycraft_Machines.js
@@ -7,6 +7,7 @@ ServerEvents.recipes(allthemods => {
   allthemods.replaceInput({mod: 'xycraft_machines'}, '#c:nuggets/aluminum', '#c:nuggets/osmium')
   allthemods.replaceInput({mod: 'xycraft_machines'}, '#xycraft:plates/aluminum', '#c:plates/osmium')
   allthemods.replaceInput({mod: 'xycraft_world'}, '#c:nuggets/aluminum', '#c:nuggets/osmium')
+  allthemods.replaceInput({mod: 'xycraft_world'}, '#c:ingots/aluminum', '#c:ingots/osmium')
 
 })
 


### PR DESCRIPTION
- replaces the remaining xycraft recipes to use osmium instead of aluminium

- fixed issue with the modified aluminium processing recipes to bring it in line with other ore maceration recipes in MI