### PR TITLE
Miscellaneous fixes and additions

### DIFF
--- a/kubejs/server_scripts/Tweaks/tags.js
+++ b/kubejs/server_scripts/Tweaks/tags.js
@@ -3,10 +3,15 @@
 
 ServerEvents.tags('block', allthemods => {
   allthemods.add('ftbchunks:interact_whitelist', ['@waystones'])
+
+  //Extreme Reactors
+  allthemods.add('c:storage_blocks/yellorium', 'alltheores:uranium_block' )
 })
 
 ServerEvents.tags('item', allthemods => {
+  //Extreme Reactors
   allthemods.add('c:ingots/yellorium', 'alltheores:uranium_ingot' )
+  allthemods.add('c:storage_blocks/yellorium', 'alltheores:uranium_block' )
 })
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 9.
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.

--- a/kubejs/server_scripts/Tweaks/tags.js
+++ b/kubejs/server_scripts/Tweaks/tags.js
@@ -4,5 +4,9 @@
 ServerEvents.tags('block', allthemods => {
   allthemods.add('ftbchunks:interact_whitelist', ['@waystones'])
 })
+
+ServerEvents.tags('item', allthemods => {
+  allthemods.add('c:ingots/yellorium', 'alltheores:uranium_ingot' )
+})
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 9.
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.

--- a/kubejs/server_scripts/mods/Applied Energistics/Recipes.js
+++ b/kubejs/server_scripts/mods/Applied Energistics/Recipes.js
@@ -19,6 +19,7 @@ ServerEvents.recipes(allthemods => {
         E: 'ae2:engineering_processor_press'
     }).id('allthemods:universal_press')
 
