### PR TITLE
Prevent Priest spawn

### DIFF
--- a/config/incontrol/spawn.json
+++ b/config/incontrol/spawn.json
@@ -1,0 +1,6 @@
+[
+    {
+      "mob": "irons_spellbooks:priest",
+      "result": "deny"
+    }
+]


### PR DESCRIPTION
Should prevent priest spawns, will not kill the ones that exist.  Until we get a proper solution from Geckolib  Requires In Control https://www.curseforge.com/minecraft/mc-mods/in-control/files/5491379