+
     function universalPress(input, output, id) {
         allthemods.custom(
             {
@@ -39,6 +40,67 @@ ServerEvents.recipes(allthemods => {
             }
         ).id(`kubejs:inscriber/universal_press/${id}`)
     }
+    function createCrystalAssemblerRecipe(output, inputs, id, fluid) {
+        let recipe = {
+            "type": "extendedae:crystal_assembler",
+            "input_items": [],
+            "output": {
+                "id": output.item,
+                "count": output.count || 1
+            }
+        };
+
+        if (fluid) {
+            recipe.input_fluid = {
+                "amount": fluid.amount || 1000,
+                "ingredient":{
+                    "fluid": fluid.fluid,
+                }
+
+            };
+
+        }
+
+        inputs.forEach(input => {
+            let ingredient = {
+                "amount": input.count || 1,
+                "ingredient": {}
+            };
+
+            if (input.tag) {
+                ingredient.ingredient.tag = input.tag;
+            } else {
+                ingredient.ingredient.item = input.item;
+            }
+
+            recipe.input_items.push(ingredient);
+        });
+
+        allthemods.custom(recipe).id(`kubejs:crystal_assembler/${id}`);
+    }
+
+
+    createCrystalAssemblerRecipe(
+        { item: 'megacells:sky_bronze_ingot', count: 8 },
+        [
+            { item: 'ae2:charged_certus_quartz_crystal', count: 4 },
+            { item: 'minecraft:copper_ingot', count: 4 },
+            { item: 'ae2:sky_stone_block', count: 4 }
+        ],
+        'sky_bronze_ingot',
+        { fluid:'minecraft:lava', count: 1000}
+    );
+    createCrystalAssemblerRecipe(
+        { item: 'megacells:sky_osmium_ingot', count: 8 },
+        [
+            { item: 'ae2:charged_certus_quartz_crystal', count: 4 },
+            { item: '#c:ingots/osmium', count: 4 },
+            { item: 'ae2:sky_stone_block', count: 4 }
+        ],
+        'sky_osmium_ingot',
+        { fluid:'minecraft:lava', count: 1000}
+    );
+
 
     universalPress('ae2:silicon', 'ae2:printed_silicon', 'printed_silicon')
     universalPress('ae2:certus_quartz_crystal', 'ae2:printed_calculation_processor', 'printed_calculation_processor')

--- a/kubejs/server_scripts/mods/Applied Energistics/Recipes.js
+++ b/kubejs/server_scripts/mods/Applied Energistics/Recipes.js
@@ -10,6 +10,15 @@ ServerEvents.recipes(allthemods => {
       N: 'minecraft:netherite_ingot'
   }).id('allthemods:aeinfinitybooster/infinity_card')
 
+    allthemods.shaped('kubejs:universal_press', ['FPF', 'CSL', 'FEF'], {
+        F: '#c:ingots/sky_steel',
+        P: 'ae2:silicon_press',
+        C: 'ae2:calculation_processor_press',
+        S: 'minecraft:slime_ball',
+        L: 'ae2:logic_processor_press',
+        E: 'ae2:engineering_processor_press'
+    }).id('allthemods:universal_press')
+
   function universalPress(input, output, id) {
       allthemods.custom(
           {

--- a/kubejs/server_scripts/mods/Applied Energistics/Recipes.js
+++ b/kubejs/server_scripts/mods/Applied Energistics/Recipes.js
@@ -2,13 +2,13 @@
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
 
 ServerEvents.recipes(allthemods => {
-  allthemods.remove({ id: 'aeinfinitybooster:infinity_card' })
-  allthemods.shaped('aeinfinitybooster:infinity_card', ['EBE', 'BUB', 'NNN'], {
-      U: 'alltheores:lumium_gear',
-      B: 'ae2:wireless_booster',
-      E: 'alltheores:enderium_gear',
-      N: 'minecraft:netherite_ingot'
-  }).id('allthemods:aeinfinitybooster/infinity_card')
+    allthemods.remove({ id: 'aeinfinitybooster:infinity_card' })
+    allthemods.shaped('aeinfinitybooster:infinity_card', ['EBE', 'BUB', 'NNN'], {
+        U: 'alltheores:lumium_gear',
+        B: 'ae2:wireless_booster',
+        E: 'alltheores:enderium_gear',
+        N: 'minecraft:netherite_ingot'
+    }).id('allthemods:aeinfinitybooster/infinity_card')
 
     allthemods.shaped('kubejs:universal_press', ['FPF', 'CSL', 'FEF'], {
         F: '#c:ingots/sky_steel',
@@ -19,32 +19,35 @@ ServerEvents.recipes(allthemods => {
         E: 'ae2:engineering_processor_press'
     }).id('allthemods:universal_press')
 
-  function universalPress(input, output, id) {
-      allthemods.custom(
-          {
-              type: 'ae2:inscriber',
-              ingredients: {
-                  top: {
-                      item: 'kubejs:universal_press'
-                  },
-                  middle: {
-                      item: input
-                  }
-              },
-              mode: 'inscribe',
-              result: {
-                  count: 1,
-                  id: output
-              }
-          }
-      ).id(`kubejs:inscriber/universal_press/${id}`)
-  }
+    function universalPress(input, output, id) {
+        allthemods.custom(
+            {
+                type: 'ae2:inscriber',
+                ingredients: {
+                    top: {
+                        item: 'kubejs:universal_press'
+                    },
+                    middle: {
+                        item: input
+                    }
+                },
+                mode: 'inscribe',
+                result: {
+                    count: 1,
+                    id: output
+                }
+            }
+        ).id(`kubejs:inscriber/universal_press/${id}`)
+    }
 
-  universalPress('ae2:silicon', 'ae2:printed_silicon', 'printed_silicon')
-  universalPress('ae2:certus_quartz_crystal', 'ae2:printed_calculation_processor', 'printed_calculation_processor')
-  universalPress('minecraft:diamond', 'ae2:printed_engineering_processor', 'printed_engineering_processor')
-  universalPress('minecraft:gold_ingot', 'ae2:printed_logic_processor', 'printed_logic_processor')
-  universalPress('minecraft:iron_block', 'kubejs:universal_press', 'universal_press_duplicate')
+    universalPress('ae2:silicon', 'ae2:printed_silicon', 'printed_silicon')
+    universalPress('ae2:certus_quartz_crystal', 'ae2:printed_calculation_processor', 'printed_calculation_processor')
+    universalPress('minecraft:diamond', 'ae2:printed_engineering_processor', 'printed_engineering_processor')
+    universalPress('minecraft:gold_ingot', 'ae2:printed_logic_processor', 'printed_logic_processor')
+    universalPress('megacells:sky_steel_ingot', 'megacells:printed_accumulation_processor', 'printed_accumulation_processor')
+    universalPress('appflux:charged_redstone', 'appflux:printed_energy_processor', 'printed_energy_processor')
+    universalPress('extendedae:entro_crystal', 'extendedae:concurrent_processor_print', 'concurrent_processor_print')
+    universalPress('minecraft:iron_block', 'kubejs:universal_press', 'universal_press_duplicate')
 
     const colors = [
         'white', 'yellow', 'orange', 'red', 'pink', 'magenta', 'purple', 'light_blue', 'cyan', 'blue', 'lime', 'green', 'brown', 'light_gray', 'gray', 'black'
@@ -57,8 +60,8 @@ ServerEvents.recipes(allthemods => {
         allthemods.shapeless(`ae2:${color}_smart_dense_cable`, [`4x ae2:${color}_smart_cable`]).id(`allthemods:ae2/${color}_smart_to_dense`);
     });
 
-  allthemods.shapeless(` 4x ae2:fluix_covered_cable`,[`ae2:fluix_covered_dense_cable`]).id(`allthemods:ae2/dense_to_normal`)
-  allthemods.shapeless(` 4x ae2:fluix_smart_cable`,[`ae2:fluix_smart_dense_cable`]).id(`allthemods:ae2/smart_dense_to_smart_normal`)
+    allthemods.shapeless(` 4x ae2:fluix_covered_cable`,[`ae2:fluix_covered_dense_cable`]).id(`allthemods:ae2/dense_to_normal`)
+    allthemods.shapeless(` 4x ae2:fluix_smart_cable`,[`ae2:fluix_smart_dense_cable`]).id(`allthemods:ae2/smart_dense_to_smart_normal`)
   
 })
 

--- a/kubejs/server_scripts/mods/ExtremeReactors/Recipes.js
+++ b/kubejs/server_scripts/mods/ExtremeReactors/Recipes.js
@@ -1,0 +1,43 @@
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
+
+ServerEvents.recipes(allthemods => {
+
+    function fluidizer(input, inamount, output, outamount, id) {
+        allthemods.custom(
+            {
+                type: "bigreactors:fluidizersolid",
+                ingredient: {
+                    count: inamount,
+                    ingredient: {
+                        type: "neoforge:components",
+                        components: {
+                            "minecraft:attribute_modifiers": {
+                                modifiers: []
+                            },
+                            "minecraft:enchantments": {
+                                levels: {}
+                            },
+                            "minecraft:lore": [],
+                            "minecraft:max_stack_size": 64,
+                            "minecraft:rarity": "common",
+                            "minecraft:repair_cost": 0
+                        },
+                        items: input,
+                        strict: true
+                    }
+                },
+                result: {
+                    amount: outamount,
+                    id: output
+                }
+            }
+        ).id(`allthemods:fluidizersolid/${id}`)
+    }
+
+    fluidizer('#c:ingots/yellorium', 1 , 'bigreactors:yellorium', 1000, 'ingot_yellorium')
+    fluidizer('#c:storage_blocks/yellorium', 1 , 'bigreactors:yellorium', 9000, 'block_yellorium')
+})
+
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.

--- a/kubejs/server_scripts/mods/JustDireThings/Recipes.js
+++ b/kubejs/server_scripts/mods/JustDireThings/Recipes.js
@@ -1,0 +1,15 @@
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
+
+ServerEvents.recipes(allthemods => {
+
+    //This is the same recipe as the one on dire's github. It currently just overrides the old one to make EMI recognize it
+    allthemods.smithing(
+        'justdirethings:celestigem_paxel',
+        'justdirethings:celestigem_axe',
+        'justdirethings:celestigem_shovel')
+        .template('justdirethings:celestigem_pickaxe');
+})
+
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.


### PR DESCRIPTION
- added the recipe for the `Universal Press` back 
(DJ said it wasn't added because the Crystal Assemblers made it obsolete, but the consensus in the Discord was that it'd be useful anyways.)
- allows the universal press to craft **all circuits**, including the ones from the **addons** 
(after some discussion in the Discord, it was agreed that this would be a fair "buff", but if it's too op, just remove it)
- added a function to allow for custom `Crystal Assembler Recipes`
- added `Sky Bronze Ingot` and `Sky Osmium Ingot` recipe using said function
(05cc575 theoretically already adds this, however only via manually writing the recipe json files and adding them to the `kubejs/data` folder)
- added the `c:ingots/yellorium` tag to the `uranium ingot` to fix the currently broken `Extreme Reactors` recipes, relying on the yellorium tag