### PR TITLE
Productive Trees Quest Work and Quest Fixes

### DIFF
--- a/config/ftbquests/quests/chapters/ars_nouveau.snbt
+++ b/config/ftbquests/quests/chapters/ars_nouveau.snbt
@@ -21,14 +21,21 @@
 	quests: [
 		{
 			id: "6E0E13806F388D7E"
-			rewards: [{
-				id: "24AA489F2E015748"
-				item: {
-					count: 1
-					id: "ars_nouveau:worn_notebook"
+			rewards: [
+				{
+					id: "24AA489F2E015748"
+					item: {
+						count: 1
+						id: "ars_nouveau:worn_notebook"
+					}
+					type: "item"
 				}
-				type: "item"
-			}]
+				{
+					id: "0CBEB0DD40A9CB80"
+					type: "xp"
+					xp: 10
+				}
+			]
 			shape: "gear"
 			size: 1.5d
 			tasks: [{
@@ -94,9 +101,9 @@
 			dependencies: ["6F3602F5600A6221"]
 			id: "7ACE7A6A71D3F4D2"
 			rewards: [{
-				id: "06CC6FB96FDA2F42"
+				id: "5380945A05E398B2"
 				type: "xp"
-				xp: 250
+				xp: 200
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -128,9 +135,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "79146466E43A2B99"
 			rewards: [{
-				id: "2A7E9481610EF8CE"
+				id: "180B4B5D8087A19D"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -162,9 +169,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "05C2A6E54898C963"
 			rewards: [{
-				id: "1D22D2CA15F8A4D3"
+				id: "04FC211787AEC5BD"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -213,9 +220,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "295703FC5B92D0E6"
 			rewards: [{
-				id: "6DE20BFC516C9D93"
+				id: "7331621CFCEB6185"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -247,9 +254,9 @@
 			dependencies: ["6F3602F5600A6221"]
 			id: "00143D4FC12AEFD9"
 			rewards: [{
-				id: "0611C740983E448E"
+				id: "382749097CE9D9BA"
 				type: "xp"
-				xp: 250
+				xp: 200
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -264,9 +271,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "73D19C0C1836CD03"
 			rewards: [{
-				id: "76E52105DFA1D72B"
+				id: "30C8E586A46FD0CD"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -281,9 +288,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "18BC056B55C25EB5"
 			rewards: [{
-				id: "66715F05B72746A8"
+				id: "74A23A5B54BD7E5E"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -298,9 +305,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "5F75215CB5956290"
 			rewards: [{
-				id: "183520B645B94E0A"
+				id: "48DD2081936F2CF0"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -315,9 +322,9 @@
 			dependencies: ["6F3602F5600A6221"]
 			id: "2714EE46B4DF620E"
 			rewards: [{
-				id: "0E66259E403E2C95"
+				id: "1D092894859BB4C9"
 				type: "xp"
-				xp: 250
+				xp: 200
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -332,9 +339,9 @@
 			dependencies: ["6F3602F5600A6221"]
 			id: "0EC08C5BBFA83A51"
 			rewards: [{
-				id: "4AF328709D941E3A"
+				id: "62411BF4000B671D"
 				type: "xp"
-				xp: 250
+				xp: 200
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -349,9 +356,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "7F97805EE8DFC9F6"
 			rewards: [{
-				id: "75CB1B6486A4A1BA"
+				id: "7CC0459E8657617D"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -366,9 +373,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "62A9FD6138446A17"
 			rewards: [{
-				id: "10F069AD9A83E88E"
+				id: "053FF9E8C45060D6"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -383,9 +390,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "36183375DAA54408"
 			rewards: [{
-				id: "4A8CCAD32C41B1F0"
+				id: "144ACC0A8CA605B9"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -400,9 +407,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "46469E3A8AF0CB80"
 			rewards: [{
-				id: "7ED14CED220DB1A0"
+				id: "6BE322E2E17CC091"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -451,9 +458,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "5F7A07D0F71044D2"
 			rewards: [{
-				id: "7F198E2F1F196E71"
+				id: "5C4373D170DB6506"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -468,9 +475,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "2CD1B2BCEDA0D473"
 			rewards: [{
-				id: "37BF85F7140B1BA5"
+				id: "53C8DDD39BC82F31"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -502,9 +509,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "0641F45BEA6C67E5"
 			rewards: [{
-				id: "0FFF8CAFF06616E6"
+				id: "7D15D979F2646C06"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -570,9 +577,9 @@
 			dependencies: ["6F3602F5600A6221"]
 			id: "7AAD3CE642A34A0C"
 			rewards: [{
-				id: "74B74CC8FDF44689"
+				id: "38102A2A0F8DA5A6"
 				type: "xp"
-				xp: 250
+				xp: 200
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -621,9 +628,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "4CAC87774C1B15C0"
 			rewards: [{
-				id: "2483EB293F404A34"
+				id: "114B29A303FE72F8"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -638,9 +645,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "1038054E334AC792"
 			rewards: [{
-				id: "56F859C404D06D60"
+				id: "3F7B8E2EB23772FB"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -655,9 +662,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "30B8E8169EAE1C01"
 			rewards: [{
-				id: "4A88E180796EF97D"
+				id: "0A9F52565D3A1C88"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -706,9 +713,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "290F943A1FF52070"
 			rewards: [{
-				id: "1243EAD7C7EF2671"
+				id: "159A57D370A30070"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -740,9 +747,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "66D63DC37FCDD268"
 			rewards: [{
-				id: "13807DD4DB0DF579"
+				id: "689041E40D7B21AD"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -825,9 +832,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "3A44DCF5B7D5024C"
 			rewards: [{
-				id: "0335AC3EC7F9AFD3"
+				id: "089F4370DF1DC77E"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -859,9 +866,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "5DE36D1C9F29F931"
 			rewards: [{
-				id: "711554480E47E3EE"
+				id: "6E337A59B9B26F03"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -876,9 +883,9 @@
 			dependencies: ["6F3602F5600A6221"]
 			id: "16C47409C0A411EF"
 			rewards: [{
-				id: "78B74A293DA4C554"
+				id: "7054D9D4D6E90D6C"
 				type: "xp"
-				xp: 250
+				xp: 200
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -894,9 +901,9 @@
 			dependency_requirement: "one_started"
 			id: "3801E818308438FF"
 			rewards: [{
-				id: "5A23E05D4AB7A880"
+				id: "534EF07A33B6FE24"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -911,9 +918,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "485EE9E6C6F59826"
 			rewards: [{
-				id: "62E2BDCDD8BD192C"
+				id: "0ACADF4272139938"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -928,9 +935,9 @@
 			dependencies: ["6F3602F5600A6221"]
 			id: "4F5FCEBB16B5B6F5"
 			rewards: [{
-				id: "7E0B39C013F2A024"
+				id: "066F2B1886D6A5CB"
 				type: "xp"
-				xp: 250
+				xp: 200
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -961,6 +968,11 @@
 		{
 			dependencies: ["3D4D88B8BE881351"]
 			id: "63DD7F5A4441ACE7"
+			rewards: [{
+				id: "1E335E020ED33E16"
+				type: "xp"
+				xp: 15
+			}]
 			shape: "hexagon"
 			tasks: [{
 				id: "15C6E9C02D1FBEC0"
@@ -972,6 +984,11 @@
 		{
 			dependencies: ["3D4D88B8BE881351"]
 			id: "441C0659ED28D935"
+			rewards: [{
+				id: "0EE072E9D039EEA5"
+				type: "xp"
+				xp: 10
+			}]
 			shape: "hexagon"
 			tasks: [{
 				id: "1CC556A6921208B8"
@@ -983,6 +1000,11 @@
 		{
 			dependencies: ["3D4D88B8BE881351"]
 			id: "6F3602F5600A6221"
+			rewards: [{
+				id: "606A80F8EB776A14"
+				type: "xp"
+				xp: 20
+			}]
 			shape: "hexagon"
 			tasks: [{
 				id: "65D68BEEB36FC805"
@@ -1022,12 +1044,19 @@
 		{
 			dependencies: ["18A2FBE2D4133FA2"]
 			id: "3D862A3D3F83CA26"
-			rewards: [{
-				exclude_from_claim_all: true
-				id: "189593D6855C1553"
-				table_id: 6355363837720688303L
-				type: "random"
-			}]
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "189593D6855C1553"
+					table_id: 6355363837720688303L
+					type: "random"
+				}
+				{
+					id: "08DB8A3EAE32ED63"
+					type: "xp"
+					xp: 100
+				}
+			]
 			shape: "hexagon"
 			size: 1.25d
 			tasks: [
@@ -1120,9 +1149,9 @@
 			dependencies: ["6F3602F5600A6221"]
 			id: "29E3DD9A3F85CE80"
 			rewards: [{
-				id: "24B9ED813A6ACDB6"
+				id: "76FB217022944E1A"
 				type: "xp"
-				xp: 250
+				xp: 200
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -1137,9 +1166,9 @@
 			dependencies: ["6F3602F5600A6221"]
 			id: "44D5ABE34271D7FE"
 			rewards: [{
-				id: "43BD5FE7A425EB01"
+				id: "444FA834D132920C"
 				type: "xp"
-				xp: 250
+				xp: 200
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -1405,15 +1434,15 @@
 			id: "3D4D88B8BE881351"
 			rewards: [
 				{
-					id: "4E42BB4E02799D87"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "3E6848E4C4E1CEBB"
 					table_id: 6355363837720688303L
 					type: "random"
+				}
+				{
+					id: "7571C36212112956"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "gear"
@@ -1483,15 +1512,15 @@
 			id: "0D330FAD6C993DBC"
 			rewards: [
 				{
-					id: "0BC389F7E63D4F9F"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "39687FD9559EA51C"
 					table_id: 6355363837720688303L
 					type: "random"
+				}
+				{
+					id: "52C538AB1A298525"
+					type: "xp"
+					xp: 100
 				}
 			]
 			tasks: [{
@@ -1507,15 +1536,15 @@
 			id: "17D7D34F519F7E5F"
 			rewards: [
 				{
-					id: "0069DCEFE2EC5E72"
-					type: "xp"
-					xp: 1000
-				}
-				{
 					exclude_from_claim_all: true
 					id: "61EBAA9E5F85E605"
 					table_id: 6355363837720688303L
 					type: "random"
+				}
+				{
+					id: "59CAE0E4B3339A4E"
+					type: "xp"
+					xp: 500
 				}
 			]
 			tasks: [{
@@ -1529,12 +1558,19 @@
 		{
 			dependencies: ["18A2FBE2D4133FA2"]
 			id: "457DE8C154641437"
-			rewards: [{
-				exclude_from_claim_all: true
-				id: "34CFBF7EBA0B2E5D"
-				table_id: 6355363837720688303L
-				type: "random"
-			}]
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "34CFBF7EBA0B2E5D"
+					table_id: 6355363837720688303L
+					type: "random"
+				}
+				{
+					id: "19BBD3F775EF438D"
+					type: "xp"
+					xp: 100
+				}
+			]
 			shape: "diamond"
 			size: 1.5d
 			tasks: [{
@@ -1550,15 +1586,15 @@
 			id: "04D9F6587EF8D9B7"
 			rewards: [
 				{
-					id: "57D993FC63FEFE77"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "1671946D01284C8F"
 					table_id: 6355363837720688303L
 					type: "random"
+				}
+				{
+					id: "3010DFC791725CD1"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "hexagon"
@@ -1575,11 +1611,6 @@
 			id: "5766C8B9E850C186"
 			rewards: [
 				{
-					id: "09511C532C90CDE3"
-					type: "xp"
-					xp: 10
-				}
-				{
 					count: 2
 					id: "62B7E8C87CCD5E12"
 					item: {
@@ -1588,6 +1619,11 @@
 					}
 					random_bonus: 2
 					type: "item"
+				}
+				{
+					id: "76B7FFF26BE79D65"
+					type: "xp"
+					xp: 50
 				}
 			]
 			tasks: [{
@@ -1613,22 +1649,14 @@
 				{
 					id: "5C16757EA6C22406"
 					type: "xp"
-					xp: 100
+					xp: 50
 				}
 			]
-			tasks: [
-				{
-					count: 2L
-					id: "181BAEE44F0E8720"
-					item: { count: 1, id: "ars_nouveau:archwood_planks" }
-					type: "item"
-				}
-				{
-					id: "2BC0F5A88E2F03C3"
-					item: { components: { "ftbfiltersystem:filter": "ftbfiltersystem:item_tag(c:logs/archwood)" }, count: 1, id: "ftbfiltersystem:smart_filter" }
-					type: "item"
-				}
-			]
+			tasks: [{
+				id: "2BC0F5A88E2F03C3"
+				item: { components: { "ftbfiltersystem:filter": "ftbfiltersystem:item_tag(c:logs/archwood)" }, count: 1, id: "ftbfiltersystem:smart_filter" }
+				type: "item"
+			}]
 			x: -1.0d
 			y: 0.0d
 		}
@@ -1751,9 +1779,9 @@
 			dependencies: ["6F3602F5600A6221"]
 			id: "73C7A44F05AB6FAC"
 			rewards: [{
-				id: "5A905E4BD4F8092C"
+				id: "59E41F4B85D1DF72"
 				type: "xp"
-				xp: 250
+				xp: 200
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -1785,9 +1813,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "407AD700892ADBF1"
 			rewards: [{
-				id: "34208794F55297FD"
+				id: "77C4576E4E086331"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -1803,15 +1831,15 @@
 			id: "19D02325579F2AA8"
 			rewards: [
 				{
-					id: "770A6318647CD783"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "7BED4418D3734649"
 					table_id: 6355363837720688303L
 					type: "random"
+				}
+				{
+					id: "74063EE17B592B0B"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "hexagon"
@@ -1826,12 +1854,19 @@
 		{
 			dependencies: ["0E2AD156E5EF263A"]
 			id: "151648179684B088"
-			rewards: [{
-				exclude_from_claim_all: true
-				id: "4B21C12F45C3BDDC"
-				table_id: 6355363837720688303L
-				type: "random"
-			}]
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "4B21C12F45C3BDDC"
+					table_id: 6355363837720688303L
+					type: "random"
+				}
+				{
+					id: "7F60DB0F171B82C9"
+					type: "xp"
+					xp: 100
+				}
+			]
 			tasks: [{
 				id: "2E649D2172E6D537"
 				item: { count: 1, id: "ars_nouveau:runic_chalk" }
@@ -1969,9 +2004,9 @@
 			dependencies: ["6F3602F5600A6221"]
 			id: "4A41FCBFE985D81E"
 			rewards: [{
-				id: "400099F57136829D"
+				id: "0E6F07E3325EF0AC"
 				type: "xp"
-				xp: 250
+				xp: 200
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -1986,9 +2021,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "790C77898FED4E5D"
 			rewards: [{
-				id: "012CAAC458234260"
+				id: "451B7BA1CEBF45FE"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -2003,9 +2038,9 @@
 			dependencies: ["6F3602F5600A6221"]
 			id: "7F3EB3F473DF8385"
 			rewards: [{
-				id: "49FE505047D7DA5B"
+				id: "565B6C2496F15D99"
 				type: "xp"
-				xp: 250
+				xp: 200
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -2020,9 +2055,9 @@
 			dependencies: ["6F3602F5600A6221"]
 			id: "08B6FA532A136AF2"
 			rewards: [{
-				id: "730F984D1201E8F4"
+				id: "60370B165A4B1C74"
 				type: "xp"
-				xp: 250
+				xp: 200
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -2071,9 +2106,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "11C2D56F3D382573"
 			rewards: [{
-				id: "73AC0617FCAE9088"
+				id: "5DCB4B1724B70622"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -2088,9 +2123,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "3D00118E2760D129"
 			rewards: [{
-				id: "00305DC754DB0F35"
+				id: "7DCD14914CCFD3AD"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -2105,9 +2140,9 @@
 			dependencies: ["63DD7F5A4441ACE7"]
 			id: "7F69A7CD6ACA97D7"
 			rewards: [{
-				id: "584920D123AAE05F"
+				id: "34428D088F52BB36"
 				type: "xp"
-				xp: 100
+				xp: 150
 			}]
 			shape: "rsquare"
 			tasks: [{
@@ -2195,15 +2230,15 @@
 					type: "item"
 				}
 				{
-					id: "383031B91565B2F6"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "57E212F3AFEC7296"
 					table_id: 6355363837720688303L
 					type: "random"
+				}
+				{
+					id: "7B1275849A889C46"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "octagon"
@@ -2239,15 +2274,15 @@
 			id: "295C77EEC89000FC"
 			rewards: [
 				{
-					id: "42C6A17CF858CF08"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "300E8FF71B9FA605"
 					table_id: 6355363837720688303L
 					type: "random"
+				}
+				{
+					id: "3DA6ED2B374E1FDE"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "hexagon"
@@ -2264,15 +2299,15 @@
 			id: "41A0BE357C8A74E1"
 			rewards: [
 				{
-					id: "5D9B8AC5306D8C48"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "35FAE533921A6B6F"
 					table_id: 6355363837720688303L
 					type: "random"
+				}
+				{
+					id: "22B67945E004D8E3"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "hexagon"
@@ -2289,15 +2324,15 @@
 			id: "77145113CD5B26FB"
 			rewards: [
 				{
-					id: "5A7B1F43A9CF4B29"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "142150641CC1E71D"
 					table_id: 6355363837720688303L
 					type: "random"
+				}
+				{
+					id: "7CED5BC7034CECBC"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "hexagon"
@@ -2314,15 +2349,15 @@
 			id: "2D0CF18C8B2ABB7D"
 			rewards: [
 				{
-					id: "5FFE6FE428A53B3F"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "4495F8A43D6942E5"
 					table_id: 6355363837720688303L
 					type: "random"
+				}
+				{
+					id: "37079BCFF87D14B7"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "hexagon"
@@ -2391,15 +2426,15 @@
 			id: "1D86B2E553503E53"
 			rewards: [
 				{
-					id: "41EAC17DF7C0BCED"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "4A8ABA537B682C1C"
 					table_id: 6355363837720688303L
 					type: "random"
+				}
+				{
+					id: "7573A7ECFA9E860E"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "rsquare"

--- a/config/ftbquests/quests/chapters/extreme_reactors.snbt
+++ b/config/ftbquests/quests/chapters/extreme_reactors.snbt
@@ -60,8 +60,19 @@
 			id: "7C4E4793DA887DE4"
 			rewards: [
 				{
+					id: "08AC2295DBD8B915"
+					item: {
+						components: {
+							"patchouli:book": "bigreactors:erguide"
+						}
+						count: 1
+						id: "patchouli:guide_book"
+					}
+					type: "item"
+				}
+				{
 					count: 3
-					id: "1C213B4FE894781D"
+					id: "17C6667F09D439F1"
 					item: {
 						count: 1
 						id: "alltheores:raw_uranium"
@@ -69,7 +80,7 @@
 					type: "item"
 				}
 				{
-					id: "4FA70911ADBAF967"
+					id: "7733E4DC78031241"
 					type: "xp"
 					xp: 10
 				}
@@ -339,8 +350,8 @@
 				item: { count: 4, id: "alltheores:uranium_ingot" }
 				type: "item"
 			}]
-			x: -7.5d
-			y: 8.0d
+			x: -7.0d
+			y: 9.0d
 		}
 		{
 			dependencies: ["4AD8363D7359A072"]
@@ -475,15 +486,15 @@
 			progression_mode: "linear"
 			rewards: [
 				{
-					id: "2D71A6EF1CA59FA7"
-					type: "xp"
-					xp: 10
-				}
-				{
 					exclude_from_claim_all: true
 					id: "52181A03434A605B"
 					table_id: 487623848494439020L
 					type: "random"
+				}
+				{
+					id: "0572948909199F86"
+					type: "xp"
+					xp: 10
 				}
 			]
 			tasks: [{
@@ -546,7 +557,7 @@
 				{
 					id: "73F2B06136C86A4E"
 					type: "xp"
-					xp: 100
+					xp: 50
 				}
 			]
 			shape: "diamond"

--- a/config/ftbquests/quests/chapters/food_and_farming.snbt
+++ b/config/ftbquests/quests/chapters/food_and_farming.snbt
@@ -110,6 +110,9 @@
 	quest_links: [ ]
 	quests: [
 		{
+			icon: {
+				id: "croptopia:starfruit"
+			}
 			id: "1827DEEA2DF1B144"
 			rewards: [
 				{
@@ -129,8 +132,9 @@
 			shape: "square"
 			size: 1.5d
 			tasks: [{
-				id: "07603A90CCCB3627"
-				type: "checkmark"
+				id: "78D7794707E4BD83"
+				item: { components: { "ftbfiltersystem:filter": "ftbfiltersystem:item_tag(c:crops)" }, count: 1, id: "ftbfiltersystem:smart_filter" }
+				type: "item"
 			}]
 			x: 0.5d
 			y: 0.0d
@@ -165,6 +169,9 @@
 		}
 		{
 			dependencies: ["18EADBAFC932F864"]
+			icon: {
+				id: "minecraft:white_wool"
+			}
 			id: "3EA883C0BB7BD38F"
 			rewards: [
 				{
@@ -246,15 +253,15 @@
 					type: "item"
 				}
 				{
-					id: "72142B51809511CF"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "4F333F2FC9C0A269"
 					table_id: 487623848494439020L
 					type: "random"
+				}
+				{
+					id: "547FC038410FD238"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "rsquare"
@@ -354,7 +361,7 @@
 		}
 		{
 			icon: {
-				id: "minecraft:wooden_hoe"
+				id: "minecraft:iron_hoe"
 			}
 			id: "43021923E220CF68"
 			rewards: [
@@ -376,8 +383,9 @@
 			shape: "diamond"
 			size: 1.25d
 			tasks: [{
-				id: "78772A2785AE9DD2"
-				type: "checkmark"
+				id: "323A434E1AF54408"
+				item: { components: { "ftbfiltersystem:filter": "ftbfiltersystem:item_tag(minecraft:hoes)" }, count: 1, id: "ftbfiltersystem:smart_filter" }
+				type: "item"
 			}]
 			x: -1.5749999999999997d
 			y: 0.0d
@@ -432,17 +440,17 @@
 			id: "361DFDB1E1352D6B"
 			rewards: [
 				{
-					id: "2D2FC5CA58E15FD7"
-					type: "xp"
-					xp: 10
-				}
-				{
 					id: "193719E857969260"
 					item: {
 						count: 1
 						id: "minecraft:sugar"
 					}
 					type: "item"
+				}
+				{
+					id: "4DA79EDA168E4CFA"
+					type: "xp"
+					xp: 10
 				}
 			]
 			tasks: [{
@@ -564,7 +572,7 @@
 				item: { count: 1, id: "cookingforblockheads:cabinet" }
 				type: "item"
 			}]
-			x: 0.5d
+			x: 1.5d
 			y: 8.5d
 		}
 		{
@@ -931,6 +939,31 @@
 			]
 			x: 0.5d
 			y: 2.0d
+		}
+		{
+			icon: {
+				id: "cookingforblockheads:white_fridge"
+			}
+			id: "791AE62ACACBD5BA"
+			shape: "diamond"
+			tasks: [{
+				id: "669DEA201002793D"
+				item: { components: { "ftbfiltersystem:filter": "ftbfiltersystem:item_tag(cookingforblockheads:fridges)" }, count: 1, id: "ftbfiltersystem:smart_filter" }
+				type: "item"
+			}]
+			x: 0.5d
+			y: 8.5d
+		}
+		{
+			id: "2786D5AC19163524"
+			shape: "diamond"
+			tasks: [{
+				id: "758CA2EB2C92A6AA"
+				item: { count: 1, id: "cookingforblockheads:white_oven" }
+				type: "item"
+			}]
+			x: -0.5d
+			y: 8.5d
 		}
 	]
 }

--- a/config/ftbquests/quests/chapters/iron_spells_and_spellbooks.snbt
+++ b/config/ftbquests/quests/chapters/iron_spells_and_spellbooks.snbt
@@ -159,6 +159,7 @@
 	quest_links: [ ]
 	quests: [
 		{
+			hide_dependent_lines: true
 			icon: {
 				id: "minecraft:book"
 			}
@@ -182,6 +183,7 @@
 			y: -6.5d
 		}
 		{
+			dependencies: ["615C3E012B2DECD3"]
 			id: "7408CCF998D9CD37"
 			rewards: [{
 				id: "4A55C808BAC88ECE"
@@ -301,6 +303,7 @@
 			y: -6.5d
 		}
 		{
+			dependencies: ["615C3E012B2DECD3"]
 			id: "66762A4743104157"
 			rewards: [{
 				id: "7CF77C5B3E6D55F7"
@@ -320,6 +323,7 @@
 			y: -6.0d
 		}
 		{
+			dependencies: ["615C3E012B2DECD3"]
 			id: "4407BD7B5F033765"
 			rewards: [{
 				id: "17E703890863C286"
@@ -339,6 +343,7 @@
 			y: -7.0d
 		}
 		{
+			dependencies: ["615C3E012B2DECD3"]
 			id: "1CAEC4C273EDDB99"
 			rewards: [{
 				id: "7BA21F76F1D1563F"
@@ -358,6 +363,7 @@
 			y: -7.0d
 		}
 		{
+			dependencies: ["615C3E012B2DECD3"]
 			id: "4E3355FDCB65BB63"
 			rewards: [{
 				id: "158AAA21F5E6260C"
@@ -377,6 +383,7 @@
 			y: -8.0d
 		}
 		{
+			dependencies: ["615C3E012B2DECD3"]
 			id: "48C68664319B0294"
 			rewards: [{
 				id: "3980F859732CFA37"
@@ -396,6 +403,7 @@
 			y: -6.0d
 		}
 		{
+			dependencies: ["615C3E012B2DECD3"]
 			id: "1A0368CB49B8CBFF"
 			rewards: [{
 				id: "017C87162F328470"
@@ -415,6 +423,7 @@
 			y: -9.0d
 		}
 		{
+			dependencies: ["615C3E012B2DECD3"]
 			id: "73D6B980D35082A0"
 			rewards: [{
 				id: "3BA65ACBDE632A92"
@@ -454,6 +463,7 @@
 			y: -4.0d
 		}
 		{
+			dependencies: ["615C3E012B2DECD3"]
 			id: "652A14E17DDE97E6"
 			rewards: [{
 				id: "7BB7AECDA4A62E3D"
@@ -1753,6 +1763,11 @@
 				id: "minecraft:netherrack"
 			}
 			id: "72AB70FD8D8FABBF"
+			rewards: [{
+				id: "42EEEAE5E04CDFD6"
+				type: "xp"
+				xp: 50
+			}]
 			shape: "octagon"
 			size: 1.2d
 			tasks: [{

--- a/config/ftbquests/quests/chapters/justdirethings.snbt
+++ b/config/ftbquests/quests/chapters/justdirethings.snbt
@@ -159,9 +159,9 @@
 					type: "item"
 				}
 				{
-					id: "6149A5BEBAF48638"
+					id: "111E2F330103F1CF"
 					type: "xp"
-					xp: 10
+					xp: 100
 				}
 			]
 			tasks: [
@@ -197,9 +197,9 @@
 					type: "item"
 				}
 				{
-					id: "641C5A601269AB28"
+					id: "6A4D350918EED3B4"
 					type: "xp"
-					xp: 10
+					xp: 100
 				}
 			]
 			tasks: [
@@ -232,9 +232,9 @@
 					type: "item"
 				}
 				{
-					id: "370BADAB44E9D07F"
+					id: "0B50AB907638F3BD"
 					type: "xp"
-					xp: 10
+					xp: 100
 				}
 			]
 			tasks: [{
@@ -353,9 +353,9 @@
 					type: "item"
 				}
 				{
-					id: "1647D19C218E8762"
+					id: "53A139C6721DBE8B"
 					type: "xp"
-					xp: 10
+					xp: 100
 				}
 			]
 			tasks: [

--- a/config/ftbquests/quests/chapters/mekanism_reactors.snbt
+++ b/config/ftbquests/quests/chapters/mekanism_reactors.snbt
@@ -290,15 +290,15 @@
 			min_width: 400
 			rewards: [
 				{
-					id: "11FABC06766669F5"
-					type: "xp"
-					xp: 50
-				}
-				{
 					exclude_from_claim_all: true
 					id: "08C5A528A0456C24"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "1575723B11F270A7"
+					type: "xp"
+					xp: 50
 				}
 			]
 			shape: "rsquare"
@@ -336,15 +336,15 @@
 			min_width: 250
 			rewards: [
 				{
-					id: "6819DA9F73BA383C"
-					type: "xp"
-					xp: 50
-				}
-				{
 					exclude_from_claim_all: true
 					id: "1BF0FCC1C88A003D"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "4EDE45E16B58AA76"
+					type: "xp"
+					xp: 50
 				}
 			]
 			shape: "rsquare"
@@ -371,15 +371,15 @@
 			optional: true
 			rewards: [
 				{
-					id: "102A352650624E7C"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "070E292041FDB840"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "0030FB0FA427E95C"
+					type: "xp"
+					xp: 50
 				}
 			]
 			shape: "hexagon"
@@ -451,15 +451,15 @@
 			progression_mode: "linear"
 			rewards: [
 				{
-					id: "08BFEE4DB82A488D"
-					type: "xp"
-					xp: 250
-				}
-				{
 					exclude_from_claim_all: true
 					id: "24535A9B5B195CDB"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "182FF5871164257D"
+					type: "xp"
+					xp: 250
 				}
 			]
 			shape: "square"
@@ -476,15 +476,15 @@
 			id: "7E17AB5A4492929E"
 			rewards: [
 				{
-					id: "48CC9D36035B2625"
-					type: "xp"
-					xp: 25
-				}
-				{
 					exclude_from_claim_all: true
 					id: "6F9EDF210644BE81"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "5F4A1E8925776A1E"
+					type: "xp"
+					xp: 25
 				}
 			]
 			shape: "rsquare"
@@ -510,15 +510,15 @@
 			progression_mode: "linear"
 			rewards: [
 				{
-					id: "147637FB74512198"
-					type: "xp"
-					xp: 25
-				}
-				{
 					exclude_from_claim_all: true
 					id: "38EBF2DB27CB0D4B"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "19AC58A3A6EBCF2C"
+					type: "xp"
+					xp: 25
 				}
 			]
 			tasks: [{
@@ -567,15 +567,15 @@
 			progression_mode: "linear"
 			rewards: [
 				{
-					id: "414A6E5BDC1A3B1E"
-					type: "xp"
-					xp: 25
-				}
-				{
 					exclude_from_claim_all: true
 					id: "20492956C6AD544F"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "6B805D0C838BFAD1"
+					type: "xp"
+					xp: 25
 				}
 			]
 			tasks: [{
@@ -592,15 +592,15 @@
 			progression_mode: "linear"
 			rewards: [
 				{
-					id: "5AEF7913046DC6FB"
-					type: "xp"
-					xp: 25
-				}
-				{
 					exclude_from_claim_all: true
 					id: "2CB5555573A7DE48"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "584E55B0CEC535E5"
+					type: "xp"
+					xp: 25
 				}
 			]
 			tasks: [
@@ -627,15 +627,15 @@
 			progression_mode: "linear"
 			rewards: [
 				{
-					id: "1AA24CF536807D83"
-					type: "xp"
-					xp: 50
-				}
-				{
 					exclude_from_claim_all: true
 					id: "34ED8F5C16ACBE63"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "77A78068EEFEFCFD"
+					type: "xp"
+					xp: 50
 				}
 			]
 			tasks: [{
@@ -652,15 +652,15 @@
 			progression_mode: "linear"
 			rewards: [
 				{
-					id: "04AA88C4D9B33E34"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "0F0F1DC9C68D607E"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "4375756CD23EADD9"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "hexagon"
@@ -680,7 +680,7 @@
 			rewards: [{
 				id: "5AC458A8C3D99B74"
 				type: "xp"
-				xp: 10
+				xp: 50
 			}]
 			shape: "square"
 			size: 1.5d
@@ -697,15 +697,15 @@
 			min_width: 300
 			rewards: [
 				{
-					id: "1EEAAB174D95E4B6"
-					type: "xp"
-					xp: 25
-				}
-				{
 					exclude_from_claim_all: true
 					id: "4278904667FC1D86"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "4A39EA7B674F19F3"
+					type: "xp"
+					xp: 50
 				}
 			]
 			tasks: [{
@@ -722,15 +722,15 @@
 			id: "2E9FC7DC2AC6FD8E"
 			rewards: [
 				{
-					id: "353657D187263DAA"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "5654C27CDA3AC9C5"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "525ABF975A4FF493"
+					type: "xp"
+					xp: 100
 				}
 			]
 			tasks: [{
@@ -746,15 +746,15 @@
 			id: "1FAAF8216CDC3AC6"
 			rewards: [
 				{
-					id: "316FC7C98CC22E11"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "2D0F32B47DB74908"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "6547B589D1091CFB"
+					type: "xp"
+					xp: 100
 				}
 			]
 			tasks: [{
@@ -782,15 +782,15 @@
 					type: "item"
 				}
 				{
-					id: "7805E5E238BB92F1"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "4EF29B7A9C4A9A5A"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "428BF67FEF060C39"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "hexagon"
@@ -825,15 +825,15 @@
 			progression_mode: "linear"
 			rewards: [
 				{
-					id: "73F01F26D46493C6"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "5E28FD20ACEBC0F3"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "3C12A78105C095A9"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "rsquare"
@@ -880,15 +880,15 @@
 					type: "item"
 				}
 				{
-					id: "3C4D31DF8C934DC9"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "1DFAC25097BB1E80"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "4E3AF207AF490C71"
+					type: "xp"
+					xp: 100
 				}
 			]
 			tasks: [{
@@ -906,15 +906,15 @@
 			progression_mode: "linear"
 			rewards: [
 				{
-					id: "7D3868B320D82382"
-					type: "xp"
-					xp: 250
-				}
-				{
 					exclude_from_claim_all: true
 					id: "41C9347CE3D3D8AE"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "75F4101CDE97EB56"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "square"
@@ -957,15 +957,15 @@
 			min_width: 400
 			rewards: [
 				{
-					id: "1D08E38CECF7C7E8"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "4F0CE5F24DACE759"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "6243A8A856FB1E7D"
+					type: "xp"
+					xp: 100
 				}
 			]
 			tasks: [
@@ -989,15 +989,15 @@
 			id: "57534FA0E09C4975"
 			rewards: [
 				{
-					id: "464CDFABB1935067"
-					type: "xp"
-					xp: 50
-				}
-				{
 					exclude_from_claim_all: true
 					id: "5B4E2F6B1A4ABA2D"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "235E2F14E5713DD8"
+					type: "xp"
+					xp: 50
 				}
 			]
 			tasks: [{
@@ -1013,15 +1013,15 @@
 			id: "4ABF0727AA569DD9"
 			rewards: [
 				{
-					id: "5A40C3DB56EDA0E3"
-					type: "xp"
-					xp: 50
-				}
-				{
 					exclude_from_claim_all: true
 					id: "24B785D6329E4565"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "389D7BDCB35A3891"
+					type: "xp"
+					xp: 50
 				}
 			]
 			tasks: [
@@ -1047,15 +1047,15 @@
 			id: "3593D955361B0C6D"
 			rewards: [
 				{
-					id: "2FBAF9E2B19C1A6F"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "29186BFA372DE715"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "541AEB1302A4F989"
+					type: "xp"
+					xp: 100
 				}
 			]
 			tasks: [{
@@ -1072,15 +1072,15 @@
 			min_width: 300
 			rewards: [
 				{
-					id: "27476AD1A921D6BC"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "5B24AFD5AA909662"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "77437CD48E2BA2BB"
+					type: "xp"
+					xp: 100
 				}
 			]
 			tasks: [{
@@ -1116,15 +1116,15 @@
 			progression_mode: "linear"
 			rewards: [
 				{
-					id: "66CC79AB269C93AC"
-					type: "xp"
-					xp: 500
-				}
-				{
 					exclude_from_claim_all: true
 					id: "12724465924DCF00"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "71B87C4F60631E43"
+					type: "xp"
+					xp: 500
 				}
 			]
 			shape: "hexagon"
@@ -1151,15 +1151,15 @@
 					type: "item"
 				}
 				{
-					id: "5FAD66DBACDEA6ED"
-					type: "xp"
-					xp: 1000
-				}
-				{
 					exclude_from_claim_all: true
 					id: "4EF01D10EB944CC6"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "3FBDCAF1033F066E"
+					type: "xp"
+					xp: 500
 				}
 			]
 			tasks: [{
@@ -1212,15 +1212,15 @@
 			min_width: 300
 			rewards: [
 				{
-					id: "0A4A1734D68DC205"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "1FA4B60F847A1D52"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "43D3DAB2A46FA3F4"
+					type: "xp"
+					xp: 50
 				}
 			]
 			shape: "diamond"
@@ -1253,15 +1253,15 @@
 			min_width: 300
 			rewards: [
 				{
-					id: "5FDADDDF8428A238"
-					type: "xp"
-					xp: 50
-				}
-				{
 					exclude_from_claim_all: true
 					id: "5EF02DD923B9AECC"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "56B1F53E853D9CAC"
+					type: "xp"
+					xp: 50
 				}
 			]
 			shape: "diamond"
@@ -1298,15 +1298,15 @@
 			id: "7C61906C6C87C97D"
 			rewards: [
 				{
-					id: "18AE58687D78BB0F"
-					type: "xp"
-					xp: 25
-				}
-				{
 					exclude_from_claim_all: true
 					id: "78B5258851C77EEF"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "037A45EE5E628919"
+					type: "xp"
+					xp: 50
 				}
 			]
 			shape: "diamond"
@@ -1329,15 +1329,15 @@
 			progression_mode: "linear"
 			rewards: [
 				{
-					id: "3B59F78B29ABD642"
-					type: "xp"
-					xp: 250
-				}
-				{
 					exclude_from_claim_all: true
 					id: "28236D14DE2BFD97"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "1B4B13B93B360CEA"
+					type: "xp"
+					xp: 250
 				}
 			]
 			shape: "hexagon"
@@ -1355,21 +1355,21 @@
 			min_width: 250
 			rewards: [
 				{
-					id: "6FBC38ABC17E2BFF"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "4F4019E53A3BC0CF"
 					table_id: 8364958827326577211L
 					type: "loot"
 				}
+				{
+					id: "0237DCA3242908C0"
+					type: "xp"
+					xp: 100
+				}
 			]
 			shape: "hexagon"
 			tasks: [{
-				id: "31A1425AA09C33F8"
-				item: { components: { "ftbfiltersystem:filter": "or(item_tag(c:dusts/lithium))" }, count: 1, id: "ftbfiltersystem:smart_filter" }
+				id: "7A6F725B1DBC0434"
+				item: { count: 1, id: "mekanism:dust_lithium" }
 				type: "item"
 			}]
 			x: 3.0d
@@ -1382,15 +1382,15 @@
 			min_width: 300
 			rewards: [
 				{
-					id: "47EF9E0FC6A57445"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "7B24AA0C25D709FA"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "36086AB1F73ACEB3"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "diamond"
@@ -1424,15 +1424,15 @@
 			min_width: 350
 			rewards: [
 				{
-					id: "3CC428CF1A7974C7"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "72F41F8D5D6CCBB6"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "799020A7CB9B26AF"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "diamond"
@@ -1460,15 +1460,15 @@
 			progression_mode: "linear"
 			rewards: [
 				{
-					id: "19F7348CFE7A14C9"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "75D4F410B2974D08"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "34415DBF4D35D753"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "diamond"
@@ -1480,32 +1480,6 @@
 			}]
 			x: 5.0d
 			y: -1.0d
-		}
-		{
-			can_repeat: false
-			disable_toast: true
-			hide_details_until_startable: true
-			hide_until_deps_visible: true
-			icon: {
-				id: "ftbquests:custom_icon"
-			}
-			id: "67423D709305AD2D"
-			invisible: true
-			optional: true
-			shape: "octagon"
-			tasks: [
-				{
-					disable_toast: true
-					id: "43556EEA05422924"
-					type: "checkmark"
-				}
-				{
-					id: "314BB5005E524D0A"
-					type: "checkmark"
-				}
-			]
-			x: 0.0d
-			y: 6.0d
 		}
 		{
 			id: "066F78936C8F943B"

--- a/config/ftbquests/quests/chapters/occultism.snbt
+++ b/config/ftbquests/quests/chapters/occultism.snbt
@@ -540,9 +540,9 @@
 			}
 			id: "08B1A64B01A8A604"
 			rewards: [{
-				id: "31005015E3D07048"
+				id: "3EE821F59A85DDED"
 				type: "xp"
-				xp: 25
+				xp: 100
 			}]
 			shape: "diamond"
 			tasks: [
@@ -585,15 +585,15 @@
 			min_width: 300
 			rewards: [
 				{
-					id: "4E321912FBCD641F"
-					type: "xp"
-					xp: 25
-				}
-				{
 					exclude_from_claim_all: true
 					id: "52274E201F793220"
 					table_id: 487623848494439020L
 					type: "loot"
+				}
+				{
+					id: "1B46AF21D2EB7794"
+					type: "xp"
+					xp: 50
 				}
 			]
 			tasks: [
@@ -616,15 +616,15 @@
 			id: "666EA8B8F13EB292"
 			rewards: [
 				{
-					id: "7D6E46BD52D37617"
-					type: "xp"
-					xp: 25
-				}
-				{
 					exclude_from_claim_all: true
 					id: "017A49F5F0062DCA"
 					table_id: 487623848494439020L
 					type: "loot"
+				}
+				{
+					id: "2B7D26A8049B7670"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "hexagon"
@@ -650,7 +650,7 @@
 				{
 					id: "66AF59413C4ADCF3"
 					type: "xp"
-					xp: 10
+					xp: 50
 				}
 			]
 			tasks: [{
@@ -692,9 +692,9 @@
 			id: "33106E24A3B5DDD8"
 			min_width: 450
 			rewards: [{
-				id: "009F58B1FC4C026D"
+				id: "503C6DFD7D89F8F0"
 				type: "xp"
-				xp: 50
+				xp: 100
 			}]
 			tasks: [{
 				id: "2C341B16967645C9"
@@ -808,9 +808,9 @@
 					type: "loot"
 				}
 				{
-					id: "3FFC1652AA52C6AE"
+					id: "0975FA0F9ABEA092"
 					type: "xp"
-					xp: 50
+					xp: 100
 				}
 			]
 			shape: "diamond"

--- a/config/ftbquests/quests/chapters/productive_bees.snbt
+++ b/config/ftbquests/quests/chapters/productive_bees.snbt
@@ -57,11 +57,6 @@
 					type: "item"
 				}
 				{
-					id: "4D695A49C4060AFD"
-					type: "xp"
-					xp: 10
-				}
-				{
 					count: 2
 					id: "0E5E0909FA99CEA5"
 					item: {
@@ -79,6 +74,11 @@
 					}
 					random_bonus: 2
 					type: "item"
+				}
+				{
+					id: "3319486407EA74B6"
+					type: "xp"
+					xp: 10
 				}
 			]
 			shape: "hexagon"
@@ -123,17 +123,17 @@
 			id: "29EE878BC8D3A742"
 			rewards: [
 				{
-					id: "495A8E79141F31AC"
-					type: "xp"
-					xp: 10
-				}
-				{
 					id: "3BAFF21709BCF43F"
 					item: {
 						count: 1
 						id: "productivebees:sturdy_bee_cage"
 					}
 					type: "item"
+				}
+				{
+					id: "66503B552E577DF4"
+					type: "xp"
+					xp: 10
 				}
 			]
 			tasks: [{
@@ -162,9 +162,9 @@
 					type: "item"
 				}
 				{
-					id: "379FD843A5076141"
+					id: "306B583227DDE467"
 					type: "xp"
-					xp: 100
+					xp: 50
 				}
 			]
 			shape: "hexagon"
@@ -669,9 +669,9 @@
 					type: "item"
 				}
 				{
-					id: "327E963A18728867"
+					id: "472BC4B08D98917C"
 					type: "xp"
-					xp: 10
+					xp: 100
 				}
 			]
 			shape: "gear"
@@ -998,11 +998,6 @@
 			id: "1D720AC88431BD70"
 			rewards: [
 				{
-					id: "1EF8A565196DEB2C"
-					type: "xp"
-					xp: 100
-				}
-				{
 					count: 2
 					id: "64643C0983D30385"
 					item: {
@@ -1013,6 +1008,11 @@
 						id: "productivebees:configurable_honeycomb"
 					}
 					type: "item"
+				}
+				{
+					id: "1A349E15AA4AC684"
+					type: "xp"
+					xp: 100
 				}
 			]
 			tasks: [{
@@ -1038,11 +1038,6 @@
 			id: "100ACB5C8A359BF0"
 			rewards: [
 				{
-					id: "7633FEC136EBA1D4"
-					type: "xp"
-					xp: 100
-				}
-				{
 					count: 2
 					id: "1ED82242D8118B20"
 					item: {
@@ -1053,6 +1048,11 @@
 						id: "productivebees:configurable_honeycomb"
 					}
 					type: "item"
+				}
+				{
+					id: "403D370B0709F789"
+					type: "xp"
+					xp: 100
 				}
 			]
 			tasks: [{
@@ -1079,11 +1079,6 @@
 			id: "117241986C99E475"
 			rewards: [
 				{
-					id: "1AA439A6CAB4A90A"
-					type: "xp"
-					xp: 100
-				}
-				{
 					count: 2
 					id: "6B3492675986DE8A"
 					item: {
@@ -1094,6 +1089,11 @@
 						id: "productivebees:configurable_honeycomb"
 					}
 					type: "item"
+				}
+				{
+					id: "0018B3107C93B218"
+					type: "xp"
+					xp: 100
 				}
 			]
 			tasks: [{
@@ -1120,11 +1120,6 @@
 			id: "5F1784E562C29B66"
 			rewards: [
 				{
-					id: "1EC07E1836DAB17A"
-					type: "xp"
-					xp: 100
-				}
-				{
 					count: 2
 					id: "0E73A093C803C622"
 					item: {
@@ -1135,6 +1130,11 @@
 						id: "productivebees:configurable_honeycomb"
 					}
 					type: "item"
+				}
+				{
+					id: "2363D0D66616EFA0"
+					type: "xp"
+					xp: 100
 				}
 			]
 			tasks: [{
@@ -1161,11 +1161,6 @@
 			id: "437DB2CE10D33A08"
 			rewards: [
 				{
-					id: "7274DFEAC7126A2D"
-					type: "xp"
-					xp: 100
-				}
-				{
 					count: 2
 					id: "7A5A8AC95C18EA92"
 					item: {
@@ -1176,6 +1171,11 @@
 						id: "productivebees:configurable_honeycomb"
 					}
 					type: "item"
+				}
+				{
+					id: "04ED5C7D50683DD9"
+					type: "xp"
+					xp: 100
 				}
 			]
 			tasks: [{
@@ -1215,6 +1215,9 @@
 		{
 			dependencies: ["131EC039435B8878"]
 			hide_dependency_lines: true
+			icon: {
+				id: "minecraft:blue_dye"
+			}
 			id: "2CA4D7253DA1825F"
 			rewards: [{
 				id: "0D9788B0439CE954"
@@ -1239,11 +1242,6 @@
 			id: "5563BD4934297522"
 			rewards: [
 				{
-					id: "0FE7E2772FA1C09A"
-					type: "xp"
-					xp: 100
-				}
-				{
 					count: 2
 					id: "4A130E264C080131"
 					item: {
@@ -1254,6 +1252,11 @@
 						id: "productivebees:configurable_honeycomb"
 					}
 					type: "item"
+				}
+				{
+					id: "4E02CE828408240A"
+					type: "xp"
+					xp: 100
 				}
 			]
 			tasks: [{
@@ -1279,11 +1282,6 @@
 			id: "39A19138C501B16F"
 			rewards: [
 				{
-					id: "5E11CF7211ADB15A"
-					type: "xp"
-					xp: 100
-				}
-				{
 					count: 2
 					id: "41FFBD14B36FECA9"
 					item: {
@@ -1294,6 +1292,11 @@
 						id: "productivebees:configurable_honeycomb"
 					}
 					type: "item"
+				}
+				{
+					id: "20336382D4565975"
+					type: "xp"
+					xp: 100
 				}
 			]
 			tasks: [{
@@ -1319,11 +1322,6 @@
 			id: "2CA3707BEE2E3C0D"
 			rewards: [
 				{
-					id: "36535E022831C4FD"
-					type: "xp"
-					xp: 100
-				}
-				{
 					count: 2
 					id: "73FB1BE90BCEF2BA"
 					item: {
@@ -1334,6 +1332,11 @@
 						id: "productivebees:configurable_honeycomb"
 					}
 					type: "item"
+				}
+				{
+					id: "51A4DAF850CC42BE"
+					type: "xp"
+					xp: 100
 				}
 			]
 			tasks: [{
@@ -1359,11 +1362,6 @@
 			id: "399882F3C51DD282"
 			rewards: [
 				{
-					id: "095AA005F163ECC5"
-					type: "xp"
-					xp: 100
-				}
-				{
 					count: 2
 					id: "2B0C0EB3246429CA"
 					item: {
@@ -1374,6 +1372,11 @@
 						id: "productivebees:configurable_honeycomb"
 					}
 					type: "item"
+				}
+				{
+					id: "4F13B43E139C5327"
+					type: "xp"
+					xp: 100
 				}
 			]
 			tasks: [{
@@ -1402,15 +1405,15 @@
 			id: "6EFFF0DC80C1C8A3"
 			rewards: [
 				{
-					id: "43280AD345FCEAC4"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "4328B4BBA9A222F2"
 					table_id: 5564196992594175882L
 					type: "random"
+				}
+				{
+					id: "20835B70D7692BE6"
+					type: "xp"
+					xp: 100
 				}
 			]
 			tasks: [{
@@ -1430,11 +1433,6 @@
 			id: "76E94639E90FEB4E"
 			rewards: [
 				{
-					id: "70F080D7463D7B92"
-					type: "xp"
-					xp: 100
-				}
-				{
 					count: 2
 					id: "59BD5E41D3B8EE0E"
 					item: {
@@ -1445,6 +1443,11 @@
 						id: "productivebees:configurable_honeycomb"
 					}
 					type: "item"
+				}
+				{
+					id: "44F03279C1CFBE4C"
+					type: "xp"
+					xp: 100
 				}
 			]
 			tasks: [{
@@ -1471,11 +1474,6 @@
 			id: "00FD36C207845895"
 			rewards: [
 				{
-					id: "7BB5EF8129DEFE69"
-					type: "xp"
-					xp: 100
-				}
-				{
 					count: 2
 					id: "4A0DF3F64E1B7C94"
 					item: {
@@ -1486,6 +1484,11 @@
 						id: "productivebees:configurable_honeycomb"
 					}
 					type: "item"
+				}
+				{
+					id: "49777B21FF0970EA"
+					type: "xp"
+					xp: 100
 				}
 			]
 			tasks: [{
@@ -1514,15 +1517,15 @@
 			id: "6E819CCD57B15D54"
 			rewards: [
 				{
-					id: "525D801E1FF98425"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "1FDBF76E4CB0BB03"
 					table_id: 5564196992594175882L
 					type: "random"
+				}
+				{
+					id: "0F0BFA4465C0C95F"
+					type: "xp"
+					xp: 100
 				}
 			]
 			tasks: [{
@@ -1544,15 +1547,15 @@
 			id: "2BE538246C672689"
 			rewards: [
 				{
-					id: "4E4DBE9FF2C1BBD0"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "752568EB48133C34"
 					table_id: 5564196992594175882L
 					type: "random"
+				}
+				{
+					id: "13C87DB20767067D"
+					type: "xp"
+					xp: 100
 				}
 			]
 			tasks: [{
@@ -1831,6 +1834,9 @@
 		{
 			dependencies: ["131EC039435B8878"]
 			hide_dependency_lines: true
+			icon: {
+				id: "minecraft:yellow_dye"
+			}
 			id: "2226555D9552236E"
 			rewards: [{
 				id: "42FD59C35B7B5AD1"
@@ -1948,6 +1954,9 @@
 		{
 			dependencies: ["17419401147B5C02"]
 			hide_dependency_lines: true
+			icon: {
+				id: "artifacts:crystal_heart"
+			}
 			id: "2E51F09F6D9E5EF8"
 			rewards: [{
 				id: "228543A8ADEDCE7E"
@@ -2907,9 +2916,9 @@
 					type: "item"
 				}
 				{
-					id: "1824DE857066CD43"
+					id: "5B44F1F9E0D9F5EA"
 					type: "xp"
-					xp: 10
+					xp: 50
 				}
 			]
 			tasks: [{
@@ -2941,11 +2950,6 @@
 			id: "419DD6FE84B91749"
 			rewards: [
 				{
-					id: "5C1387EEB2AC5D4E"
-					type: "xp"
-					xp: 10
-				}
-				{
 					count: 2
 					id: "5E255C49AD125390"
 					item: {
@@ -2953,6 +2957,11 @@
 						id: "minecraft:honeycomb"
 					}
 					type: "item"
+				}
+				{
+					id: "0465B5524AB936C1"
+					type: "xp"
+					xp: 10
 				}
 			]
 			tasks: [{
@@ -2981,12 +2990,6 @@
 					id: "08B9B9C77F1239AD"
 					type: "xp"
 					xp: 10
-				}
-				{
-					exclude_from_claim_all: true
-					id: "2560F92C8A497C16"
-					table_id: 487623848494439020L
-					type: "random"
 				}
 			]
 			tasks: [{
@@ -3109,9 +3112,9 @@
 					type: "random"
 				}
 				{
-					id: "3170F19F86C90337"
+					id: "28133B0FFC3269DB"
 					type: "xp"
-					xp: 50
+					xp: 100
 				}
 			]
 			tasks: [{
@@ -3133,9 +3136,9 @@
 					type: "loot"
 				}
 				{
-					id: "6C5EF8AA831FAEB1"
+					id: "3369265CFC323286"
 					type: "xp"
-					xp: 50
+					xp: 150
 				}
 			]
 			tasks: [{
@@ -3157,9 +3160,9 @@
 					type: "loot"
 				}
 				{
-					id: "1AB61D621EAEB84A"
+					id: "701899D7386C5160"
 					type: "xp"
-					xp: 100
+					xp: 200
 				}
 			]
 			tasks: [{

--- a/config/ftbquests/quests/chapters/productive_trees.snbt
+++ b/config/ftbquests/quests/chapters/productive_trees.snbt
@@ -15,8 +15,8 @@
 			image: "minecraft:textures/gui/sprites/toast/tree.png"
 			rotation: 0.0d
 			width: 1.0d
-			x: -9.0d
-			y: 11.0d
+			x: 4.5d
+			y: 12.5d
 		}
 		{
 			height: 0.3d
@@ -51,8 +51,8 @@
 				item: { components: { "ftbfiltersystem:filter": "ftbfiltersystem:item_tag(minecraft:saplings)" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 				type: "item"
 			}]
-			x: -9.0d
-			y: 12.0d
+			x: 4.0d
+			y: 11.0d
 		}
 		{
 			dependencies: ["7C4F1012F5B6532F"]
@@ -1135,6 +1135,7 @@
 				"5B114CE7192A0549"
 				"3A79E24283523E58"
 			]
+			hide_dependent_lines: true
 			id: "4D562F5D72038083"
 			rewards: [{
 				count: 16
@@ -3749,6 +3750,10 @@
 			y: 1.0d
 		}
 		{
+			dependencies: [
+				"289B30DAC960BFF2"
+				"22151D56616559CB"
+			]
 			id: "71AA40CB2948A8D7"
 			rewards: [{
 				count: 16
@@ -3764,8 +3769,8 @@
 				item: { count: 1, id: "productivetrees:water_wonder_sapling" }
 				type: "item"
 			}]
-			x: 3.0d
-			y: 12.0d
+			x: 4.5d
+			y: 6.0d
 		}
 		{
 			id: "22151D56616559CB"
@@ -3784,8 +3789,8 @@
 				item: { count: 1, id: "productivetrees:blue_yonder_sapling" }
 				type: "item"
 			}]
-			x: -6.0d
-			y: 12.0d
+			x: 5.5d
+			y: 10.0d
 		}
 		{
 			id: "4281BCDCE233F65B"
@@ -3804,8 +3809,8 @@
 				item: { count: 1, id: "productivetrees:firecracker_sapling" }
 				type: "item"
 			}]
-			x: -7.0d
-			y: 12.0d
+			x: 4.5d
+			y: 10.0d
 		}
 		{
 			id: "18A2F6BA778D96B1"
@@ -3824,8 +3829,8 @@
 				item: { count: 1, id: "productivetrees:black_ember_sapling" }
 				type: "item"
 			}]
-			x: -3.0d
-			y: 12.0d
+			x: 2.5d
+			y: 10.0d
 		}
 		{
 			id: "4C3B7BAEA653587B"
@@ -3844,8 +3849,8 @@
 				item: { count: 1, id: "productivetrees:flickering_sun_sapling" }
 				type: "item"
 			}]
-			x: -5.0d
-			y: 12.0d
+			x: 6.5d
+			y: 10.0d
 		}
 		{
 			id: "289B30DAC960BFF2"
@@ -3864,8 +3869,8 @@
 				item: { count: 1, id: "productivetrees:soul_tree_sapling" }
 				type: "item"
 			}]
-			x: -4.0d
-			y: 12.0d
+			x: 3.5d
+			y: 10.0d
 		}
 		{
 			id: "768C07D1B5EB1FEB"
@@ -3884,10 +3889,14 @@
 				item: { count: 1, id: "productivetrees:brown_amber_sapling" }
 				type: "item"
 			}]
-			x: -8.0d
-			y: 12.0d
+			x: 5.0d
+			y: 11.0d
 		}
 		{
+			dependencies: [
+				"289B30DAC960BFF2"
+				"18A2F6BA778D96B1"
+			]
 			id: "6BF6C7C04F26D8BA"
 			rewards: [{
 				count: 16
@@ -3903,10 +3912,14 @@
 				item: { count: 1, id: "productivetrees:cave_dweller_sapling" }
 				type: "item"
 			}]
-			x: 0.0d
-			y: 12.0d
+			x: 3.0d
+			y: 9.0d
 		}
 		{
+			dependencies: [
+				"289B30DAC960BFF2"
+				"6BF6C7C04F26D8BA"
+			]
 			id: "1D31C515533DAD36"
 			rewards: [{
 				count: 16
@@ -3922,10 +3935,14 @@
 				item: { count: 1, id: "productivetrees:foggy_blast_sapling" }
 				type: "item"
 			}]
-			x: 7.0d
-			y: 12.0d
+			x: 4.0d
+			y: 7.0d
 		}
 		{
+			dependencies: [
+				"4281BCDCE233F65B"
+				"22151D56616559CB"
+			]
 			id: "526CED9509FAA79B"
 			rewards: [{
 				count: 16
@@ -3941,10 +3958,14 @@
 				item: { count: 1, id: "productivetrees:purple_spiral_sapling" }
 				type: "item"
 			}]
-			x: -1.0d
-			y: 12.0d
+			x: 5.0d
+			y: 9.0d
 		}
 		{
+			dependencies: [
+				"22151D56616559CB"
+				"4C3B7BAEA653587B"
+			]
 			id: "74CD3FC35F245DF2"
 			rewards: [{
 				count: 16
@@ -3960,10 +3981,14 @@
 				item: { count: 1, id: "productivetrees:rippling_willow_sapling" }
 				type: "item"
 			}]
-			x: 1.0d
-			y: 12.0d
+			x: 6.0d
+			y: 9.0d
 		}
 		{
+			dependencies: [
+				"289B30DAC960BFF2"
+				"74CD3FC35F245DF2"
+			]
 			id: "5FC92F3794004A98"
 			rewards: [{
 				count: 16
@@ -3979,10 +4004,14 @@
 				item: { count: 1, id: "productivetrees:slimy_delight_sapling" }
 				type: "item"
 			}]
-			x: 2.0d
-			y: 12.0d
+			x: 5.0d
+			y: 7.0d
 		}
 		{
+			dependencies: [
+				"289B30DAC960BFF2"
+				"4281BCDCE233F65B"
+			]
 			id: "4AEB4BF7624ABA0F"
 			rewards: [{
 				count: 16
@@ -3998,10 +4027,14 @@
 				item: { count: 1, id: "productivetrees:sparkle_cherry_sapling" }
 				type: "item"
 			}]
-			x: -2.0d
-			y: 12.0d
+			x: 4.0d
+			y: 9.0d
 		}
 		{
+			dependencies: [
+				"4C3B7BAEA653587B"
+				"4281BCDCE233F65B"
+			]
 			id: "3707C3EDA1C5A0B2"
 			rewards: [{
 				count: 16
@@ -4017,10 +4050,14 @@
 				item: { count: 1, id: "productivetrees:thunder_bolt_sapling" }
 				type: "item"
 			}]
-			x: 4.0d
-			y: 12.0d
+			x: 3.5d
+			y: 8.0d
 		}
 		{
+			dependencies: [
+				"74CD3FC35F245DF2"
+				"22151D56616559CB"
+			]
 			id: "05F428C34DD00B61"
 			rewards: [{
 				count: 16
@@ -4036,10 +4073,14 @@
 				item: { count: 1, id: "productivetrees:time_traveller_sapling" }
 				type: "item"
 			}]
-			x: 5.0d
-			y: 12.0d
+			x: 5.5d
+			y: 8.0d
 		}
 		{
+			dependencies: [
+				"526CED9509FAA79B"
+				"4AEB4BF7624ABA0F"
+			]
 			id: "20DDAC076A2479A8"
 			rewards: [{
 				count: 16
@@ -4055,8 +4096,8 @@
 				item: { count: 1, id: "productivetrees:night_fuchsia_sapling" }
 				type: "item"
 			}]
-			x: 6.0d
-			y: 12.0d
+			x: 4.5d
+			y: 8.0d
 		}
 		{
 			id: "25D8BE0280B6E7F1"
@@ -4072,8 +4113,45 @@
 					type: "checkmark"
 				}
 			]
-			x: -10.0d
-			y: 12.0d
+			x: -1.5d
+			y: 14.0d
+		}
+		{
+			id: "543F00603790AD3E"
+			rewards: [{
+				id: "7BA341680A73A46F"
+				item: {
+					count: 1
+					id: "minecraft:stone_axe"
+				}
+				type: "item"
+			}]
+			tasks: [{
+				id: "16391CD1A55DEA7C"
+				item: { count: 1, id: "productivetrees:stripper" }
+				type: "item"
+			}]
+			x: -2.0d
+			y: 13.0d
+		}
+		{
+			id: "76A0592F4C294545"
+			rewards: [{
+				count: 5
+				id: "3C72A695620499FC"
+				item: {
+					count: 1
+					id: "productivetrees:sawdust"
+				}
+				type: "item"
+			}]
+			tasks: [{
+				id: "01E6A96EBEF754EB"
+				item: { count: 1, id: "productivetrees:sawmill" }
+				type: "item"
+			}]
+			x: -1.0d
+			y: 13.0d
 		}
 	]
 }

--- a/config/ftbquests/quests/chapters/railcraft.snbt
+++ b/config/ftbquests/quests/chapters/railcraft.snbt
@@ -775,9 +775,9 @@
 					type: "item"
 				}
 				{
-					id: "3477C827E4D13499"
-					type: "xp_levels"
-					xp_levels: 2
+					id: "1E6E3974E8683CA3"
+					type: "xp"
+					xp: 50
 				}
 			]
 			shape: "hexagon"
@@ -802,9 +802,9 @@
 					type: "item"
 				}
 				{
-					id: "52D66AFF7B56AA2A"
-					type: "xp_levels"
-					xp_levels: 2
+					id: "3F4B9AB62B21A8AC"
+					type: "xp"
+					xp: 50
 				}
 			]
 			shape: "hexagon"
@@ -829,9 +829,9 @@
 					type: "item"
 				}
 				{
-					id: "61881DA8EB9F7360"
-					type: "xp_levels"
-					xp_levels: 2
+					id: "0D401BDCBDB7A49A"
+					type: "xp"
+					xp: 50
 				}
 			]
 			shape: "hexagon"
@@ -856,9 +856,9 @@
 					type: "item"
 				}
 				{
-					id: "38EA2C5027B8FDB0"
-					type: "xp_levels"
-					xp_levels: 2
+					id: "140764D21597E3A8"
+					type: "xp"
+					xp: 50
 				}
 			]
 			shape: "hexagon"
@@ -883,9 +883,9 @@
 					type: "item"
 				}
 				{
-					id: "784E2DF2C10EBF7B"
-					type: "xp_levels"
-					xp_levels: 3
+					id: "574D2C6E715A2975"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "hexagon"
@@ -910,9 +910,9 @@
 					type: "item"
 				}
 				{
-					id: "0317AB4673C25B5D"
-					type: "xp_levels"
-					xp_levels: 3
+					id: "2C8EE578E31970A9"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "hexagon"
@@ -937,9 +937,9 @@
 					type: "item"
 				}
 				{
-					id: "5AD52D0F66ED3BA0"
-					type: "xp_levels"
-					xp_levels: 3
+					id: "71508A174898098B"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "hexagon"
@@ -964,9 +964,9 @@
 					type: "item"
 				}
 				{
-					id: "487E2D1DDFBADDD7"
-					type: "xp_levels"
-					xp_levels: 3
+					id: "3AA4A1220CB86824"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "hexagon"
@@ -1338,12 +1338,6 @@
 				{
 					exclude_from_claim_all: true
 					id: "5E8B50B75DED4AA2"
-					table_id: 8502370445492231902L
-					type: "choice"
-				}
-				{
-					exclude_from_claim_all: true
-					id: "3C1ED0C7DC7441E8"
 					table_id: 8502370445492231902L
 					type: "choice"
 				}

--- a/config/ftbquests/quests/chapters/theurgy.snbt
+++ b/config/ftbquests/quests/chapters/theurgy.snbt
@@ -103,6 +103,7 @@
 	quest_links: [ ]
 	quests: [
 		{
+			dependencies: ["0542FE108089A0A2"]
 			id: "02593CD4B4AE814C"
 			rewards: [{
 				count: 10
@@ -251,7 +252,11 @@
 		}
 		{
 			id: "45996B848792379E"
-			optional: true
+			rewards: [{
+				id: "08E663CBC638D862"
+				type: "xp"
+				xp: 50
+			}]
 			shape: "rsquare"
 			tasks: [{
 				id: "1476F390A6789572"
@@ -263,6 +268,11 @@
 		}
 		{
 			id: "76F675A898EAB4E8"
+			rewards: [{
+				id: "521AFCFE3F8C0B95"
+				type: "xp"
+				xp: 50
+			}]
 			tasks: [{
 				id: "0A2949304DBB3D75"
 				item: { count: 1, id: "minecraft:water_bucket" }
@@ -298,6 +308,11 @@
 			}
 			icon_scale: 1.5d
 			id: "19A2016B54C6FA34"
+			rewards: [{
+				id: "55B6A322CAAF47E0"
+				type: "xp"
+				xp: 10
+			}]
 			shape: "square"
 			tasks: [{
 				id: "3489080F5FDE8B1B"
@@ -349,6 +364,7 @@
 			y: -2.0d
 		}
 		{
+			dependencies: ["0542FE108089A0A2"]
 			id: "36926B5EBFF6E55A"
 			rewards: [{
 				id: "3DC18770E98DCB85"
@@ -414,6 +430,7 @@
 			y: -6.0d
 		}
 		{
+			hide_dependent_lines: true
 			icon: {
 				id: "theurgy:alchemical_sulfur_sulfur"
 			}
@@ -446,9 +463,9 @@
 			icon_scale: 1.2d
 			id: "2B29E9AB9447E1C6"
 			rewards: [{
-				id: "25EA3C476F52E3F9"
-				type: "xp_levels"
-				xp_levels: 10
+				id: "21D3EB1A785C7B7B"
+				type: "xp"
+				xp: 500
 			}]
 			shape: "octagon"
 			size: 1.65d
@@ -585,17 +602,17 @@
 			id: "3EB63AF53E70C931"
 			rewards: [
 				{
-					id: "3BF7CCA7BD5E3A62"
-					type: "xp_levels"
-					xp_levels: 4
-				}
-				{
 					id: "68C21C4AED7D0FF7"
 					item: {
 						count: 1
 						id: "theurgy:mercury_catalyst"
 					}
 					type: "item"
+				}
+				{
+					id: "667E5699C991DE91"
+					type: "xp_levels"
+					xp_levels: 4
 				}
 			]
 			shape: "diamond"

--- a/config/ftbquests/quests/chapters/welcome.snbt
+++ b/config/ftbquests/quests/chapters/welcome.snbt
@@ -152,7 +152,7 @@
 			rewards: [{
 				id: "6935874719DCABBC"
 				type: "xp"
-				xp: 100
+				xp: 10
 			}]
 			shape: "rsquare"
 			size: 1.8d

--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -560,7 +560,7 @@
 		""
 		"Simply put something Enchanted, like a Diamond Helmet with Protection V into the Pressure Chamber with a Book and you'll get your Diamond Helment and a book with Protection V back!"
 	]
-	quest.04E9253AB8F17A07.quest_subtitle: "'I wish I could have Silk Touch on my Pickaxe instead'"
+	quest.04E9253AB8F17A07.quest_subtitle: "\"I wish I could have Silk Touch on my Pickaxe instead\""
 	quest.04E9253AB8F17A07.title: "Removing Echantments"
 	quest.050AAD831C0AE375.title: "Rejuvenated Flesh"
 	quest.0515422E36E4E9A3.quest_desc: ["Grants invisibility when sneaking."]
@@ -865,7 +865,6 @@
 	quest.083ABBA1C45FF960.title: "Sickle Blueprint"
 	quest.083D458032F0325C.quest_desc: ["The &bME Export Bus&f periodically spits items in its whitelist filter out to whatever external storage the bus is facing. Unlike the Import Bus, the Export Bus cannot work without being filtered."]
 	quest.083D458032F0325C.quest_subtitle: "The O"
-	quest.083D458032F0325C.title: "ME Export Bus"
 	quest.08457BEED799E600.quest_desc: ["These new &7Carts&r are mostly for laying down &6Tracks&r. \\nThe &7Track Layer&r places down &6Tracks&r while the &7Track Remover&r removes &6Tracks&r. \\nThe &7Track Relayer&r replaces the &6Tracks&r with different ones and the &7Track UnderCutter&r replaces the blocks beneath the &6Tracks&r."]
 	quest.08457BEED799E600.title: "&7Carts&r and &6Tracks&r"
 	quest.0854AD352218E1C3.quest_desc: ["Don't you hate when you have all this power but no Heating? \\n\\nNow you can change that with the Caloric Flux Emitter! Shift Right Click with it to bind it to a Machine. Then place it down and power it to send Heat. \\n\\nCan't be set to multiple Machines!"]
@@ -895,7 +894,7 @@
 	quest.08903890F577D43A.quest_desc: ["In order to get more fun little Mahou Tsukai weapons, you'll need a Scroll of Strengthening. To get one, place down a Spell Cloth, then do the ritual of strengthening on top of it and pick up the cloth."]
 	quest.08903890F577D43A.title: "Scroll of Strengthening"
 	quest.0893EFCAC7031FEA.quest_desc: ["Time to bake a cake, if you've got some milk and eggs ready."]
-	quest.0893EFCAC7031FEA.title: "You can have your Cake and Eat it too."
+	quest.0893EFCAC7031FEA.quest_subtitle: "Have your Cake and Eat it too"
 	quest.0897F7A3203E45AF.quest_desc: [
 		"Can convert certain blocks into liquids."
 		""
@@ -1034,6 +1033,7 @@
 		"Yes, we are not direclty utilizing this immediately. But setting it up now to craft and collect will be very beneficial, and save you a ton of time!"
 	]
 	quest.0A1BACA070EB5264.quest_subtitle: "Star Matter"
+	quest.0A1C2A7A8617D3E4.quest_subtitle: "Speedrunners Love This Stuff"
 	quest.0A1C2A7A8617D3E4.title: "Wheat"
 	quest.0A207A437AF153AA.quest_desc: ["Chance of being found in Phantom Knight chests."]
 	quest.0A2675CF16B6443B.quest_desc: [
@@ -1552,6 +1552,7 @@
 		""
 		"It can also provide infinite water by pumping water out via cables or pipes."
 	]
+	quest.0EFF1AA37772156B.quest_subtitle: "1 Block does the trick!"
 	quest.0EFF1AA37772156B.title: "The Sink = Infinite Water"
 	quest.0F00BBDF3618B3BA.quest_desc: [
 		"This lets you access your storage, but with a crafting table! "
@@ -1577,7 +1578,7 @@
 		""
 		"&dMEGA Cells&f offers the bespoke &bBulk Item Storage Cell&f, which is limited to no more than &oone&r type of item storeable per cell but can store a practically &o&lINFINITE&r* number of that item type. Before it can accept an item type, it must be filtered in advance using a Cell Workbench. "
 		""
-		"*&oTechnically 'max long'. If you know then you know.&r"
+		"*&oTechnically \"max long\". If you know, you know.&r"
 	]
 	quest.0F03E75CF79BADD7.quest_subtitle: "Bulk and cut"
 	quest.0F03E75CF79BADD7.title: "Bulk Item Storage"
@@ -2027,7 +2028,8 @@
 		"The &n&5Shafts&r must be at either 45, 90 or 180 degrees from each other."
 	]
 	quest.13AFCD3B6F62B986.quest_desc: ["Provides Ice and Snow recipes!"]
-	quest.13AFCD3B6F62B986.title: "Ice, Ice, Baby"
+	quest.13AFCD3B6F62B986.quest_subtitle: "Ice, Ice, Baby!"
+	quest.13AFCD3B6F62B986.title: "Ice Upgrade"
 	quest.13BAD4B9C69117C6.quest_desc: [
 		"There are multiple ways to make Raw Carbon Fibers"
 		""
@@ -2275,6 +2277,7 @@
 	quest.166DF03D93BC11F1.title: "(Better) Reforing Table"
 	quest.167E1474644C9908.quest_desc: ["The Quartz makes whatever the other item does, it does the opposite for the Spawner. With Quartz in your offhand and the other Spawner Modification item in your main it will do the opposite of its role. With Quartz and Blaze Rods instead of increasing Spawn Range it will decrease it. With Quartz and Ghast Tears it'll decrease Max Entities."]
 	quest.167E1474644C9908.title: "Opposite Day"
+	quest.1697CC05D08B388D.quest_subtitle: "Yummy Fried Chicken!"
 	quest.1697CC05D08B388D.title: "The Chickens Must Go"
 	quest.1698565EBB68DC85.quest_desc: [
 		"The &6Wye Track&r is the second track made by using a Spike Maul. It directs two &6Tracks&r into one. If you have one &6Track&r intersected by another the &6Wye&r will move &7Carts&r on the first &6Track&r into the intersecting one."
@@ -2536,7 +2539,6 @@
 		""
 		"Also, be mindful that each individual pylon (regardless of its length) takes up one channel. For particularly large spaces, you may wish to build a dedicated network with a controller to fit all the required pylons."
 	]
-	quest.18DFB25DC48D8BF7.title: "Spatial Pylon"
 	quest.18E0F5A78F696FA3.quest_desc: ["Echo shards give a special effect to the spawner. Any mobs spawned will have the loot that they drop multiplied."]
 	quest.18E0F5A78F696FA3.title: "Echoing"
 	quest.18EADBAFC932F864.title: "It's Clippin' Time"
@@ -2875,10 +2877,12 @@
 		""
 		"I guess the chickens are just getting... &oEggs-ercise!!!&r."
 	]
-	quest.1D2EF12FD7FDD217.title: "I'm not gonna make an Egg pun."
+	quest.1D2EF12FD7FDD217.quest_subtitle: "or am I?"
+	quest.1D2EF12FD7FDD217.title: "I'm not gonna make an Egg pun"
 	quest.1D31C515533DAD36.quest_subtitle: "Cave Dweller + Soul Tree"
 	quest.1D48298525EEADC9.quest_desc: ["You should have everything you need already."]
-	quest.1D48298525EEADC9.title: "You so sweet."
+	quest.1D48298525EEADC9.quest_subtitle: "Pour some Sugar on me!"
+	quest.1D48298525EEADC9.title: "You're so sweet"
 	quest.1D56D3B444A4B2D4.quest_desc: ["The Gauntlet of Bulwark acts not as you'd assume. Instead of bringing mobs closer it pushes them away, when holding right click, and gives them Blazing Brand. Then when you release right click you'll do the normal charge. It's made by fusing the Gauntlet of Guard with a Bulwark of Flame in the Mechanical Fusion Anvil."]
 	quest.1D56D3B444A4B2D4.title: "Gauntlet of Bulwark"
 	quest.1D6FAF0E25A0D596.quest_subtitle: "Clove + Allspice"
@@ -2936,6 +2940,7 @@
 	quest.1DBF5A76DCDF5E49.quest_desc: ["Youll need quite a bit of Ruridit. Passive your lines to keep a steady supply."]
 	quest.1DBF5A76DCDF5E49.quest_subtitle: "I have a bad feeling about this."
 	quest.1DCAA0310AA55F1C.quest_desc: ["But he usually closes by 5, so who cares."]
+	quest.1DCAA0310AA55F1C.quest_subtitle: "Willy would be proud"
 	quest.1DCAA0310AA55F1C.title: "The Start of a Fisher"
 	quest.1DCFC67A8E3DCA2C.quest_desc: ["Similar to the Alchemy Catalyst, when placed under a Mana Pool, the &9Conjuration Catalyst&r unlocks the abillity to use conjuration recipes. "]
 	quest.1DDA5ADA11DF868F.quest_desc: ["Now we can upgrade our Multiblock structures Tiers! EBF's, VF's, Crackers, LFD, and more! They can process faster, and they can process &dLuV&r tier materials! Lets Go!"]
@@ -3048,8 +3053,9 @@
 	quest.1F114EB0AAB86DB4.quest_desc: [
 		"Markets provide you with a villager than can sell you anything if you have the right amount of emeralds. "
 		""
-		"Spoiler: It's usually just 1 Emerald per item. BUT THEY HAVE EVERYTHING."
+		"Spoiler: It's usually just 1 Emerald per item, luckily, they have EVERYTHING."
 	]
+	quest.1F114EB0AAB86DB4.quest_subtitle: "The villager has more than one way to spawn"
 	quest.1F114EB0AAB86DB4.title: "Purchasing Farm Supplies"
 	quest.1F146FE1002643B2.quest_subtitle: "Brazilwood + Rose Gum"
 	quest.1F18B64C84C8809D.quest_subtitle: "Kill 5 Spiders"
@@ -3865,6 +3871,9 @@
 		"2.) The pipes &0&lMUST&r&r be colored to function. This is accomplished by using the Gregtech Spray Can."
 	]
 	quest.278252472B5B94D4.quest_subtitle: "Fricken Lasers"
+	quest.2786D5AC19163524.quest_desc: ["This block enables smelting recipes in your kitchen multi-block!"]
+	quest.2786D5AC19163524.quest_subtitle: "No Timer Needed"
+	quest.2786D5AC19163524.title: "Honey, there's a Furnace in the Kitchen"
 	quest.279BC6FAF7827738.quest_desc: ["For now we get 2 of these, but with a few advancements in the next tier up, we can get 4 IV Processors per set of crafting items! Worth!"]
 	quest.279BC6FAF7827738.quest_subtitle: "IV"
 	quest.27A0BCE75F198A82.title: "Fire Seeds"
@@ -3979,6 +3988,7 @@
 		""
 		"You can finally create a nice kitchen in Minecraft."
 	]
+	quest.28C9EDBF6607E180.quest_subtitle: "Betty White was born before Sliced Bread"
 	quest.28C9EDBF6607E180.title: "THE BEST THING SINCE SLICED BREAD"
 	quest.28E60192912BEBAD.quest_desc: [
 		"In Vanilla, Villagers can be really frustrating to deal with. Cycling trades is not easy at all, and professions can sometimes be tough to deal with. "
@@ -4473,9 +4483,10 @@
 	quest.2E9C035EEE7E5C34.quest_desc: [
 		"The classic Lead. Use this to get animals into your farm area. "
 		""
-		"This isn't the same thing found in paint."
+		"This isn't the same thing as the ore."
 	]
-	quest.2E9C035EEE7E5C34.title: "We're doing this the old fashioned way."
+	quest.2E9C035EEE7E5C34.quest_subtitle: "Get along little doggy"
+	quest.2E9C035EEE7E5C34.title: "We're doing this the Old Fashioned way"
 	quest.2E9FC7DC2AC6FD8E.quest_desc: [
 		"&8Nuclear Waste&r can be sent into an Isotopic Centrifuge to create &9Plutonium&r."
 		""
@@ -4939,7 +4950,6 @@
 		"Alternatively, you have to craft a Voltage Transformer"
 	]
 	quest.33682F4B44950123.quest_desc: ["To gain further knowledge of spells, we'll need a specific type of magical wood! \\n\\nArchwood Trees can be found in the overworld."]
-	quest.33682F4B44950123.title: "Archwood Wood"
 	quest.3371570F189DF994.quest_desc: [
 		"This scepter summons shields around you for protection."
 		""
@@ -5071,17 +5081,9 @@
 	quest.356F450F4ADD22D7.title: "2 Dimensional Storage Actuator"
 	quest.358706CA93DC2A9C.quest_desc: ["Cook the dust up in the &aEBF&r and cool it down in the &eChemical Bath&r"]
 	quest.3591EAA8E397F992.quest_desc: [
-		"Let's go through the checklist &oone more time&r to ensure we have everything ready to go before we boot it up:"
-		""
-		"1. Hazmat Suit On (safety first)"
-		"2. Water/coolant pumping into an input Port."
-		"3. Fissile Fuel pumping into an input Port."
-		"4. A Port set to output the Heated Coolant, either to a trashcan or an Industrial Turbine."
-		"5. A Port set to output Nuclear Waste leading to Radioactive Waste Barrels or machines to process it, or both!"
-		""
-		"If you're ready to go, hit that &eActivate&r button! You can also adjust the &3Burn Rate&r to produce more Nuclear Waste, but start slow."
+		"Let's go through the checklist &oone more time&r to ensure we have everything ready to go before we boot it up:\\\\n\\\\n1. Hazmat Suit on (safety first).\\\\n2. Water/coolant pumping into an input Port."
+		"3. Fissile Fuel pumping into an input Port.\\\\n4. A Port set to output the Heated Coolant, either to a trashcan or an Industrial Turbine.\\\\n5. A Port set to output Nuclear Waste leading to Radioactive Waste Barrels or machines to process it, or both!\\\\n\\\\nIf you're ready to go, hit that &eActivate&r button! You can also adjust the &3Burn Rate&r to produce more Nuclear Waste, but start slow."
 	]
-	quest.3591EAA8E397F992.title: "Booting Up The Reactor"
 	quest.3593D955361B0C6D.quest_desc: [
 		"To kick start the Fusion Reactor, we'll need a quick shot of D-T fuel. This is made by combining &cDeuterium&r and &eTritium&r together in a Chemical Infuser."
 		""
@@ -5145,7 +5147,7 @@
 		"And once we have the UV Circuit Assembler, we can make 4x LuV Tier Wetware processors with 1 craft!!!!"
 	]
 	quest.361D5B42688D5C53.quest_subtitle: "Stocking up"
-	quest.361DFDB1E1352D6B.quest_desc: ["Find some sugar cane!"]
+	quest.361DFDB1E1352D6B.quest_desc: ["Find some Sugar Cane near some water."]
 	quest.361DFDB1E1352D6B.title: "Sugar Sugar"
 	quest.365D4B1DC953D406.quest_desc: ["The &7Cart&r Dispenser will do as the name suggests. It can dispense any &7Carts&r onto the &6Tracks&r in front of it. Needs a Redstone signal to dispense."]
 	quest.365D4B1DC953D406.title: "&7Cart&r Dispenser"
@@ -5211,7 +5213,6 @@
 	quest.371A34B297C8A8EF.quest_subtitle: "The Power of Air"
 	quest.371A34B297C8A8EF.title: "PneumaticCraft: Repressurized"
 	quest.371A382CF1DDF2B2.quest_desc: ["The &bCapacity Card&f allows a bus upgraded with it to carry a larger filter. Import and Export buses upgraded with capacity cards can go from supporting only one filtered item each to their maximum nine-slot filter, while Storage buses will go from 18 slots to a maximum of 63."]
-	quest.371A382CF1DDF2B2.title: "Capacity Card"
 	quest.371DF7589239CB78.quest_subtitle: "Arrow Go Boom"
 	quest.371E09ED2A3F6BDC.quest_subtitle: "Spawns in empty Advanced Beehives in a dark place"
 	quest.371E09ED2A3F6BDC.title: "ZomBee"
@@ -5276,7 +5277,8 @@
 		""
 		"You can also place other kitchen multi-block items on it, like toasters and a Cow in a Jar."
 	]
-	quest.37CA6F9F0226F10E.title: "I need more cooking space."
+	quest.37CA6F9F0226F10E.quest_subtitle: "We need more cooking space"
+	quest.37CA6F9F0226F10E.title: "Need more cooking space?"
 	quest.37CBBAB88E2E49AC.quest_desc: [
 		"Increases max hearts."
 		""
@@ -5755,7 +5757,7 @@
 		"Make sure you upgrade your power source too! "
 	]
 	quest.3DCCEDC5A817EBEB.quest_subtitle: "EBF Upgrades"
-	quest.3DCD38634176BD92.quest_desc: ["Combine the AllTheModium &eSpell Book&r with a Vibranium Ingot and Template in a Smithing Table. \\n\\nThis template can be obtained from Brushing Suspicious Soul Sand in a Bastion."]
+	quest.3DCD38634176BD92.quest_desc: ["Combine the &6Allthemodium&r &eSpell Book&r with a Vibranium Ingot and Template in a Smithing Table.\\n\\nThis template can be obtained from Brushing Suspicious Soul Sand in a Bastion."]
 	quest.3DCD38634176BD92.title: "&3Vibranium&r Spell Book"
 	quest.3DCF26B53AE1EBF6.quest_desc: [
 		"Inside the Dark Forest, you'll find a structure that leads underground."
@@ -5881,6 +5883,7 @@
 	quest.3E99F4CD379DE9D7.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks. \\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission. \\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
 	quest.3E99F4CD379DE9D7.title: "AllRightsReserved"
 	quest.3EA883C0BB7BD38F.quest_desc: ["Let's gather some pieces of wool!"]
+	quest.3EA883C0BB7BD38F.quest_subtitle: "Whose fleece was....rainbow?"
 	quest.3EA883C0BB7BD38F.title: "Mary had a Little Lamb"
 	quest.3EB63AF53E70C931.quest_desc: [
 		"Reformation takes Mercury Flux to work! You'll need to Shift Right Click all 3 Pedestals with the Sulfuric Flux Emitter to set them. Then place down the Emitter and feed it power.\\n\\nAfter that it should be ready to Reform!"
@@ -6340,6 +6343,7 @@
 		"Lubricant is very useful with a cutter because recipes using it are much faster compared to water for example"
 	]
 	quest.4300938A4E8AF937.title: "Scheelite Vein"
+	quest.43021923E220CF68.quest_subtitle: "Wait until you get machines for this..."
 	quest.43021923E220CF68.title: "The Planter"
 	quest.431A8FDF15701BA4.quest_desc: ["The &2Hunter's Belt&r works like the Leather Belt as in it holds Talismans. That's its first ability which can be upgraded to hold more! \\n \\nThe Second Ability increases the damage your pets do. Pets are tamed Mobs that can do damage to other Mobs, like wolves!"]
 	quest.431A8FDF15701BA4.quest_subtitle: "Found in Butcher's Huts of any Village"
@@ -6424,14 +6428,13 @@
 	]
 	quest.4415C9F8DA2D7E68.title: "Making Turbines"
 	quest.441C0659ED28D935.quest_desc: ["Tier 1 Glyphs require 3 levels of experience to be made."]
-	quest.441C0659ED28D935.title: "Tier 1 Glyphs"
 	quest.441F37A95AB66E6B.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks. \\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission. \\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
 	quest.441F37A95AB66E6B.title: "AllRightsReserved"
 	quest.4434D7B66521D69A.quest_subtitle: "For Transferring Gasses"
 	quest.44454B2637069C9F.title: "IV Tier"
 	quest.4458F8829800A950.quest_desc: ["Polymorphic Fluid is the base of all Fluids / Fuels in JDT. Polymorphic Fluid is crafted by dropping Polymorphic Catalyst into water."]
-	quest.445C21949ADA1FE3.quest_desc: ["Combine an Ancient Codex with an AllTheModium Ingot and Template in a Smithing Table. \\n\\nYou can get the Template from Brushing Suspicious Clay in an &9Ancient City&r."]
-	quest.445C21949ADA1FE3.title: "&6AllTheModium&r Spell Book"
+	quest.445C21949ADA1FE3.quest_desc: ["Combine an Ancient Codex with an &6Allthemodium Ingot&r and Template in a Smithing Table.\\n\\nYou can get the Template from Brushing Suspicious Clay in an &9Ancient City&r."]
+	quest.445C21949ADA1FE3.title: "&6Allthemodium&r Spell Book"
 	quest.445C9117198936B6.quest_desc: ["The Wither Assault Shoulder Weapon (W.A.S.W.) is the last weapon you can make from Witherite. It has 2 different projectiles it can shoot: Wither Missiles and Wither Howitzers. The Wither Missiles shoot from just holding right click, and will damage whatever hit them with low cooldown. The Wither Howitzers are fired when you shift hold right click, they damage a bigger area and leave an area of wither effect that damages whatever walks in it. They have much longer cooldown though."]
 	quest.445C9117198936B6.title: "W.A.S.W. (Wither Assault Shoulder Weapon)"
 	quest.446A37C7FCDACF84.quest_desc: ["Voidflame Coal is a new material added by JDT. Voidflame is aquired by performing Goo Spread on Blaze Ember Blocks using tier three goo or higher. Voidflame Coal Ore is affected by fortune."]
@@ -6548,7 +6551,8 @@
 	]
 	quest.45EC31812FB9934D.quest_desc: ["The &n&5Mechanical Piston&r is similar to the Piston, it can push blocks, but you can add as many Extension Poles as you wish."]
 	quest.45EC31812FB9934D.title: "Mechanical Pistons"
-	quest.45F83C2750F70F9B.quest_desc: ["Go ahead. Put a book in a furnace."]
+	quest.45F83C2750F70F9B.quest_desc: ["Go ahead, put a Book in a Furnace and smelt it."]
+	quest.45F83C2750F70F9B.quest_subtitle: "Totally won't catch on fire..."
 	quest.45F83C2750F70F9B.title: "Making a Kitchen, with a book."
 	quest.45FBEABEBA7CC09E.quest_desc: ["&5The Sunken City&r is the Dungeon that houses the &5Deeplings&r, &5Coralssus&r, and &5The Leviathan&r. It spawns... well in Oceans. It's big and made of Stone Bricks. Once you get through it's defenses you'll find the Altar of Abyss which brings us to..."]
 	quest.45FBEABEBA7CC09E.title: "&5Sunken City&r: Home of &5The Leviathan&r"
@@ -6708,6 +6712,7 @@
 		""
 		"I have no clue what this glass is made of, but it's stronger than my relationship with Chicken."
 	]
+	quest.47764EFC822E462A.quest_subtitle: "Phenomenal Milking Powers....Itty bitty living space"
 	quest.47764EFC822E462A.title: "A Cow in a Jar"
 	quest.47768B1FFD57D56E.quest_desc: ["Don't you just hate &4Redstone&r having to be wired to everywhere? If we can have Wireless FE why not Wireless &4Redstone&r? Finally we can thanks to &c&lLaserIO&r. You can Input a &4Redstone Signal&r with the &4Card&r then use an &4Output Card&r to Output the &4Signal&r somewhere else!"]
 	quest.47768B1FFD57D56E.title: "&4Redstone Card"
@@ -7139,7 +7144,7 @@
 	quest.4C47EB9D2CE26BC6.quest_desc: [
 		"The Crystalline Bee is spawned from a Quartz Nest."
 		""
-		"This bee is needed to make many of the other metal bees, like Iron and Copper."
+		"This Bee is needed to make many of the other metal bees, like Iron and Copper."
 	]
 	quest.4C47EB9D2CE26BC6.quest_subtitle: "Spawns from a Quartz Nest in the Nether"
 	quest.4C47EB9D2CE26BC6.title: "Crystalline Bee"
@@ -7776,7 +7781,6 @@
 		"This can be useful for situations where a block can be processed simply by placing it and breaking it with a certain tool."
 	]
 	quest.525F25F4ADE45B50.quest_subtitle: "GET OUT"
-	quest.525F25F4ADE45B50.title: "ME Formation Plane"
 	quest.526559F94031FE43.quest_desc: [
 		"The &6Eternal Stella&r has 3 charges, and when right-clicked, can fully repair all of your items in your inventory."
 		""
@@ -8033,7 +8037,6 @@
 		""
 		"The second function of a memory card is to link &eP2P tunnels&f together. When doing so, the P2P tunnel being linked will be assigned a unique ID, which is stored on the memory card for further linking."
 	]
-	quest.55186B8602689B66.title: "Memory Card"
 	quest.551A4916F032ACCF.quest_desc: [
 		"The Arcane Anvil has the most uses out of any block in &lIron Spells&r. \\n\\nYou can combine &3Spells&r with the same Ink to level it up. \\nIt can combine &3Scrolls&r into Weapons to be used with them, like a Sword. \\nYou can also set an Affinity to Rings using Upgrade Orbs, or add Upgrade Orbs to Weapons and Gear."
 		"{image:atm:textures/questpics/iron_spells/spells_anvil_gui.png width:100 height:100 align:center}"
@@ -8277,6 +8280,7 @@
 		""
 		"And you can't put things on top of it."
 	]
+	quest.58495CFBF4F20CE9.quest_subtitle: "So much room for activities!"
 	quest.58495CFBF4F20CE9.title: "Even More Storage"
 	quest.58514FDE153FD971.quest_desc: ["*Note: To upgrade an already placed vanilla chest to an Iron Sophisticated Chest, you will first need to convert the chest with a 'Basic Tier Upgrade.'"]
 	quest.58514FDE153FD971.quest_subtitle: "A single chest the size of 2."
@@ -8364,6 +8368,7 @@
 		""
 		"I'll even give you a Diamond back."
 	]
+	quest.58D5BD3106BFD94A.quest_subtitle: "This is totally worth it"
 	quest.58D5BD3106BFD94A.title: "Cooking with the power of Diamonds"
 	quest.58DDD32F849940A0.quest_subtitle: "&dTier 6&r"
 	quest.58DDD32F849940A0.title: "Mystical and Blue Skies Max Picks"
@@ -8792,7 +8797,6 @@
 		""
 		"For fluids, 1 byte equals 8 buckets (8000mb)."
 	]
-	quest.5E24012A3D9B72A1.title: "Fluid Storage"
 	quest.5E2AA5695D1F21D7.quest_desc: ["Found only in treasure chests, the &0Black Lotus&r can be thrown into a non-empty Mana Pool to give it a good deal of concentrated Mana."]
 	quest.5E2AA5695D1F21D7.title: "The Elusive Mana-infused Lotus"
 	quest.5E2CB036B00758AE.quest_desc: [
@@ -9345,7 +9349,6 @@
 	quest.63CAD77A4488F2CE.quest_subtitle: "The All In One Tool"
 	quest.63CAD77A4488F2CE.title: "Paxel Blueprint"
 	quest.63DD7F5A4441ACE7.quest_desc: ["Tier 2 Glyphs require 5 levels of experience to be made. \\n\\nThey also require a &9Mage's Spell Book&r to create."]
-	quest.63DD7F5A4441ACE7.title: "Tier 2 Glyphs"
 	quest.63E4149FF75592C8.quest_desc: [
 		"Finally, at &6HV&r you get access to the &dByproducts&r from the &eMacerator&r"
 		""
@@ -9511,6 +9514,7 @@
 	quest.6581D4AF1A6DE230.title: "Preparing for a Ritual: &aCandles&r"
 	quest.659531F14E62EBEB.quest_desc: ["One Scroll you'll need applied to get Replica is the Scroll of Damage Exchange. To get it do the Ritual of Damage Exchange with 1 Powdered Iron and 2 Powdered Emeralds."]
 	quest.659531F14E62EBEB.title: "Scroll of Damage Exchange"
+	quest.659A903F97F93BE2.quest_subtitle: "Quick and Simple"
 	quest.659A903F97F93BE2.title: "The Bread of Life"
 	quest.65A075160D46BEF7.quest_desc: [
 		"This is a powerful, highly accurate machine known for processing massive sets of data and complex calculations at rapid speeds."
@@ -10458,7 +10462,6 @@
 	quest.6F1A9A95F40F554D.quest_subtitle: "&f12&r &4Damage&r"
 	quest.6F1A9A95F40F554D.title: "Magic Swords"
 	quest.6F3602F5600A6221.quest_desc: ["Tier 3 Glyphs require 10 levels of experience to be made. \\n\\nThey also require an &6Archmage's Spell Book&r."]
-	quest.6F3602F5600A6221.title: "Tier 3 Glyphs"
 	quest.6F3D0A248B5A9CA2.quest_desc: [
 		"&bSpatial Storage Cells&f are used to hold one defined volume each, and come in three different capacities allowing for a maximum of 2x2x2, 16x16x16 and 128x128x128 blocks' worth of space. "
 		""
@@ -10747,6 +10750,7 @@
 	quest.7270A37E31A70C91.quest_desc: ["&6&lHoly&r is for all the Medic/Support players. It's mostly meant for healing and helping. \\n\\n&6&lHoly's&r Focus Material is &6Divine Pearls&r which are crafted. You can make Runes with those or kill the &6&lPriest&r to get &6Holy Runes&r. \\n\\n&6Holy Scrolls&r are &fWhite&r with &6Gold&r texts."]
 	quest.7270A37E31A70C91.title: "&6&lHoly&r"
 	quest.72717D1135486D7F.quest_desc: ["Let's gather some seeds."]
+	quest.72717D1135486D7F.quest_subtitle: "Block Hand 1, Block Grass 0"
 	quest.72717D1135486D7F.title: "Punch the Grass"
 	quest.728BE1816DA23DC0.title: "Kill the Ender Dragon"
 	quest.7297391D026EE9A6.quest_desc: ["Want something exciting and new to make Energy? What about using &dPotions&r for it! That's what the &dPotion Generator&r does, it will take your &dPotions&r and make Energy out of it depending on its strength and duration."]
@@ -10909,7 +10913,8 @@
 		""
 		"Seriously, why no bulls?"
 	]
-	quest.73B8A70240E6070E.title: "Find a cow. Milk the cow. Profit."
+	quest.73B8A70240E6070E.quest_subtitle: "Why aren't there Bulls in the game?"
+	quest.73B8A70240E6070E.title: "Milk a Cow - Profit"
 	quest.73C70B15582958A5.quest_desc: [
 		"The &eDirt Nest&r can be placed in any overworld biome to lure in bees."
 		""
@@ -11236,7 +11241,6 @@
 		""
 		"However, unlike regular cells, their contents can also be accessed standalone via the cell item itself, a bit like a digital ME-flavoured backpack."
 	]
-	quest.77C9EE701F72586D.title: "Portable Storage"
 	quest.77D3546953550E39.quest_subtitle: "Bull Pine + Spruce"
 	quest.77F241BEE9902751.quest_desc: ["Even MORE slots for storage and upgrades."]
 	quest.77F241BEE9902751.quest_subtitle: "So much room for activities!"
@@ -11355,6 +11359,7 @@
 	]
 	quest.790F509BAA15A68E.quest_subtitle: "An Introduction"
 	quest.790F509BAA15A68E.title: "Tools"
+	quest.791AE62ACACBD5BA.quest_subtitle: "You'll open it, close it, then open it again, just because you're bored"
 	quest.791E5CB36B5C1E73.quest_desc: [
 		"You'll need thin sheets and foil to make this, both of which can be made in a &eBender&r"
 		""
@@ -11407,7 +11412,8 @@
 		""
 		"The Laser Focus Matrix is placed in the center of one face of the Fusion Reactor. We'll build the Lasers next."
 	]
-	quest.79757F66DF263FA0.title: "Frickin' Laser Beams"
+	quest.79757F66DF263FA0.quest_subtitle: "Frickin' Laser Beams"
+	quest.79757F66DF263FA0.title: "Laser Focus"
 	quest.7975C7145572C438.quest_desc: [
 		"Whether you are an experienced modded player, or a complete noob to MC, everyone has to make a &2Wooden Pickaxe&r. "
 		""
@@ -12106,14 +12112,15 @@
 	]
 	quest.7FE969CB4B419FC6.quest_subtitle: "Also works for items, gases, liquids, and heat."
 	quest.7FE969CB4B419FC6.title: "&9Wireless Transfer:&r &6Quantum Entangloporter&r"
-	reward_table.1DB1EEDA7B79672B.title: "RailCraft Rails"
-	reward_table.3602F483568B92BA.title: "chapter1"
+	reward_table.1DB1EEDA7B79672B.title: "RailCraft: Rails"
+	reward_table.3602F483568B92BA.title: "Chapter 1: Rewards"
 	reward_table.43C220CBD5447FE6.title: "PNC: PCB Tier"
 	reward_table.57002573D954732E.title: "PNC: Basic Tier"
-	reward_table.5832C9BCFDB476AF.title: "Ars Nouveau"
+	reward_table.5832C9BCFDB476AF.title: "Ars Nouveau: Rewards"
 	reward_table.5A138D1EDF8AA0C1.title: "PNC: Plastic Tier"
-	reward_table.75FE7CDF68581EDE.title: "RailCraft random"
-	reward_table.7609CF2A167B45C8.title: "theurgy salt"
+	reward_table.63E11953DD289422.title: "Mekanism: Rewards"
+	reward_table.75FE7CDF68581EDE.title: "RailCraft: Random"
+	reward_table.7609CF2A167B45C8.title: "Theurgy: Salt"
 	reward_table.7FB97C5850827C71.title: "PNC: Advanced Tier"
 	task.00648047034C9531.title: "Rock Crusher"
 	task.00C6A5CB44392D7E.title: "AllRightsReserved"
@@ -12180,6 +12187,7 @@
 	task.14DEFFB80CC96BC1.title: "ME Dense Covered Cables"
 	task.15389D4D64D19ACA.title: "GT Screwdrivers"
 	task.15BD622D04888DD8.title: "Carts"
+	task.15C6E9C02D1FBEC0.title: "Tier 2 Glyphs"
 	task.15DC25BCFCE78DE2.title: "Aluminium Ingot"
 	task.15ED5ED72A7965B5.title: "Welcome to Eidolon"
 	task.16010377566C75F3.title: "Stocking up"
@@ -12209,6 +12217,7 @@
 	task.1CAC89F6DFC2AB72.title: "Non-ABS Multiblocks"
 	task.1CBF0C7F2044EA9A.title: "&5The Summoner"
 	task.1CC0983CB7DBE526.title: "Gallium Ingot"
+	task.1CC556A6921208B8.title: "Tier 1 Glyphs"
 	task.1D8904E53906D972.title: "AllRightsReserved"
 	task.1DCE7B9772542FDB.title: "&dUpgrading The Forge&r"
 	task.1E0593F1AA073CFD.title: "Flux Efficiency"
@@ -12231,7 +12240,7 @@
 	task.263F0E416A8E1110.title: "Copper Comb"
 	task.26CDA4EADF919D5C.title: "Generators"
 	task.27529E8EA019A89A.title: "Blood Magic"
-	task.27709080B4B77B09.title: "Ready To Go!"
+	task.27709080B4B77B09.title: "Booting Up The Reactor"
 	task.27D8027E1B88F02A.title: "AllRightsReserved"
 	task.282B4264413EFB2D.title: "Platinum Ingot"
 	task.28A1D25CDDBF5163.title: "Any #c:chests"
@@ -12244,7 +12253,7 @@
 	task.2A2D77813F3127A6.title: "Rails"
 	task.2A6E713A062510B6.title: "Fueling the Reactor"
 	task.2BA7FC10243AA011.title: "Pressurized Tubes"
-	task.2BC0F5A88E2F03C3.title: "Any #c:logs/archwood"
+	task.2BC0F5A88E2F03C3.title: "Archwood Logs"
 	task.2C268116DA162155.title: "AllRightsReserved"
 	task.2C816285392535F0.title: "AllRightsReserved"
 	task.2CC38211F4C54ED8.title: "Draconic Comb"
@@ -12264,10 +12273,10 @@
 	task.30FE30A7FA067459.title: "Brown Shroombee Comb"
 	task.3153288DCE1C4FEF.title: "&aMekanism&r: &dAdvanced&r"
 	task.3165B02F2BFFEDDA.title: "Chemical Reactor"
-	task.31A1425AA09C33F8.title: "Lithium Dust"
 	task.31A7661D828CB33C.title: "Valid Ores"
 	task.31E6FDB712244B72.title: "64x Generators"
 	task.3202568944BCBF77.title: "Magmatic Comb"
+	task.323A434E1AF54408.title: "Hoes"
 	task.3282910297C28795.title: "AllRightsReserved"
 	task.335D80E83360A7DB.title: "Ether Gas? Huh?"
 	task.337725ECA2C04090.title: "Logical Transporters"
@@ -12428,6 +12437,7 @@
 	task.6047113DC2263E46.title: "Lumber Bee"
 	task.60BF6E0420C91050.title: "&dAdvanced Mekanism&r"
 	task.616C07AFBAFA7AE4.title: "Any #minecraft:hoes"
+	task.61D93B13D496547D.title: "Fluid Storage"
 	task.621A4E28BD50F96C.title: "Observe a Completed Induction Matrix"
 	task.62F11A588B293CA6.title: "AllRightsReserved"
 	task.64248C6FBC867D56.title: "Nomad Bee"
@@ -12436,9 +12446,12 @@
 	task.64EAD3DE84E94F02.title: "ME Covered Cables"
 	task.653ED58A9B65C796.title: "Crowbars"
 	task.65A04FD7D3F264DD.title: "GT Mallets"
+	task.65C439FD14C5EEB9.title: "Portable Storage"
 	task.65D52E6A67DD11EB.title: "Centrifuges"
+	task.65D68BEEB36FC805.title: "Tier 3 Glyphs"
 	task.65E53C9C5AE98B69.title: "AllRightsReserved"
 	task.669BC6911F43DB26.title: "Fluix Comb"
+	task.669DEA201002793D.title: "Fridges"
 	task.66C97246C3EEFB7C.title: "Observe Sulfuric Acid in a Machine"
 	task.6754D9E162472CA1.title: "Allthemodium Progression"
 	task.6887F86C8673DAF6.title: "Reed Bee"
@@ -12489,6 +12502,7 @@
 	task.77EF6FE6C54C104A.title: "Arc Furnace"
 	task.7830C98BD32DB5F2.title: "Lead Comb"
 	task.783B177BEB5F921E.title: "HV or EV or IV Laser Engraver"
+	task.78D7794707E4BD83.title: "Crops"
 	task.79712C13C6597E82.title: "Aluminum Comb"
 	task.79AEDC66EB312BCA.title: "Brass Comb"
 	task.79E961F671475850.title: "Thermodynamic Conductors"

--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -136,6 +136,8 @@
 	]
 	quest.00A17728A387B426.quest_subtitle: "Can be used in any Overworld biome"
 	quest.00A17728A387B426.title: "Wood Nest"
+	quest.00A91BD731486644.quest_subtitle: "Ceylon Ebony + Sour Cherry"
+	quest.00B7DD3AFC94B037.quest_subtitle: "Beech + Alder"
 	quest.00BD90363CA2D893.quest_desc: [
 		"&aSophisticated Backpacks&r add some of the most useful Backpacks to Minecraft! "
 		""
@@ -152,6 +154,7 @@
 	quest.00D7BCC68D971A53.quest_subtitle: "Max: 1"
 	quest.00DB5495C3A44999.quest_subtitle: "Allows the backpack to be emptied."
 	quest.00DB5495C3A44999.title: "Deposit Upgrade"
+	quest.00DEFA26F2B896D6.quest_subtitle: "Silver Lime + Oak/Birch"
 	quest.00E1F1279F97557B.quest_desc: ["Similar to the Extruder MK1 but this one is more evolved! Can be used with Patterns so when Blocks are placed they will go in that pattern!"]
 	quest.00EC37E07591FFC4.quest_desc: ["The last thing you need for Replica, obviously involves another Scroll. Scroll of the Mystic Eyes of Death Collection. It will allow you to collect Souls from watchings mobs die. Each death is only a very little bit of souls so you'll need to see a lot of death. Once you have 100 you're ready to get Replica."]
 	quest.00EC37E07591FFC4.title: "Souls"
@@ -163,6 +166,7 @@
 	quest.00FD36C207845895.quest_desc: ["Place an Obsidian Nest in the End to lure this bee."]
 	quest.00FD36C207845895.quest_subtitle: "&9Requires Obsidian Nest"
 	quest.00FD36C207845895.title: "Draconic Bee"
+	quest.00FF2CA7BA326007.quest_subtitle: "Mandarin + Wild Cherry"
 	quest.0104C2E2E30B966B.quest_desc: [
 		"Is the &cBlood Chest&r not working fast enough? Do you have too many items that need to be repaired? You can make a &cColossal Blood Chest&r to solve these problems."
 		""
@@ -214,6 +218,7 @@
 		"Note: Use wirecutters to enable and disable wire connections to blocks and each other"
 	]
 	quest.01339A8C26CC6E0C.title: "Energy Converters"
+	quest.0145727E40D7F674.quest_subtitle: "Cempedack + Breadfruit"
 	quest.0152938EE5651409.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks. \\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission. \\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
 	quest.0152938EE5651409.title: "AllRightsReserved"
 	quest.0152C49AB74B9D32.quest_desc: [
@@ -238,7 +243,9 @@
 		"The &6Vanishing Blocks&r will disappear when right-clicked, but they don't come back."
 	]
 	quest.019CA0E35F888222.title: "&eAdvanced Restock Upgrade&r"
+	quest.01B2DDD81065B4EF.quest_subtitle: "Dark Oak + Jungle"
 	quest.01C5D8357D8B0D62.quest_desc: ["If you know how a Detector Rail works then this Module will be explanatory for you. \\n\\nBasically if a certain Item is in the Router, it will emit a Redstone Signal out of the Router. \\n\\nIn the Module you can set the Item, where the Signal comes from, and how strong a Signal."]
+	quest.01CF1A9D9F29AFF7.quest_subtitle: "Pomelo + Orange"
 	quest.01D895369791881A.quest_desc: ["Now we get 2 ZPM processors for each craft! This is a great breakthrough, and will make expanding our machine footprint much easier!"]
 	quest.01D895369791881A.quest_subtitle: "Stacking them up"
 	quest.01E1A7BCDAE8EB9F.quest_desc: [
@@ -264,6 +271,7 @@
 		"If a mob or player happens to stand inside of the SCS while the space is being captured, they too will be transported to where the rest of the space goes, i.e. in a dedicated dimension. Just make sure you have a way to get back out and in if you're the one being captured."
 	]
 	quest.01F3F0C25BA72BDA.title: "Spatial IO"
+	quest.01F51EBFEC660549.quest_subtitle: "Silver Lime + European Larch"
 	quest.01F7F3589EBD8872.quest_subtitle: "Feed a Shroombee a Brown Mushroom!"
 	quest.01F7F3589EBD8872.title: "Brown Shroombee"
 	quest.02057E81D8139BAE.quest_desc: [
@@ -339,7 +347,7 @@
 		"But dont fear, we found the Gallium!"
 	]
 	quest.02AFB98510478664.quest_subtitle: "Found it!"
-	quest.02B0CCD5607FF3B5.quest_desc: ["The player accessor acts as a chest that interfaces with the player's inventory. Using the GUI the player accessor can have it's sides configured to interface with the player's inventory, off-hand or armour slots."]
+	quest.02B0CCD5607FF3B5.quest_desc: ["The player accessor acts as a chest that interfaces with the player's inventory. Using the GUI the player accessor can have it's sides configured to interface with the player's inventory, off-hand or armor slots."]
 	quest.02B8F50721F12CFF.quest_desc: [
 		"&lAbility Type:&r Passive"
 		""
@@ -482,6 +490,7 @@
 	quest.04636DE704AD7B0B.quest_desc: ["Ever feel like the Autoclave just wasnt enough for you? Well than this multiblock will fill that void! This large structure is a direct replacement for the single block Autoclave!"]
 	quest.04636DE704AD7B0B.quest_subtitle: "Lets make some Crystals! LCC"
 	quest.046C417B2ADF3AA7.quest_desc: ["Cards have their limits. Item Extration can only extract 8 items per Operation. Fluid Extract at only 5 Buckets. God knows with Chemical and Energy. \\n\\nThis is Modded &2&lMinecraft&r these limits won't suffice we need to Overclock them. \\n\\nThrow some Overclockers in the top right of the Card and it'll upgrade the cap they can transfer! \\n\\nMax of 4."]
+	quest.0480DF316ACF12DA.quest_subtitle: "Western Hemlock + Jungle"
 	quest.048BD38532A1DDCF.quest_subtitle: "Holds a max of 1M LP"
 	quest.048F2942436D3C46.title: "&6Master of The Sky&r"
 	quest.0496E8E786262464.quest_desc: ["Do I really need to explain the &2Overworld&r to you?"]
@@ -539,6 +548,7 @@
 	quest.04CE14D92603FC7A.title: "&aSummoning the&r &5Guardian of Gaia&r"
 	quest.04D9F6587EF8D9B7.quest_desc: ["The &9Potion Jar&r stores up to 100 potions. You can remove them by using an empty bottle or a potion flask on the jar. \\n\\nWixies will use these jars during Potion Autocrafting."]
 	quest.04D9F6587EF8D9B7.quest_subtitle: "Storing Potions"
+	quest.04DEC6E210F06D65.quest_subtitle: "Balsa + Cocobolo"
 	quest.04E2D539E33B7B0F.quest_desc: [
 		"This machine combines two gases to create a new gas."
 		""
@@ -565,6 +575,7 @@
 		""
 	]
 	quest.051E0C85E7B71CE0.title: "The &9Metal&r Age"
+	quest.052BE1D845794702.quest_subtitle: "Teak + Acacia"
 	quest.0542FE108089A0A2.quest_desc: ["&l&6Theurgy&r is the art of using Magic for Alchemy! Or in our sense using Machines and Items to make more or different Items! \\n\\nLot's of the Machines that we need for &l&6Theurgy&r needs Copper so start there!"]
 	quest.0542FE108089A0A2.title: "&l&6Theurgy&r"
 	quest.054D2D3C20C2D32F.quest_desc: [
@@ -575,6 +586,7 @@
 		"But you're not done yet... This may be the last processor, but theres still more to come. Its going to get even more fun from this point on!"
 	]
 	quest.054D2D3C20C2D32F.quest_subtitle: "Great Success!!!"
+	quest.054F3A0499F8A0D8.quest_subtitle: "Sweet Chestnut + Capoazu"
 	quest.05618FE80F2E0372.quest_desc: [
 		"The &9Infusion Crystal&r is used to upgrade to higher tier &dEssences&r. "
 		""
@@ -583,6 +595,7 @@
 		"Eventually, you'll be able to make an Infusion Crystal that works for all tiers and doesn't break!"
 	]
 	quest.05618FE80F2E0372.title: "&9The Infusion Crystal&r"
+	quest.056E1E3B1ED14917.quest_subtitle: "Teak + Dark Oak"
 	quest.0583862ED0114442.quest_subtitle: "&f4&r &4Damage&r"
 	quest.05A845C811A9A4A0.quest_desc: [
 		"While the &bManaweave Robes&r don't offer the greatest overall protection, the set bonus is pretty powerful!"
@@ -641,6 +654,7 @@
 		"Great for stopping hostile spawns in dark parts of your base"
 	]
 	quest.05F186C95510BD4B.title: "Preventing Mob Spawns"
+	quest.05F428C34DD00B61.quest_subtitle: "Blue Yonder + Rippling Willow"
 	quest.060233F903FAE63B.quest_desc: ["These plates will be important in creating more &dLuV&r tier machines."]
 	quest.060233F903FAE63B.quest_subtitle: "This is my &dLuV&r language!"
 	quest.060233F903FAE63B.title: "LuV Machine Casing"
@@ -737,6 +751,7 @@
 		"Here we will use its liquid form so the Fusion Reactor can form a byproduct for us."
 	]
 	quest.06CD5693FF52270F.quest_subtitle: "Liquid Lanthanum"
+	quest.06EA86F9F6C9DECF.quest_subtitle: "Plum + Peach"
 	quest.06EAA74E0A10CBB6.title: "&9Imperium Growth Accelerator&r"
 	quest.06F2C42E6408149E.quest_desc: [
 		"I hope you didn't steal this from the &c&lPyromancer&r, he's the nice one!"
@@ -838,6 +853,7 @@
 	]
 	quest.07ECC87DFF2D3991.title: "&aCompleting the&r &9Matrix&r"
 	quest.07FC106AFE76E766.quest_desc: ["You need the &5EV Electrolyzer&r to get Tungsten Dust from the Tungstic Acid"]
+	quest.0813CEDCC201216A.quest_subtitle: "Kapok + Old Fustic"
 	quest.08143AD0D63FFD1F.quest_subtitle: "Holds a max of 25k LP"
 	quest.08245411AFDB63DB.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks. \\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission. \\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
 	quest.08245411AFDB63DB.title: "AllRightsReserved"
@@ -853,7 +869,8 @@
 	quest.08457BEED799E600.quest_desc: ["These new &7Carts&r are mostly for laying down &6Tracks&r. \\nThe &7Track Layer&r places down &6Tracks&r while the &7Track Remover&r removes &6Tracks&r. \\nThe &7Track Relayer&r replaces the &6Tracks&r with different ones and the &7Track UnderCutter&r replaces the blocks beneath the &6Tracks&r."]
 	quest.08457BEED799E600.title: "&7Carts&r and &6Tracks&r"
 	quest.0854AD352218E1C3.quest_desc: ["Don't you hate when you have all this power but no Heating? \\n\\nNow you can change that with the Caloric Flux Emitter! Shift Right Click with it to bind it to a Machine. Then place it down and power it to send Heat. \\n\\nCan't be set to multiple Machines!"]
-	quest.0854AD352218E1C3.title: "Wireless Heat?"
+	quest.0854AD352218E1C3.quest_subtitle: "How?"
+	quest.0854AD352218E1C3.title: "Wireless Heat"
 	quest.087726194EED4BDF.quest_desc: ["Hold a Shield in your off hand and the Scroll of Strengthening in your main and hold right click."]
 	quest.087726194EED4BDF.title: "Strong Shield"
 	quest.088D685775ED92EE.quest_desc: [
@@ -896,10 +913,12 @@
 	quest.08B1A64B01A8A604.title: "&bCapturing&r &dDemons&r"
 	quest.08B60D8A25008CCC.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks. \\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission. \\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
 	quest.08B60D8A25008CCC.title: "AllRightsReserved"
+	quest.08C6B7D2DAE87222.quest_subtitle: "Oak + Birch"
 	quest.08D1CC753F6B4283.title: "Kill the Elder Guardian"
 	quest.08D48D7C2C6EEF54.quest_desc: ["What good is regular Tungsten? Well, since you asked, it is an integral component of many IV Machines, primarily in the form of Tungsten Cables"]
 	quest.08DA36DAD1422B0A.quest_desc: ["Increases damage done when poisoned."]
 	quest.08DA36DAD1422B0A.quest_subtitle: "Drops from the Arachnarch's Loot Bag"
+	quest.08DB91D079C5B715.quest_subtitle: "Red Maple + Mahogany"
 	quest.08DDE018A804BFE7.quest_desc: [
 		"This machine works like a Macerator or Pulverizer, and will break ores down into dusts."
 		""
@@ -1125,6 +1144,7 @@
 		"This is a very important crafting ingot used in a lot of recipes, plus it also makes some pretty blocks!"
 	]
 	quest.0B68E3C046C82860.title: "&6Deorum"
+	quest.0B70D40FA951E13B.quest_subtitle: "Oak + Birch"
 	quest.0B7E3FD8B8CB04A2.title: "Simple Black Hole Storage"
 	quest.0B7F2B63D867D221.quest_desc: ["Once you get to the bottom of the &eCursed Pyramid&r you might notice that the &eAncient Remnant&r doesn't move much. That's because you'll need a Necklace of Desert to ressurect the beast. To find it you'll need to brush the sus sand in the &eCursed Pyramid&r. (Hope you read this before heading all the way down)."]
 	quest.0B7F2B63D867D221.quest_subtitle: "Resurecting an Ancient Remnant"
@@ -1161,6 +1181,8 @@
 	]
 	quest.0BB367839D28607D.title: "Coal Generator"
 	quest.0BB562FB44B0AAA7.quest_desc: ["Cards aren't the only ones with limits, so they also aren't the only ones with Overclockers! \\n\\nThese go into the &cNode&r itself on bottom right and boost how fast it does Operations. \\n\\nMax of 8."]
+	quest.0BD908937BC6E97B.quest_subtitle: "Kapok + Rosewood"
+	quest.0BFAF1499415DD68.quest_subtitle: "Silver Lime + Cherry"
 	quest.0C1D55AA9CC902BD.quest_desc: [
 		"Vaild Upgrades:"
 		"- Lawnmower"
@@ -1197,6 +1219,7 @@
 		""
 		"To learn more about each, follow the corner quests!"
 	]
+	quest.0C7491BA5857AA00.quest_subtitle: "Teak + Jungle"
 	quest.0C78FB6EB275960B.title: "Sheldonite Vein"
 	quest.0C856BBB1679A7DD.quest_desc: ["On this page, you'll find some useful items and info to help you on your journey!"]
 	quest.0C856BBB1679A7DD.quest_subtitle: "And Other Useful Items!"
@@ -1318,6 +1341,7 @@
 	quest.0D6D45DBA64E612D.title: "Maximum Spawn Delay"
 	quest.0D7FA4B9120DDE0E.quest_subtitle: "&f9&r &4Damage&r"
 	quest.0D7FA4B9120DDE0E.title: "Crafted Swords"
+	quest.0D888A4C5EF0073E.quest_subtitle: "Mahogany + Kapok"
 	quest.0D8AC4FB1F61B07A.quest_desc: [
 		"Welcome to &dAd Astra&r!"
 		""
@@ -1426,6 +1450,7 @@
 		"Keep up the processing, were going to need quite a few of these Assembly lines as we move forward through the tiers!"
 	]
 	quest.0E4C711E77497984.quest_subtitle: "Of course its Gears."
+	quest.0E4DA8EE961D443F.quest_subtitle: "Sycamore + Sugar Maple"
 	quest.0E51D6BB2BC756B6.quest_subtitle: "Holds a max of 150k LP"
 	quest.0E594BC58CC7476F.quest_desc: [
 		"He may be evil, but he still is fashionable. "
@@ -1658,6 +1683,7 @@
 	quest.100ACB5C8A359BF0.quest_subtitle: "Redstone + Blue Banded"
 	quest.100ACB5C8A359BF0.title: "Lapis Bees"
 	quest.100ADA8508F6502A.quest_desc: ["A Glass Lens (Red) can also make this, but making glass lenses is an HV recipe"]
+	quest.10162AD188CB3327.quest_subtitle: "Plum + Red Delicious Apple"
 	quest.104049993CC62E7F.quest_desc: ["The Advanced Item Loader is everything the regular one is but can be used from anywhere near the &6Track&r. Next to, above, next to on the other side. Use the &4Crowbar&r to change its direction."]
 	quest.104049993CC62E7F.title: "Advanced Item Loader"
 	quest.104EBBC08B4733F5.quest_desc: [
@@ -1771,6 +1797,7 @@
 	]
 	quest.11B0B93D725ABE43.quest_subtitle: "Your First Repair Kit"
 	quest.11B0B93D725ABE43.title: "Repairing Items"
+	quest.11B1FB0AB2677902.quest_subtitle: "Balsa + Silver Lime"
 	quest.11B8C5F88DCB3BF5.quest_desc: [
 		"The journey to the &6ATM Star&r takes a LOT of time and materials, so how do you get started? "
 		""
@@ -1950,6 +1977,7 @@
 		""
 		"Make sure to check out which biome you need to be in to lure in the right bees!"
 	]
+	quest.1322907FDFF08ADA.quest_subtitle: "Walnut + Wild Cherry/Silver Lime"
 	quest.1323E846A2B82BE1.quest_desc: [
 		"We have already made a bunch of Biomass when we were first making our Ethylene. "
 		""
@@ -2148,6 +2176,7 @@
 	]
 	quest.14E7D8E642DE7463.quest_subtitle: "A dense alloy ingot with magic in every bite."
 	quest.14EB725643E9F8FE.quest_desc: ["Allows the Mana Burst to move a block just as if a piston would."]
+	quest.14F856E0D32FBB5B.quest_subtitle: "Teak + Balsa"
 	quest.15006CF73F8CAB7C.quest_desc: ["Just like the Charm of Life I, this item is consumed to prevent your death. When consumed, you'll regen all of your health and be given Regen IV, Resistance, and Fire Resistance for 30 seconds."]
 	quest.15007DCAF701B361.quest_desc: ["Charges other pressurizable items in your inventory from the chestplate's storage."]
 	quest.15007DCAF701B361.quest_subtitle: "Max: 6"
@@ -2160,6 +2189,7 @@
 	quest.153F111B4CCC850B.title: "Eternal Stella"
 	quest.15564C11744D6AA0.quest_desc: ["Once you have obtained a full set of the required &eInscriber Presses&r, it's time to start making some &eProcessors&f. These are an important crafting ingredient used to make the large majority of ME-connected devices."]
 	quest.15564C11744D6AA0.title: "Processors"
+	quest.1556777B07BD7C2B.quest_subtitle: "European Larch + Sugar Maple"
 	quest.155A843A562DB7C4.title: "Zombie Seeds"
 	quest.1569CD190336F5F6.quest_desc: [
 		"We cant leave the ever important Circuit Assembler out, could we?? Of course this multiblock will help to make sure you can keep making all those important circuits."
@@ -2209,6 +2239,7 @@
 	quest.15DE3BF0CBD8E0B4.title: "Your First Tool!"
 	quest.15ECBC8E174FA39B.quest_desc: ["Allows you to access your storage wirelessly."]
 	quest.15ECBC8E174FA39B.title: "Wireless Grid"
+	quest.15FF9D19FBC873CF.quest_subtitle: "Plum + Peach"
 	quest.1609BF52108238B0.title: "Stone Seeds"
 	quest.160BD0185954C891.quest_desc: ["Instead of using Honey Treats, this hive requires Gold Ingots to attract Bees."]
 	quest.160BD0185954C891.quest_subtitle: "Lures a Gold Bee when placed in the Nether"
@@ -2264,6 +2295,7 @@
 	quest.16E02F671FBE9148.quest_desc: ["The Portal Gun is an item that uses power to create two portals to teleport between two points. Left Click shoots a blue portal, Right Click an orange portal and Shift Right Click removes both portals."]
 	quest.16E4EA08B647E8E0.quest_desc: ["No matter which path you took for your Digital Storage, one of these is needed to make the &6Star&r!"]
 	quest.16E4EA08B647E8E0.title: "Wireless Terminals"
+	quest.16FA120455D36B58.quest_subtitle: "Orange + Mangrove"
 	quest.170118E3C3C072E5.quest_desc: [
 		"The &6Junction&r is the last &6Track&r made by the Spike Maul. It acts as a normal intersection for &6Tracks. &7Carts&r keep going the same way as before but now &6Tracks&r can intersect. What happens if 2 &7Carts&r hit each other on it? THEY EXPLODE!!! I'm kidding but &eElectric Locomotives&r will though."
 		"{image:atm:textures/questpics/railcraft/rail_junction.png width:100 height:100 align:center}"
@@ -2429,6 +2461,7 @@
 	]
 	quest.1809493D8765E67A.quest_desc: ["Don't forget, once you've made these you can update those old circuit recipes that used regular Transistors to use the Advanced Transistor"]
 	quest.1812BF72305CFFCF.quest_desc: ["Put Aluminium dust, Iron dust, and Chromium dust together in a &eMixer&r and watch it blend!"]
+	quest.1815661333016983.quest_subtitle: "Date Palm + Black Cherry"
 	quest.1823CC81D613892B.quest_desc: [
 		"Passive Mobs -> More Pink Slime"
 		"Hostile Mobs -> More Meat"
@@ -2451,6 +2484,7 @@
 	quest.184F98BE0F6710E2.quest_desc: ["These 2 &cTrack Kits&r are for using &7Carts&r and Redstone. \\n\\nThe &cActivator Kit&r will activate whatever &7Cart&r goes over it. \\nThe &cDetector Kit&r will activate a redstone signal whenever a &7Cart&r passes over it. \\n\\nBoth are similar to their &2Vanilla&r counters for regular &6tracks&r."]
 	quest.184F98BE0F6710E2.title: "&cTrack Kits&r for using Redstone"
 	quest.185074907753AE77.quest_desc: ["If you are using Routers I hope you have some game knowledge. \\n\\nJust incase, to void an Item means to delete it. \\n\\nAny items that come into the Router, will be deleted forever! \\n\\nRecommend using Filters with this one..."]
+	quest.18601369F049D10D.quest_subtitle: "Ceylon Ebony + Purple Crepe Myrtle"
 	quest.186593EBCE3FE8D8.quest_desc: ["The Spawn Range is the area of where mobs can spawn. The bigger the area, the more room for them to spawn in. The smaller the area the cheaper the factory."]
 	quest.186593EBCE3FE8D8.title: "Spawn Range"
 	quest.186731580B14F9D2.quest_desc: [
@@ -2478,10 +2512,12 @@
 		""
 		"Glowstone dust through an &eExtractor&r makes liquid glowstone"
 	]
-	quest.18A2F6BA778D96B1.quest_subtitle: "In the Nether Bastions."
+	quest.18A2F6BA778D96B1.quest_desc: ["These can be found in chests inside Bastions."]
+	quest.18A2F6BA778D96B1.quest_subtitle: "Bastion Chests"
 	quest.18A2FBE2D4133FA2.quest_desc: ["Arcane Pedestals are needed for the Ritual Brazier and crafting items with an Enchanting Apparatus. \\n\\nGo ahead and make yourself 8 of them!"]
 	quest.18A2FBE2D4133FA2.quest_subtitle: "Fancy Tables"
 	quest.18A2FBE2D4133FA2.title: "Arcane Pedestals"
+	quest.18D4BE3AF7869DE2.quest_subtitle: "Ceylon Ebony + Persimmon"
 	quest.18D88932916C7A98.quest_desc: [
 		"The Electrolytic Separator (big fancy name) is used to separate chemicals from certain liquids and gases."
 		""
@@ -2578,7 +2614,7 @@
 	]
 	quest.199E7C89584C3DB1.quest_subtitle: "Removes Bad Potion Effects"
 	quest.19A2016B54C6FA34.quest_desc: ["Some Machines in &l&6Theurgy&r need Heat to get started! Except &l&6Theurgy&r is very jealous with how their Machines get Heat, you can only use these two Machines as Heat sources. \\n\\n(The Machines that use Heat are: Liquefaction Cauldron, Calcination Oven, &cMercury&r Distiller, and Incubator.)"]
-	quest.19A2016B54C6FA34.title: "Man you're Hot!"
+	quest.19A2016B54C6FA34.quest_subtitle: "Man you're Hot!"
 	quest.19B70E2F329AED83.title: "LuV Tier"
 	quest.19BA973FECFA3B06.quest_desc: [
 		"There are two main ways to acquire &dRadon Gas&r"
@@ -2587,6 +2623,7 @@
 		""
 		"The alternative is to create the &aLarge Chemical Reactor&r and just react &3Air&r with some Uranium Dust and Plutonium Ingots - you even get the plutonium back!"
 	]
+	quest.19C22C5B247F4D7D.quest_subtitle: "Ceylon Ebony + Kapok"
 	quest.19CD3E69746F2849.quest_desc: ["Cheaper EV circuits! Don't forget to update your recipes!"]
 	quest.19D02325579F2AA8.quest_desc: ["The Volcanic Sourcelink generates Source by consuming burnable items. Archwood logs will generate bonus Source. \\n\\nAs it burns items, it will convert nearby stone into lava. \\n\\nThis also generates Lava Lilys."]
 	quest.19DB4970B3D11C1B.quest_desc: [
@@ -2613,6 +2650,7 @@
 	quest.1A0368CB49B8CBFF.quest_desc: ["This &eSpell Book&r is a rare drop from &cBlazes&r. I remember that because I was confused when I got 1 from my &cBlaze&r Farm. \\n\\nIt gives a Boost to &cFire Spells&r and has 10 &3Spell&r Slots."]
 	quest.1A0368CB49B8CBFF.quest_subtitle: "Hot! Hot! Hot!"
 	quest.1A0368CB49B8CBFF.title: "&cBlaze Instruction Manual&r"
+	quest.1A09AF508EFAE0EC.quest_subtitle: "Citron + Key Lime"
 	quest.1A46A97A00A31C03.quest_desc: [
 		"The second step is the Target Pedestal. This is where you put the &eSulfur&r that you want the first one to be made into. \\n\\nOr where you put the &3Alchemical Niter&r."
 		"{image:atm:textures/questpics/theurgy/theurgy_reform_2.png width:100 height:100 align:center}"
@@ -2752,6 +2790,7 @@
 		"Make sure you have 10 buckets available."
 	]
 	quest.1BB1E43FFE3FD451.quest_subtitle: "The Star that started it all"
+	quest.1BC611E39465B026.quest_subtitle: "Wenge + Silver Lime"
 	quest.1BCA04665A8F5EF5.quest_desc: ["Instantly moisten farmland it creates. Do we know if there is a better word for that?"]
 	quest.1BCE8D02CDD13838.quest_desc: ["Can Create \\\"Liquid\\\" Potions that can be bottled into Potions."]
 	quest.1BD5B25B80EC0F97.quest_desc: ["Also makes those magnetic iron rods for just some energy - save your redstone!"]
@@ -2821,12 +2860,14 @@
 	quest.1CC4F8570A7A99EB.title: "&aInferium Essence&r"
 	quest.1CD2C6AFD788C35E.quest_subtitle: "Compacts items in the backpack to their 2x2 recipe."
 	quest.1CD2C6AFD788C35E.title: "Compacting Upgrade"
+	quest.1CD5ABD827CEB3AE.quest_subtitle: "Brazilwood + Balsa"
 	quest.1CF8263756EE8F2A.quest_desc: ["This special &eDust&r is dropped from the Wither and the Ender Dragon when killed by an &dEssence Weapon&r enchanted with &dMystical Enlightenment&r."]
 	quest.1CF8263756EE8F2A.title: "&5Cognizant Dust&r"
 	quest.1D06097B6206BA60.quest_desc: ["Infusion is a special version of Enchanting which ironically is used for better enchantments. When the right amount of &aEterna&r, &cQuanta&r, and &5Arcana&r is reached the enchantments will offer Infusion. (To know the Levels needed you can check JEI or follow these Quests)"]
 	quest.1D06097B6206BA60.title: "Infusion Enchanting"
 	quest.1D0B60026346A844.quest_desc: ["Mixing Iridium and Osmium together will get you this Ingot! We have quite a few uses for this new resource. Having a bunch on standby may prove useful!"]
 	quest.1D0B60026346A844.quest_subtitle: "Making Osmium OP"
+	quest.1D1ABA9BD978E8A1.quest_subtitle: "Citron + Wild Cherry"
 	quest.1D2700821045CCF2.quest_desc: ["The 65536k Storage Disk can store 65536000 items."]
 	quest.1D2700821045CCF2.title: "&565536k Storage Part&r"
 	quest.1D2EF12FD7FDD217.quest_desc: [
@@ -2835,10 +2876,12 @@
 		"I guess the chickens are just getting... &oEggs-ercise!!!&r."
 	]
 	quest.1D2EF12FD7FDD217.title: "I'm not gonna make an Egg pun."
+	quest.1D31C515533DAD36.quest_subtitle: "Cave Dweller + Soul Tree"
 	quest.1D48298525EEADC9.quest_desc: ["You should have everything you need already."]
 	quest.1D48298525EEADC9.title: "You so sweet."
 	quest.1D56D3B444A4B2D4.quest_desc: ["The Gauntlet of Bulwark acts not as you'd assume. Instead of bringing mobs closer it pushes them away, when holding right click, and gives them Blazing Brand. Then when you release right click you'll do the normal charge. It's made by fusing the Gauntlet of Guard with a Bulwark of Flame in the Mechanical Fusion Anvil."]
 	quest.1D56D3B444A4B2D4.title: "Gauntlet of Bulwark"
+	quest.1D6FAF0E25A0D596.quest_subtitle: "Clove + Allspice"
 	quest.1D7104AE853A3D86.quest_desc: [
 		"&dMekanism&r is a mod that you can start from the beginning, and still be working on it right before you complete the pack. "
 		""
@@ -2921,6 +2964,7 @@
 		""
 		"The edges and floor of the Cleanroom needs to be Plascrete"
 	]
+	quest.1DFC9F33D9FD6357.quest_subtitle: "Cacao + Candlenut"
 	quest.1DFD4712153C1A55.title: "Certus Quartz Vein"
 	quest.1E0C6409B2573CCA.quest_desc: [
 		"&lAbility Type:&r Active"
@@ -2979,7 +3023,7 @@
 	quest.1E9B2D814F50A265.quest_desc: ["The &n&5Encased Fan&r is used to pull/push items and entities if you spin it. The arrow will show you the direction it's facing and the rotation direction will determine if it pushes or pulls."]
 	quest.1E9BD4B74DAEA9FC.quest_desc: ["To attract Bees to this nest, you'll need Popped Chorus Fruit instead of Honey Treats."]
 	quest.1E9BD4B74DAEA9FC.quest_subtitle: "Lures in Ender Bees when placed in the End"
-	quest.1EA02BA24AF02256.quest_desc: ["Eclipse Alloy Templetes are used to upgrade Celestigem armour and tools to Eclipse Alloy while retaining enchantments and installed upgrades."]
+	quest.1EA02BA24AF02256.quest_desc: ["Eclipse Alloy Templetes are used to upgrade Celestigem armor and tools to Eclipse Alloy while retaining enchantments and installed upgrades."]
 	quest.1EBD5E4410A6DF34.quest_subtitle: "Feed a Ghostly Bee a Soulium Dagger!"
 	quest.1EBD5E4410A6DF34.title: "Soulium Bee"
 	quest.1ECFA72CF2BA4B45.quest_desc: ["A simple dropper and you can configure the amount dropped at once."]
@@ -3007,8 +3051,10 @@
 		"Spoiler: It's usually just 1 Emerald per item. BUT THEY HAVE EVERYTHING."
 	]
 	quest.1F114EB0AAB86DB4.title: "Purchasing Farm Supplies"
+	quest.1F146FE1002643B2.quest_subtitle: "Brazilwood + Rose Gum"
 	quest.1F18B64C84C8809D.quest_subtitle: "Kill 5 Spiders"
 	quest.1F18B64C84C8809D.title: "&l&9Overworld Bounty:&r&e Spiders"
+	quest.1F1B4948FCC14BB4.quest_subtitle: "Silver Fir + Spruce"
 	quest.1F317D3C47F4543B.quest_desc: [
 		"With this special workbench, you can craft magical items."
 		"Inlays can be crafted in a normal bench, but here is just fine."
@@ -3221,6 +3267,7 @@
 		"Pro Tip: It's always a good idea to have extra &bOxygen&r on hand... just in case."
 	]
 	quest.20DA5CA244B7ABBF.title: "&aPreparing Some&r &bOxygen&r"
+	quest.20DDAC076A2479A8.quest_subtitle: "Purple Spiral + Sparkle Cherry"
 	quest.20EC8001A05CE2C8.quest_desc: ["Wireless Heat is a fun and easy way of powering Furnaces. First place the Wireless Heat Transmitter and put Energy into it. Then put the Receiver into the Transmitter to bind it. Finally put the Receiver into the Furnace Fuel section to start powering it!"]
 	quest.20ECBCF42E1B0660.quest_desc: [
 		"Welcome to the world of &6Everdawn&r, the world where the sun is forever rising."
@@ -3303,6 +3350,7 @@
 	quest.219C80DAFBAB36B8.quest_subtitle: "The final boss of STEAM"
 	quest.21A0FD474FBB49F7.quest_desc: ["Another structure to cover the barren &5End&r, the &dRuined Citadel&r. Don't worry this ones on the ground! In it you'll find &dEndmaptera&r, &dEnder Golem&r, and the Altar of Void. Thankfully you don't need to sacrifice anything to summon the &dEnder Guardian&r, just get to the Altar of Void."]
 	quest.21A0FD474FBB49F7.title: "&dRuined Citadel&r: Home of the &dEnder Guardian&r"
+	quest.21B8116BDADD7476.quest_subtitle: "Papaya + Cacao"
 	quest.21BEE9867796933A.quest_desc: ["This ones very simple. Put on your &9Mittens&r, pick up some &fSnow&r, mush it together, and Boom you just made a &fSnowball&r! These are better than &2Vanilla&r &fSnowballs&r, these were made with &9Mittens&r!"]
 	quest.21BEE9867796933A.quest_subtitle: "Found in Villages in Taigas or Snowy Taigas"
 	quest.21BEE9867796933A.title: "&9Wool Mittens&r"
@@ -3327,7 +3375,8 @@
 		"In the corners of the newly created ring, place a Demonite Block with one empty space on each side. "
 	]
 	quest.2214B7DCE4075A02.title: "The Tier 5 Altar"
-	quest.22151D56616559CB.quest_subtitle: "Found in Chests of Shipwrecks."
+	quest.22151D56616559CB.quest_desc: ["These can be found in chests inside Shipwrecks."]
+	quest.22151D56616559CB.quest_subtitle: "Shipwreck Chests"
 	quest.2226555D9552236E.quest_subtitle: "Spawns from most Wood Nests"
 	quest.222739E77C745519.title: "Osmium Seeds"
 	quest.2230244B2CE5851D.quest_desc: [
@@ -3343,6 +3392,7 @@
 		""
 		"You can then &eChemical React&r the Sodium Hydroxide Dust with your Dichlorobenzene to create &6Phenol&r!"
 	]
+	quest.227BEFEF59977CC4.quest_subtitle: "Rosewood + Teak"
 	quest.227DBA8836021B0B.quest_desc: ["In Ars Nouveau, the power system for machines is called &9Source&r. \\n\\nTo start collecting some Source, we'll need a Source Jar. \\n\\nSource can also be moved with buckets, or by breaking and picking up Source Jars."]
 	quest.227DBA8836021B0B.quest_subtitle: "Storing Source"
 	quest.228D1C880563CCBB.quest_desc: [
@@ -3478,6 +3528,7 @@
 		"{image:atm:textures/questpics/botania/t_a_plate_base.png width:200 height:150 align:1}"
 	]
 	quest.23A2865FBE7831AB.title: "&aCreating&r &dTerrasteel&r"
+	quest.23A5F5C9BC7B5CC7.quest_subtitle: "Plum + Walnut"
 	quest.23A9617F183C4EB1.quest_desc: [
 		"The &n&5Cogwheel&r transfers rotational power but also doubles or halves speed."
 		""
@@ -3516,7 +3567,7 @@
 	quest.24042326B4632DD4.quest_subtitle: "Transporting Items/Fluids"
 	quest.24042326B4632DD4.title: "Logistics"
 	quest.2405663C033CBDF1.quest_desc: ["MK3 doesn't worry about XYZ axis, line of sight, or Dimension. \\n\\nAs long as the Inventory is in the same Minecraft World it can move items into it. \\n\\nHeck I'm not even sure if the Inventory has to be in the game of Minecraft to send to!"]
-	quest.2409EAD96CE3BDF7.quest_desc: ["Blazegold Templetes are used to upgrade Ferricore armour and tools to Blazegold while retaining enchantments and installed upgrades."]
+	quest.2409EAD96CE3BDF7.quest_desc: ["Blazegold Templetes are used to upgrade Ferricore armor and tools to Blazegold while retaining enchantments and installed upgrades."]
 	quest.24150DE600C2D761.quest_desc: ["This one is single-handly taking us from E10 to Teen rating. &4&lBlood&r is all about slaying enemies for your own &cHealth&r! Most attacks will heal you back. \\n\\n&4&lBlood's&r Focus Material is &4Blood Vials&r which you get from cooking a Mob or Player in a Cauldron. \\n\\nIts &4Scrolls&r are Brown (there's no color for Brown) with &4Dark Red&r texts."]
 	quest.24150DE600C2D761.title: "&4&lBlood&r"
 	quest.24174700F7FB771C.quest_desc: ["In this chapter, we'll be using advanced Mekanism machines to create powerful multiblock &aReactors&r, as well as advanced ways to create and store power. This will also lead to making &dAntimatter Pellets&r, which are used to make the &6ATM Star&r, as well as some of the strongest tools and weapons in the pack."]
@@ -3638,6 +3689,7 @@
 	quest.2555BA914C466B5C.quest_subtitle: "The Best Casing"
 	quest.2559201BCF5D497C.quest_desc: ["Makes various Overworld materials."]
 	quest.2559201BCF5D497C.title: "Generalized Overworld Prediction"
+	quest.257D8912FC58DB59.quest_subtitle: "Brazilwood + Mahogany"
 	quest.2581B7D8E6C6E510.title: "Obsidian Seeds"
 	quest.2586C2C9D1EFB2DC.quest_desc: [
 		"Attaching all of your Multiblocks to your ME system uses up a lot of Interfaces. Add in the fact that you need covers to manipulate the resources and it can get tiresome. "
@@ -3704,8 +3756,9 @@
 	]
 	quest.25DBFE887B041E94.quest_subtitle: "The basics"
 	quest.25DBFE887B041E94.title: "Ore Processing"
-	quest.25E915AE1FC53254.quest_desc: ["Celestigem Templetes are used to upgrade Blazegold armour and tools to Celestigem while retaining enchantments and installed upgrades."]
+	quest.25E915AE1FC53254.quest_desc: ["Celestigem Templetes are used to upgrade Blazegold armor and tools to Celestigem while retaining enchantments and installed upgrades."]
 	quest.25EFC21A3C48E0B6.title: "Tier: &2Spirited&r"
+	quest.25F4D4A723B298A4.quest_subtitle: "Red Delicious Apple + Birch"
 	quest.26004F997C758011.quest_desc: ["One ruby plate in the Lathe will make a Ruby Lens"]
 	quest.260F19B468957BCD.quest_desc: [
 		"Have you seen the random floating island in the sky?"
@@ -3740,6 +3793,7 @@
 		"This gives us access to even more rituals, including the ritual that gets us to the Demon Realm."
 	]
 	quest.263925A79EBB270F.title: "Tier II rituals"
+	quest.263FBD9ED2756190.quest_subtitle: "Walnut + Coconut"
 	quest.2647B2830F8F022F.quest_subtitle: "&f6&r &4Damage&r"
 	quest.2647B2830F8F022F.title: "Meka and AE2 Iron Swords"
 	quest.264BFB8C5F79616F.quest_desc: ["Placing a Snow Nest in a snowy biome will lure in a Sweat Bee."]
@@ -3753,6 +3807,7 @@
 		"Note: You can either make a &dStructure Compass&r to locate the Temple, or by using &dEyes of the Abyss&r like you would an Eye of Ender."
 	]
 	quest.266AB725974E464C.title: "Abyssal Sacrifice"
+	quest.268768465119632A.quest_subtitle: "Aspen + Alder"
 	quest.26988E22BD019628.title: "&eAuto-Blasting Upgrade&r"
 	quest.26A7746051A4A079.title: "Skeleton Seeds"
 	quest.26A9F402DAE15EA2.quest_subtitle: "Adds a smoker GUI to the backpack."
@@ -3904,7 +3959,8 @@
 		"This is used for most of the items in the mod."
 	]
 	quest.2897FA291E5A38D8.quest_desc: ["The &bSpatial Anchor&f is a companion device from the Spatial IO lineage that simply functions as a chunk loader. When connected to an ME network, the Anchor will force-load all the chunks occupied by the ME network across all cables and devices, excluding subnetworks, as long as the network remains powered."]
-	quest.289B30DAC960BFF2.quest_subtitle: "Located in End City Chests."
+	quest.289B30DAC960BFF2.quest_desc: ["These can be found in chests inside End Cities."]
+	quest.289B30DAC960BFF2.quest_subtitle: "End City Chests"
 	quest.28B1787B61BB214B.quest_desc: ["Lets take the Epoxy from the IV tier and make some reinforcements for our next tier Processors!"]
 	quest.28B1787B61BB214B.quest_subtitle: "So many uses for Epoxy!"
 	quest.28BF66D1B8CD4D44.quest_desc: [
@@ -3929,7 +3985,7 @@
 		""
 		"&aEasy Villagers&r is a mod to make all of it much easier to deal with! For starters, you can pick up a villager by sneak-right clicking them. They can then be easily placed in the world, or in specific blocks from the Easy Villager mod! "
 		""
-		"You can search &d@EasyVillagers&r in JEI to see blocks the mod offers!"
+		"You can search &d@EasyVillagers&r in EMI to see blocks the mod offers!"
 	]
 	quest.28E60192912BEBAD.title: "&aEasy Villagers&r"
 	quest.28EB26056EF18C5F.quest_desc: [
@@ -3940,6 +3996,7 @@
 	quest.28EB26056EF18C5F.quest_subtitle: "Durable?"
 	quest.28F49121DEB0000A.quest_desc: ["This is an odd element. It is extremely resistant to corrosion in dry climates, but it's not resistant in moist climates. "]
 	quest.28F49121DEB0000A.quest_subtitle: "Liquid Lutetium"
+	quest.28FB4B9DCC268404.quest_subtitle: "Plum + Cherry"
 	quest.28FEB4C11AD1AE7C.quest_desc: ["&bDiamonds&r are usually expensive... for Vanilla, but this is modded you'll have enough for atleast 1 &bDiamond Generator&r. Still uses normal Furnace Fuel."]
 	quest.28FEB4C11AD1AE7C.title: "&bDiamond Generator&r"
 	quest.290FAB3DE8FD04E7.quest_desc: ["Works like the &aMace of Distortion&r, except it causes an AoE explosion instead."]
@@ -3950,6 +4007,7 @@
 	quest.291C76140DE97E3C.quest_desc: ["Ignitium is like Netherite but takes actual skill to get it. The &bIgnis&r will only drop 1 so get good use of it. You can use it to upgrade your netherite armor or use it to make 2 weapons."]
 	quest.291C76140DE97E3C.quest_subtitle: "Better than Netherite?!?!?!"
 	quest.291C76140DE97E3C.title: "Ignitium"
+	quest.291EE514A1602C46.quest_subtitle: "Balsa + Flowering Azalea"
 	quest.29417616D8F673D5.quest_desc: ["Moving forward a lot of mixed metals and alloys will need to be made in the ABS. As Fluids they are then pushed through a Vacuum Freezer with an Ingot Mold to make the ingots. The Multiblock Structures referenced in the following quests all have support blocks which utilize metals which need the ABS to be made. Making at least 1 Alloy Blast Smelter now will be beneficial."]
 	quest.29417616D8F673D5.quest_subtitle: "Anti-Lock Braking System is a Go!"
 	quest.2943989C642F93AE.quest_desc: ["Finally! We now have a crafting recipe that gives us 2 LuV processors for 1 Craft! Lets Gooo!"]
@@ -3970,7 +4028,9 @@
 	quest.29706E3681616E41.quest_subtitle: "That's a Lot of Different Dusts!"
 	quest.2982D38BD5EE6349.quest_subtitle: "Feed a Shroombee Warped Fungus!"
 	quest.2982D38BD5EE6349.title: "Warped Shroombee"
+	quest.298437197EA5680D.quest_subtitle: "Black Cherry + Cacao"
 	quest.29917E6196649F5D.quest_desc: ["The Speedometer will show you the speed of the currently connected gear."]
+	quest.2993EAB4850B7172.quest_subtitle: "White Willow + Cherry"
 	quest.299F56B753286D0C.quest_subtitle: "&eTier 5&r"
 	quest.29A05589E96C0569.quest_subtitle: "&5Tier 4&r"
 	quest.29AE69722AB4C75C.title: "Fish Seeds"
@@ -3996,6 +4056,7 @@
 		"Adventuring can also net you some &6Sturdy Bee Cages&r, so keep an eye out!"
 	]
 	quest.29EE878BC8D3A742.title: "Capturing Bees!"
+	quest.29FA0E9664935566.quest_subtitle: "Balsa + Cacao"
 	quest.2A01CE9206DD4F8A.quest_desc: [
 		"&lAbility Type:&r Passive"
 		""
@@ -4074,6 +4135,7 @@
 		"- Phase"
 	]
 	quest.2A976D41F79C34B1.quest_desc: ["&e&lPipez&r do have their own way of Filtering Items, you need atleast an Advanced Upgrade to get it though. When an Advanced Upgrade is in you can click the Add button to add Filters. \\nThen you can add: Item, Tag, or NBT in the Filter. \\n\\nThere you can also add the set Destination Filter. To set it, Shift Right Click an Inventory with it. \\n\\nYou'll also have to set it to either Whitelist the Filter or Blacklist, so only the Filter or everything but the Filter."]
+	quest.2AA407EB0BF2922E.quest_subtitle: "Sweetgum + Loblolly"
 	quest.2AB0FA084739827A.quest_desc: ["To actually use a &9Tunnel Bore&r you'll need a &9Tunnel Bore Head&r. \\n\\nThey come in 4 different styles and it mines dependent on the &9Bore Head&r. \\n\\nIt can be enchanted and has durability so you'll want to enchant it!"]
 	quest.2AB0FA084739827A.title: "&9Tunnel Bore, Bore Head&r"
 	quest.2AB457E29360E3B8.quest_desc: [
@@ -4246,6 +4308,7 @@
 	quest.2C9DDB3AAA30E02A.quest_subtitle: "Start Now"
 	quest.2CA28551F2A5B761.quest_desc: ["Using loot from the Demon Realm, you can upgrade each rune to double its effect. "]
 	quest.2CA28551F2A5B761.title: "Reinforced Runes"
+	quest.2CA2B3A1783B4040.quest_subtitle: "Aspen + Alder"
 	quest.2CA3707BEE2E3C0D.quest_subtitle: "Feed Diamond Bee a Block of Netherite"
 	quest.2CA3707BEE2E3C0D.title: "Ancient Bee (Netherite)"
 	quest.2CA4D7253DA1825F.quest_subtitle: "Spawned using a Wood Nest"
@@ -4323,15 +4386,17 @@
 		"As previously stated, you should really figure out how to passive the processing line. To be fair, at this point, everything should be passived."
 	]
 	quest.2D65DC315CCC60C8.quest_subtitle: "By Products"
+	quest.2D6FDCC948DB927D.quest_subtitle: "Mahogany + Teak"
 	quest.2D84DA544D7A24FA.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks. \\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission. \\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
 	quest.2D84DA544D7A24FA.title: "AllRightsReserved"
 	quest.2D86D4403E0F4EB9.quest_desc: [
 		"Blazegold is a new material added by JDT. Blazegold is aquired by performing Goo Spread on Gold Blocks using tier two goo or higher. Blazegold Ore is affected by fortune."
 		""
-		"Blazegold grants the intrinsic ability of Lava Repair to Tool and Armour. Lava Repair, repairs the tool / armour when dropped into a lava source block, converting the source block into obsidian in exchange for repairing the tool / armour."
+		"Blazegold grants the intrinsic ability of Lava Repair to tools and Armor. Lava Repair, repairs the tool/armor when dropped into a lava source block, converting the source block into obsidian in exchange for repairing the tool/armor."
 	]
 	quest.2D86D4403E0F4EB9.title: "Blazegold"
 	quest.2DB81CE6F647D08A.title: "Unobtainium-AllTheModium Alloy"
+	quest.2DC639C39AE90272.quest_subtitle: "Yellow Meranti + Rose Gum"
 	quest.2DD5F0693780B10A.quest_desc: ["Used with the Extruder MK2, blocks extruded will mimic the actual blocks. Redstone Blocks will emit Redstone, Glowstone will emit light, Grass will act transparent. But only with this Augment! \\nDoesn't work with Block Entities like Furnaces or Enrichment Chambers."]
 	quest.2DDA8AC73C2D50B4.quest_desc: [
 		"Styrene + Butadiene + Oxygen or Air in a &eChemical Reactor&r gets you the raw dust of the highest tier of rubber available"
@@ -4392,8 +4457,10 @@
 	quest.2E5EF984B9CE0CB9.quest_desc: ["The all in one, big battery, big range ore/fluid finder"]
 	quest.2E6D11A5F5626A6C.quest_subtitle: "&fTier 2&r"
 	quest.2E6F1C8718EB8C66.title: "&4Blood&r Upgrade Orb"
+	quest.2E6F761585C1FB4D.quest_subtitle: "Ash + Silver Lime"
 	quest.2E7E1278D9796141.quest_desc: ["Fiber Reinforced Circuit Boards, strong enough to support Quantum processors and the heat those qubits produce!"]
 	quest.2E7E1278D9796141.quest_subtitle: "Now thats a strong Circuit Board!"
+	quest.2E89ABF1A6145184.quest_subtitle: "Brazilwood + Kapok"
 	quest.2E8F851A4E98F741.quest_desc: [
 		"The &3Pneumatic Armor&r by itself is pretty great, however if you want to make this armor amazing, you'll need to install upgrades. Press 'U' by default to open the Upgrade GUI, some upgrades use pressure, some don't."
 		""
@@ -4784,6 +4851,7 @@
 		"Temperature: 167.0 Â°C"
 	]
 	quest.32738F324B799879.title: "Visit Mecury"
+	quest.327587EEEF6849BE.quest_subtitle: "Silver Fir + European Larch"
 	quest.329916B2CB8342B2.quest_desc: [
 		"&eChemical React&r that &aTetrafluoroethylene&r with a little Air or better yet, &bOxygen Gas&r, to receive the final product of &6Polytetrafluoroethylene&r!"
 		""
@@ -4889,6 +4957,7 @@
 	quest.3384308C78D86059.title: "Chicken Seeds"
 	quest.33882172DA8021F6.quest_subtitle: "Keeps the player's inventory stacked up from items in the backpack."
 	quest.33882172DA8021F6.title: "Refill Upgrade"
+	quest.33977CEF056F0A13.quest_subtitle: "Alder + Rowan"
 	quest.339DF320DDCAD98B.title: "Item \\\\& Fluid Transport"
 	quest.33A0E06FE5CFD8F3.quest_desc: [
 		"The &9Centrifuge&r is used to process Combs from Bees into useful items and honey! While you can definitely just use a regular &9Centrifuge&r in the beginning, getting a &6Powered Centrifuge&r soon after is a must. This is a faster Centrifuge that runs off of power!"
@@ -4977,6 +5046,7 @@
 		"These Energy Transmitters will do the trick."
 	]
 	quest.350B4AC4ADF7F84B.quest_subtitle: "Utilizing the Power"
+	quest.3512A883CD4E007C.quest_subtitle: "Bull Pine + Spruce"
 	quest.3513D89C6FD2D852.quest_desc: ["The Scepter shoots out energy orbs when charged up with Right-Click. If a mob is hit, it'll strike it with lightning."]
 	quest.3513D89C6FD2D852.quest_subtitle: "Go Pew Pew"
 	quest.3513D89C6FD2D852.title: "&1Draco Weapons"
@@ -5087,13 +5157,12 @@
 		"The simplest of the simplest of &e&lPipes&r, the &eItem Pipe&r. \\n\\nIt will move Items from one Inventory to another. Could be from one Chest to another, could be a Farm to a System, or even a Quarry to a Smelter. \\n\\nVery simple just connect the &ePipes&r to what you want moved, and use your Wrench to configure which side it Pulls from. "
 		"{image:atm:textures/questpics/logistics/pipez_item.png width:200 height:50 align:center}"
 	]
-	quest.36836AD948F96B9F.title: "&eItem Pipez&r"
+	quest.36836AD948F96B9F.title: "&eItem Pipez"
 	quest.36926B5EBFF6E55A.quest_desc: [
 		"&cMercury&r is one of the most important materials for &l&6Theurgy&r! \\n\\nTo get it we'll need to distill some in the &cMercury&r Distiller. Put Items into the Distiller, and give it some Heat! \\n\\nSome Items give more &cMercury&r like Diamonds which will give 10 &cMercury&r for 1 Diamond, compared to Stone which needs 10 Stone for 1 &cMercury&r."
 		"{image:atm:textures/questpics/theurgy/theurgy_distiller.png width:100 height:150 align:center}"
 	]
 	quest.36926B5EBFF6E55A.title: "Making &cMercury&r"
-	quest.36836AD948F96B9F.title: "&eItem Pipez"
 	quest.369D3AF332181DA8.quest_desc: ["The Stone Nest can be placed in any overworld biome to lure in a Mason Bee or Digger Bee."]
 	quest.369D3AF332181DA8.quest_subtitle: "Lures Bees in any Overworld Biome"
 	quest.36A3ECD4F6CA2732.quest_subtitle: "&f8&r &4Damage&r"
@@ -5125,10 +5194,11 @@
 	quest.36F87173D8CD1D68.title: "&5&lLightning&r"
 	quest.37045B986619A03D.quest_subtitle: "Yellow + Green Carpenter Bee"
 	quest.37045B986619A03D.title: "Lumber Bee"
+	quest.3707C3EDA1C5A0B2.quest_subtitle: "Firecracker + Flickering Sun"
 	quest.3708A4780ACEB34E.quest_desc: [
 		"In this modpack, Quests are optional. Mods are not gated behind completing any quests!"
 		""
-		"The individual questlines outside of the Main questline are meant to serve as mod guides. If you want to follow the progression, make sure to check out the Main Questline!"
+		"A lot of the individual questlines outside of the Main questline are meant to serve as mod guides. If you want to follow the progression, make sure to check out the Main Questline!"
 	]
 	quest.3708A4780ACEB34E.title: "Quests"
 	quest.371A34B297C8A8EF.quest_desc: [
@@ -5192,6 +5262,8 @@
 	]
 	quest.37A1137A59A2086B.quest_subtitle: "Superconductors!"
 	quest.37ACDA018D07A4DF.title: "&dUnobtainium Tools&r"
+	quest.37AD651E91FE3E20.quest_subtitle: "Pomelo + Key Lime"
+	quest.37B805E875D82A8B.quest_subtitle: "Balsa + Teak"
 	quest.37B903620493A354.quest_desc: [
 		"Vaild Upgrades:"
 		"- Auto Smoker"
@@ -5257,6 +5329,7 @@
 		"Its going to be used as a crafting component."
 	]
 	quest.38C0D3A240E43A23.quest_subtitle: "Transformers Robots in Disguise"
+	quest.38C236042AB5DDB9.quest_subtitle: "Bull Pine + Silver Fir"
 	quest.38C76A58EBED6C37.quest_subtitle: "&f7.5&r &4Damage&r"
 	quest.3908F7C80154D9CA.quest_desc: [
 		"Because who doesn't want to summon their own Zombies?"
@@ -5276,7 +5349,9 @@
 	quest.3930404D5C8B44EB.quest_subtitle: "Combines Materials"
 	quest.3930404D5C8B44EB.title: "Metal Alloyer"
 	quest.393DA9C9D808A851.quest_desc: ["&l&6Theurgy's&r Wrench is the &cMercurial&r Wand. You can Shift and Scroll to change its Modes. \\n\\nYou can Enable/Disable to basically stop Wires from transferring. \\n\\nYou can change the side of where Items will Extract or Insert to. \\n\\nAnd you can change the Frequency Channel!"]
+	quest.393DA9C9D808A851.quest_subtitle: "I thought this was a magic mod..."
 	quest.393DA9C9D808A851.title: "Of course there's a Wrench"
+	quest.3942B5F5FD8ADF89.quest_subtitle: "Sycamore + Breadfruit"
 	quest.395668FBCB6537AF.quest_desc: ["The 'Babes' love the &eBling&r! The &eBastion Ring&r is perfect for the bartering man. While wearing it Piglins will be neutral with you like how they are when you wear &eGold&r. This does not mean you can freely loot their chests though. The &eRing&r will also give you a chance at getting more Loot from Bartering. \\n \\n(While wearing the &eRing&r Piglins might point you toward the nearest Bastion)."]
 	quest.395668FBCB6537AF.quest_subtitle: "Found in Ruined Portals, Nether Fortresses, and Bastions"
 	quest.395668FBCB6537AF.title: "&eBastion Ring&r"
@@ -5290,10 +5365,12 @@
 	quest.39615B8E568E0380.quest_desc: ["Take the Yttrium Barrium Cuprate and make wires."]
 	quest.39615B8E568E0380.quest_subtitle: "Yit-Trium? is the Y silent?"
 	quest.396AA75774059D0B.quest_desc: ["You are too powerful."]
-	quest.3971FF7D044D1FE5.quest_desc: ["Armour abilities can be configured and toggled in the configuration menu. Use a JDT tool / wand to open the menu and click on your armour to configure the abilities of that armour piece."]
-	quest.3971FF7D044D1FE5.title: "Armour"
+	quest.396E7A2078F2CBC5.quest_subtitle: "Ash + Whitebeam"
+	quest.3971FF7D044D1FE5.quest_desc: ["Armor abilities can be configured and toggled in the configuration menu. Use a JDT tool/wand to open the menu and click on your armor to configure the abilities of that armor piece."]
+	quest.3971FF7D044D1FE5.title: "Armor"
 	quest.397E2D14BDE7DED0.quest_desc: ["All Bees will give Comb Blocks instead of Combs, effectively quadrupling outputs!"]
 	quest.397E2D14BDE7DED0.quest_subtitle: "4x Comb"
+	quest.399858D28294D633.quest_subtitle: "Mandarin + Citron"
 	quest.399882F3C51DD282.quest_subtitle: "Feed a Skeletal Bee a Withered Rose"
 	quest.399882F3C51DD282.title: "Withered Bee"
 	quest.3999760881C855FA.quest_desc: [
@@ -5341,6 +5418,7 @@
 		"Throwing in our &aLexica Botania&r will also upgrade it with &6Elven Knowledge&r, giving you more insight into your journey in Botania."
 	]
 	quest.3A20210242A1C865.title: "Communing with Elves"
+	quest.3A2249D94C019F0E.quest_subtitle: "Silver Lime + Cherry"
 	quest.3A27B65A0B4FFB5B.quest_desc: ["ME Item Output! Have the resultant item go directly back into your ME system."]
 	quest.3A27B65A0B4FFB5B.quest_subtitle: "ME Item Output"
 	quest.3A3ED88027331A6C.quest_desc: ["This item will let you keep all of your items in your inventory when you die."]
@@ -5352,6 +5430,7 @@
 		"Provides the player with an Elytra, note the Elytra provided by this upgrade is affected by the Walk and Run Speed upgrades."
 	]
 	quest.3A4B5A9B432576AD.title: "&cAwakened Watering&r"
+	quest.3A79E24283523E58.quest_subtitle: "Spruce + Birch"
 	quest.3A88906FC2E72528.quest_desc: ["Use the holy symbol three times to ignite what you are looking at."]
 	quest.3A88906FC2E72528.quest_subtitle: "Forgot a flint and steel in the caves?"
 	quest.3A8BF9BE08F54513.quest_desc: [
@@ -5467,6 +5546,7 @@
 	quest.3B84215240D9F2CB.quest_subtitle: "Secure your grid!"
 	quest.3B84215240D9F2CB.title: "Security Manager"
 	quest.3B88D58B11B5DC78.quest_subtitle: "&5Tier 4&r"
+	quest.3BAEF1A3FDB818A4.quest_subtitle: "European Larch + Red Maple"
 	quest.3BB3AA6C29285837.title: "&2Prudentium Apple&r"
 	quest.3BC0A50886A3222B.quest_desc: [
 		"ATM10 is a kitchensink pack that allows you to explore the world of modded Minecraft in your own way!"
@@ -5476,6 +5556,7 @@
 		"If you have any questions or issues, feel free to join the ATM discord!"
 	]
 	quest.3BC0A50886A3222B.title: "&dWelcome to All The Mods 10!"
+	quest.3BD304D851F49EC0.quest_subtitle: "Elderberry + Silver Fir"
 	quest.3BD5C517AD024A45.quest_desc: ["The last Superconductor we made was a while back. But now each tier's Superconductor will become more important, as well as allow us to have no Amperage loss cabling!"]
 	quest.3BD5C517AD024A45.quest_subtitle: "Recall"
 	quest.3BD73FEAE853D350.quest_desc: ["Ever hate how slow &bIce&r is unless using a Boat? Which still doesn't make sense to me! &bIce Skates&r change that now you accelerate on &bIce&r while wearing &bIce Skates&r. You can upgrade them to accel faster! \\n \\nAfter upgrading them you can get a Second Ability which allows you to damage Mobs by running into them while wearing &bIce Skates&r."]
@@ -6099,6 +6180,7 @@
 		""
 		"The arrows on the Crafters must eventually converge on the same Crafter to finish the recipe. You can turn the arrows by R-Clicking it with the Wrench."
 	]
+	quest.419C808FE10DB496.quest_subtitle: "Balsa + Wenge"
 	quest.419DD6FE84B91749.quest_desc: ["When collecting genes, you'll get a percentage of a trait. You can combine them in a crafting table to add them together, or place them in a Gene Indexer to auto-combine."]
 	quest.419DD6FE84B91749.quest_subtitle: "The Gene Combiner and Chest"
 	quest.41A0BE357C8A74E1.quest_desc: ["The &9Alchemical Sourcelink&r produces Source from adjacent potion jars. \\n\\nThe amount of source varies per potion and complexity."]
@@ -6195,6 +6277,7 @@
 	quest.425E375A9EC127EB.title: "&6Reinforced Tracks&r"
 	quest.427516AA3E8C9442.quest_subtitle: "Versatile Hoe"
 	quest.427516AA3E8C9442.title: "Mattock Blueprint"
+	quest.427B9C6D95885DE2.quest_subtitle: "Red Delicious Apple + Flowering Azalea"
 	quest.427C3AFC0FF131CD.title: "Fluids"
 	quest.427E7112ED0978FB.quest_desc: [
 		"With a reputation of being super overpowered, &2Mystical Agriculture&r allows you to grow crops of almost everything in the game. Want to grow Diamonds? Plant a Diamond Seed! "
@@ -6202,7 +6285,8 @@
 		"To learn more about the mod, check out the &2Mystical Agriculture&r questline!"
 	]
 	quest.427E7112ED0978FB.title: "&2Mystical Agriculture&r"
-	quest.4281BCDCE233F65B.quest_subtitle: "In Chests of Ancient Cities."
+	quest.4281BCDCE233F65B.quest_desc: ["These can be found in chests inside Ancient Cities."]
+	quest.4281BCDCE233F65B.quest_subtitle: "Ancient City Chests"
 	quest.42822B1E8A53D051.quest_subtitle: "Kill 5 Skeles"
 	quest.42822B1E8A53D051.title: "&l&9Overworld Bounty:&r&e Skeles"
 	quest.4285510271B5223D.quest_desc: ["The &n&5Gearbox&r can rotate the direction of the rotation in any direction by 90 degrees."]
@@ -6271,6 +6355,7 @@
 	]
 	quest.431C44439CA54077.title: "Upgrading Our Altar: Tier 4"
 	quest.4321E32D0EA3367C.quest_desc: ["Upgrading this machine to &5EV&r unlocks recipes necessary for eventually making &bTungsten&r"]
+	quest.43265FEF45846357.quest_subtitle: "Pomelo + Citron"
 	quest.433117EEA55B6A54.quest_desc: ["Just a simple fluid placer."]
 	quest.4351DAA8B607BCBB.quest_subtitle: "Ghostly + Skeletal/Zombee"
 	quest.4351DAA8B607BCBB.title: "Grave's Bee"
@@ -6374,6 +6459,7 @@
 		"With these Coils we can now processes the UHV Superconductors, and finally make them into ingots!"
 	]
 	quest.44EE336BC265D21C.quest_subtitle: "Tritanium Coils"
+	quest.44FEE957BD333241.quest_subtitle: "Silver Lime + Sour Cherry"
 	quest.450B3C0520D6B2BB.quest_desc: [
 		"Slap one of these down and start drilling! This will unearth the ancient oils from beneath the crust of bedrock"
 		""
@@ -6381,6 +6467,7 @@
 		""
 		"Do keep in mind, the oils in the chunk will deplete over time, so you will need to move the Fluid Drilling Rig occasionally"
 	]
+	quest.4510FD92BACF00FF.quest_subtitle: "Plum + Sweet Chestnut"
 	quest.451D03BE892CDE74.quest_subtitle: "&dTier 6&r"
 	quest.451D03BE892CDE74.title: "Exploration Mod Max Pickaxes"
 	quest.45268A619787288F.title: "&bDiamond Backpack&r"
@@ -6442,9 +6529,11 @@
 	]
 	quest.4597D3B3BDC2BED5.title: "Molecular Assembler"
 	quest.45996B848792379E.quest_desc: ["You can Mine &dSal Ammoniac Crystals&r in the &2Overworld&r but it isn't that easy. We'll still need &9Water&r and the Machines to make &dSal Ammoniac&r to make &eAlchemical Sulfur&r. \\n\\nThe &dCrystals&r are optional but help a ton; with just Water 1000mb will be turned into 100mb of &dSal Ammoniac&r. With 1000mb of &9Water&r and a &dSal Ammoniac Crystal&r we'll instead get 1000mb of &dSal Ammoniac&r. \\n\\n10 times the production with only a single Item more!"]
-	quest.45996B848792379E.title: "Why do we need Machines if we can just Mine it?"
+	quest.45996B848792379E.quest_subtitle: "Why do we need Machines if we can just Mine it?"
+	quest.45996B848792379E.title: "Why Machines?"
 	quest.459BA85E48B343AE.quest_desc: ["The &n&5Radial Chassis&r can be used similar to the &n&5Super Glue&r. It will connect blocks in a line, on the sides, without the need for glue."]
 	quest.45A25221F54A1DEC.quest_desc: ["The Ferricore Wrench allows the player to rotate machines, but it is also used to link swappers together."]
+	quest.45D1FFB263CD722D.quest_subtitle: "Teak + Clove"
 	quest.45D683D7F1A32B04.quest_desc: [
 		"&lAbility Type:&r Passive"
 		""
@@ -6512,6 +6601,7 @@
 		"Alternatively, you could &eCentrifuge&r &cRuby&r or &9Sapphire&r slurries"
 	]
 	quest.4665E6FD0AAED164.quest_desc: ["This item will let you keep your armor and hotbar when you die."]
+	quest.4676E9CD0F312C1A.quest_subtitle: "Mandarin + Kumquat"
 	quest.467CDD14AE21A850.quest_subtitle: "Increases Fuel Efficiency of Dynamos"
 	quest.469443A3BA0C3BEE.quest_desc: [
 		"Converts items from a liquid to a solid, some requiring casts."
@@ -6665,6 +6755,7 @@
 		"The bucket can pick up the underwater mobs in Blue Skies."
 	]
 	quest.47EFF4429010E26C.title: "Ventium Tools"
+	quest.481205F0C9B08200.quest_subtitle: "Teak + Clove"
 	quest.4821419D44F8083F.quest_desc: [
 		"&9Growth Accelerators&r very slightly increase the growth speed of a seed when placed directly underneath the farmland. Each tier has a range of how many blocks 'up' it can accelerate, with Inferium being the lowest at 12. "
 		""
@@ -6725,11 +6816,14 @@
 		"{image:atm:textures/questpics/iron_spells/spells_outfit_cryomancer.png width:60 height:100 align:center}"
 	]
 	quest.489833A2A6C39151.title: "&bCryomancecr Outfit&r"
+	quest.489A811AB1CFCBA3.quest_subtitle: "Kapok + Dark Oak"
 	quest.489B77B85B000B39.quest_desc: [
 		"Setting this machine up with lava on one side and water on another allows you to create either stone or cobblestone"
 		""
 		"At later tiers you can create any stone variant, even obsidian at HV!"
 	]
+	quest.48B97E3C2A93BC46.quest_subtitle: "Aspen + Beech"
+	quest.48BA8ACFADE3C8CE.quest_subtitle: "Citron + Wild Cherry"
 	quest.48BE7DAC5082044D.quest_desc: ["The Stressometer will show you how stressed the system is when you connect it."]
 	quest.48BF71269DEA1AB1.title: "&4Supremium Farmland&r"
 	quest.48C68664319B0294.quest_desc: ["To obtain this special Spell Book you'll need to slay the &4&lDead King&r! \\n\\nIt has 10 &3Spell&r Slots but 4 are taken up already. &4Blood Slash&r, &4Blood Step&r, &4Ray of Siphoning&r, and &4Blaze Storm&r come on it already and can't be taken off."]
@@ -6907,6 +7001,8 @@
 	quest.4AE05E80142C12A6.title: "Resistors Revisited"
 	quest.4AE3A2326EA07B7A.quest_desc: ["You'll get half the &6Phenol&r back when you turn this into &3Polybenzimidazole&r"]
 	quest.4AE3A2326EA07B7A.quest_subtitle: "How do you pronounce this?"
+	quest.4AEB4BF7624ABA0F.quest_subtitle: "Firecracker + Soul Tree"
+	quest.4AFA3CB55F6C10C2.quest_subtitle: "Pandanus + Coconut"
 	quest.4AFF81D3D0E78255.quest_desc: [
 		"This machine needs water to operate, and uses the water to clean \\\"Ore Slurry\\\" into \\\"Clean Ore Slurry.\\\""
 		""
@@ -7034,7 +7130,8 @@
 	]
 	quest.4C33366BAD0256CF.quest_subtitle: "Huh?"
 	quest.4C366515E3CCB0B2.quest_desc: ["Meat through a tube, yummy"]
-	quest.4C3B7BAEA653587B.quest_subtitle: "Found in Chests of Desert Pyrmids."
+	quest.4C3B7BAEA653587B.quest_desc: ["These can be found in chests inside Desert Pyramids."]
+	quest.4C3B7BAEA653587B.quest_subtitle: "Desert Pyramid Chests"
 	quest.4C41FD926F31180B.quest_desc: ["In order to move &2Items&r with &c&lLaserIO&r you'll need some &2Item Cards&r. \\n\\nSet one to Extract and put it on the side of the &cLaser Node&r you want to Import from. Then set the other to Insert and put it to the side you want the Items to Export to. \\n\\nThere are mutliple settings you can change with the Extract in order of where you want the Items to go if there's multiple places to Extract from. Round Robin will make it Extract items in an order instead of closest Inventory first."]
 	quest.4C41FD926F31180B.title: "&2Item Card"
 	quest.4C446F22771E2B53.quest_desc: ["Ever want THE most perfect Enchants? Then this is the setup you need, for 100%% everything. &95 Echoing Skulkshelves&r, &95 Soul-Touched Sculkshelves&r, and &d1 Draconic Shelf&r will get you &a50 Eterna&r, &c100%% Quanta&r, &5100%% Arcana&r and &96 Enchanting Clues&r. &e3 Shelves of End Fused Rectification&r will give &e100%% Rectification&r. And &6Deepshelf of Arcane Treasures&r will top it all off with &6Treasure Enchantments&r."]
@@ -7117,6 +7214,7 @@
 	quest.4D3D96B6019CA7F9.title: "Singularity"
 	quest.4D4AB60B3B1CD437.quest_desc: ["From the scales of the Naga, you can craft some armor. Not super strong, but looks nice."]
 	quest.4D4AB60B3B1CD437.title: "Naga Scale Armor"
+	quest.4D562F5D72038083.quest_subtitle: "Alder + European Larch"
 	quest.4D644A9829C240CB.quest_desc: ["You like the &bIgnis'&r shield? Well you can make 1 of your own with Ignitium. The Bulwark of the Flame can be used like a normal shield but also has a special effect. When holding right click and shift, letting go will let you charge at whatever is infront of you, like how goats do. Whatever gets hit will take damage and if pinched against a wall will also get stunned. Definitely nice to have around!"]
 	quest.4D644A9829C240CB.title: "Bulwark of the Flame"
 	quest.4D6885EFA4EE272F.quest_desc: [
@@ -7240,6 +7338,7 @@
 	]
 	quest.4E67C04AD43EB70D.quest_subtitle: "Tesla ain't got nothing on this motor!"
 	quest.4E7990AEBCCC3C95.title: "Uranium Seeds"
+	quest.4E802144C6E40D43.quest_subtitle: "Ceylon Ebony + Cherry"
 	quest.4E8A05C3BFA80540.quest_desc: [
 		"Arguably the most important aspect of Applied Energistics 2 is its storage system, making use of digital &eStorage Cells&f. These cells are accessible through either an &eME Chest&r for single cells, or an &eME Drive&r for multiple cells. "
 		""
@@ -7258,6 +7357,7 @@
 		"Temperature: -65.0 Â°C"
 	]
 	quest.4E8E49EB9C83188E.title: "Visit Mars"
+	quest.4E8ECD407C8EA2DC.quest_subtitle: "Mandarin + Pomelo"
 	quest.4E9229FBA875C0BE.quest_desc: [
 		"Exploration is a big part of the &6ATM&r packs! "
 		""
@@ -7457,6 +7557,7 @@
 		"The Robust Star Housing is strong enough to withstand the forces exerted in the star forge, and support the components that make up the GregStar"
 	]
 	quest.502FF1A93E06073C.quest_subtitle: "Precursor"
+	quest.5030F1D96457202E.quest_subtitle: "European Larch + Birch"
 	quest.5034A9137E0F3D3D.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks. \\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission. \\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
 	quest.5034A9137E0F3D3D.title: "AllRightsReserved"
 	quest.5037849316098890.title: "Pyrope Tools"
@@ -7467,6 +7568,7 @@
 	]
 	quest.5041EDE3E75E1EDF.quest_desc: ["A growth medium or culture medium is a solid, liquid, or semi-solid designed to support the growth of a population of microorganisms or cells via the process of cell proliferation or small plants like the moss Physcomitrella patens. "]
 	quest.5041EDE3E75E1EDF.quest_subtitle: "Growing Organics"
+	quest.504752A1C9EFED76.quest_subtitle: "Citron + Wild Cherry"
 	quest.5047792C6EF6D2AD.quest_desc: [
 		"When Bio Fuel is combined with Water and Hydrogen in a &aPressurized Reaction Chamber&r it creates Substrates. It also creates Ethylene as a by-product."
 		""
@@ -7578,6 +7680,7 @@
 	quest.515D958C0F436BE8.quest_subtitle: "Ultimate Voltage"
 	quest.515E7703BA1F55FB.quest_desc: ["The &dOther&r is home to several dungeons filled to the brim with loot and spawners. You can also find the boss of the ATM packs, the &5Piglich&r. Good luck killing this guy!"]
 	quest.515E7703BA1F55FB.title: "&aThe&r &dOther&r &aDimension&r"
+	quest.5160D62F07A642A7.quest_subtitle: "Rowan + Beech"
 	quest.517F0135926B15EE.quest_desc: ["All simple machines come with redstone controll, and some come with filtering."]
 	quest.517F0135926B15EE.title: "Simple Machines"
 	quest.5180CDD196518F64.quest_desc: [
@@ -7682,11 +7785,14 @@
 	quest.526559F94031FE43.title: "&dEternal Stella"
 	quest.52672B7FFFD51D16.quest_subtitle: "Adds a Stonecutting GUI to the backpack."
 	quest.52672B7FFFD51D16.title: "Stonecutter Upgrade"
+	quest.526A9655A62C93F4.quest_subtitle: "European Larch + Bull Pine"
+	quest.526CED9509FAA79B.quest_subtitle: "Blue Yonder + Firecracker"
 	quest.527453CD5A20AE38.title: "&6Master of Dragons&r"
 	quest.52ACADDFCB0E22AB.quest_desc: ["The 4096k Storage Disk can store 4096000 items."]
 	quest.52ACADDFCB0E22AB.title: "&a4096k Storage Part&r"
 	quest.52B22C07818981D0.quest_subtitle: "Copper + Nickel"
 	quest.52B22C07818981D0.title: "Constantan Bee"
+	quest.52B2ADE472707372.quest_subtitle: "Golden Declious Apple + Granny Smith Apple"
 	quest.52CDB46F6CBF007B.title: "Shovel Blueprint"
 	quest.52D3697F1F5625C7.quest_desc: ["&3Etching Acid&r is made in the Pressure Chamber with Molten Plastic...and some other stuff. Used in the Etching Tank."]
 	quest.52D3697F1F5625C7.quest_subtitle: "Don't Ask..."
@@ -7785,8 +7891,10 @@
 	quest.53B44E24BB111D24.quest_desc: ["Cheaper IV tier as well?! This just keeps getting better!"]
 	quest.53B44E24BB111D24.quest_subtitle: "IV"
 	quest.53B58FC3958750E7.quest_desc: ["Did you play around with the Placer too much and need to Break those Blocks? \\n\\nIts Tier and Enchants are determined by the Pickaxe its Crafted with. \\n\\nNow set the area and hopefully put a Filter and let it run! \\n\\nCan be used with a Placer to do stuff like turning Ores into Items."]
+	quest.53BA0C64804ADD24.quest_subtitle: "Pomelo + Wild Cherry"
 	quest.53BBE717148C0B18.quest_subtitle: "Lots of iron in these ores"
 	quest.53BBE717148C0B18.title: "Goethite Vein"
+	quest.53BDD0459F7B1D60.quest_subtitle: "Coffea + Teak"
 	quest.53C5CE6433E201BD.quest_desc: [
 		"These Wafers make the highest tier traditional Semi-Conductor chip, the UHPIC or Ultra High Power IC (Integrated Circuit). "
 		""
@@ -7829,6 +7937,9 @@
 	]
 	quest.54277F570314DCE1.title: "&dExtreme Reactors&r"
 	quest.542C6D76B579886C.quest_desc: ["Using our Enchanting Apparatus structure, we'll want to craft our first seed, the &5Magebloom Seed&r. \\n\\nThis will be used to create us some magical clothing!"]
+	quest.543F00603790AD3E.quest_desc: ["The (Log) Stripper strips Logs automatically using Axes put in the machine."]
+	quest.543F00603790AD3E.quest_subtitle: "Please don't"
+	quest.543F00603790AD3E.title: "Stripping"
 	quest.544011D1C48D8E65.quest_desc: ["Gem Cutting Table! To change the Rarity of your Gem you'll need to use this table. By using 2 of the same Gem and Rarity Materials you can increase your Gems rarity and that increases its power."]
 	quest.544011D1C48D8E65.title: "Getting better Gems"
 	quest.54423ED491F170B5.quest_desc: [
@@ -7885,6 +7996,7 @@
 		"{image:atm:textures/questpics/mek/fusion_activated.png width:225 height:150 align:1}"
 	]
 	quest.54D8B9CB3F98040F.title: "&dI Think We're Ready&r"
+	quest.54E7967B45B20F36.quest_subtitle: "Holly + Purple Crepe Myrtle"
 	quest.54E812911D10AA51.quest_desc: [
 		"Why generate resources when you can just harvest the world for them? "
 		""
@@ -8058,6 +8170,7 @@
 	quest.574E65B7954A13D0.quest_subtitle: "Zero Points!"
 	quest.57534FA0E09C4975.quest_desc: ["By now, you're already making &aLithium&r. Pump that into a Solar Neutron Activator to create &eTritium&r."]
 	quest.57534FA0E09C4975.title: "Fueling the Fusion Reactor: &eTritium&r"
+	quest.5753E0138A072A3F.quest_subtitle: "Cherry + Oak/Dark Oak"
 	quest.5758645223B4B5BA.quest_desc: ["With &3Aqua Walkers&r you can use it's Ability to walk on &9Water&r! You can hold Shift to sink into &9Water&r and Swim. I think I've read about a story like that once?"]
 	quest.5758645223B4B5BA.quest_subtitle: "Found in Shipwrecks and Ocean Ruins"
 	quest.5758645223B4B5BA.title: "&3Aqua Walkers&r"
@@ -8076,6 +8189,7 @@
 	]
 	quest.5766C8B9E850C186.quest_subtitle: "Creating Source Gems"
 	quest.576ABF43FCF886B7.title: "&2Prudentium Farmland&r"
+	quest.577A5FC500E14C05.quest_subtitle: "Lawson Cypress + Oak"
 	quest.5792CC9E3AFAB229.quest_desc: ["We also have the mod called &aGenerators Galore&r! This mod adds unique generators that use coal or other items."]
 	quest.57940981E8DE55D4.quest_desc: [
 		"It's easy to get lost in the Forest. In your travels, you'll run into Obsidian pillars."
@@ -8139,7 +8253,8 @@
 	quest.583F0F3C00D211BE.quest_desc: ["Did you know that plasma is considered the 4th state of Matter next to Solid, Liquid, and Gaseous?"]
 	quest.583F0F3C00D211BE.quest_subtitle: "Argon Plasma"
 	quest.5844DD2BEE5EC3DC.quest_desc: ["Don't eat it! \\n\\n&cMercury&r can be used for 3 different things: Incubation, Power Creation, and Logistics!"]
-	quest.5844DD2BEE5EC3DC.title: "Venus... no &cMercury&r!"
+	quest.5844DD2BEE5EC3DC.quest_subtitle: "Venus... no &cMercury&r!"
+	quest.5844DD2BEE5EC3DC.title: "Mercury"
 	quest.58452F7D73C30E72.quest_desc: [
 		"IT'S TIME TO GO TO SPACE!"
 		""
@@ -8373,6 +8488,7 @@
 	quest.5A658F239928850E.title: "I &dLuV &7Progression"
 	quest.5A6670364ADE0858.quest_subtitle: "&f29&r &4Damage&r"
 	quest.5A7FF6D0AED656DC.quest_desc: ["Decreases the amount of time that it takes for a Mana Burst to start losing its Mana, but will also decrease its rate of loss."]
+	quest.5A84A64CB3D3E6F5.quest_subtitle: "White Willow + Oak/Birch/Silver Lime"
 	quest.5A8F4CA0F09F4842.quest_desc: [
 		"Need to remove &dEnchantments&r from an item you've found? Maybe you want to remove a Curse? This can be done using the &cPurifier&r."
 		""
@@ -8427,6 +8543,8 @@
 		"- Void Shift: Improved teleportation distance."
 		"- Eclipse Gate: Creates a portable hole in a 3x3 area, direction is dependant of the face of the block targeted. Distance of the hole created is configurable. Note Eclipse Gate doesn't work on tile entities."
 	]
+	quest.5B0FF8E0B58A4150.quest_subtitle: "Walnut + Wild Cherry"
+	quest.5B114CE7192A0549.quest_subtitle: "Beech + Birch"
 	quest.5B1C5C9F9CCC51EB.quest_desc: [
 		"A little sulfuric acid with cyan dye and 2 salt dust will make the liquid cyan dye"
 		""
@@ -8512,6 +8630,7 @@
 		"All cables can also be crafted with dye to colour them. Uncoloured ('Fluix') cables can connect to any other colour of cable, but otherwise differently-coloured cables will never connect to one another."
 	]
 	quest.5C22E3103544B120.title: "Basic Cabling"
+	quest.5C26EBA2F58F28F1.quest_subtitle: "Red Delicious Apple + Cherry"
 	quest.5C38DAD6BA43A7F1.quest_desc: ["Take that Acetic Acid and add more Ethylene and Oxygen, this time on &aProgram 3&r in a &eChemical Reactor&r"]
 	quest.5C3FF43CF16BCF30.quest_desc: ["With Source Gems, you can get started crafting the various machines by creating &5Sourcestones&r."]
 	quest.5C3FF43CF16BCF30.quest_subtitle: "Formerly known as 'Arcane Stones'"
@@ -8652,6 +8771,7 @@
 	quest.5DB7C962203735ED.quest_subtitle: "&fTier 2&r"
 	quest.5DC892BA79EB52EC.quest_desc: ["The &n&5Mixer&r can be used combined with the Basin to craft."]
 	quest.5DC9848CC15DCACB.quest_subtitle: "Chill of the thrill"
+	quest.5DCDDC346359DF28.quest_subtitle: "Balsa + Dark Oak"
 	quest.5DE863C3FB6492BE.quest_desc: ["{image:atm:textures/questpics/iron_spells/spells_outfit_cultist.png width:60 height:100 align:center}"]
 	quest.5DE863C3FB6492BE.title: "&4Cultist Outfit&r"
 	quest.5DF26D712B643655.quest_subtitle: "Copper + Zinc"
@@ -8727,6 +8847,7 @@
 		"{image:atm:textures/questpics/railcraft/rail_turnout.png width:100 height:100 align:center}"
 	]
 	quest.5E750DB2244A67A1.title: "&6Turnout Tracks&r"
+	quest.5E766840DAB839A2.quest_subtitle: "Ash + Sugar Maple"
 	quest.5E799B92358A8732.quest_desc: ["In the &cNether&r, you'll run into &6Ancient Debris&r. This can be smelted down into Scraps that can be combined with Gold to create &6Netherite Ingots&r, which is an endgame metal use to craft some of the strongest tools and armor in the game."]
 	quest.5E799B92358A8732.title: "&dAncient Metals&r"
 	quest.5E7E35CCAF1C88EE.quest_desc: ["The &bME Import Bus&f periodically sucks items in from whatever external storage the bus is facing. It can optionally be filtered to only take in certain items from said inventory."]
@@ -8829,6 +8950,7 @@
 	quest.5F3BF06A1DA8AB8D.quest_subtitle: "Lasering it Up"
 	quest.5F458D79D43D8842.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks. \\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission. \\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
 	quest.5F458D79D43D8842.title: "AllRightsReserved"
+	quest.5F4AA7E7D050C327.quest_subtitle: "White Poplar + Ceylon Ebony"
 	quest.5F5120451BA5B2FE.quest_desc: ["Advanced machines have the same capabilities as their simple varients with the addition of configurable working area, more filter slots and requiring power."]
 	quest.5F5120451BA5B2FE.title: "Advanced Machines"
 	quest.5F5675E30ED046F7.quest_desc: ["You've probably already acquired some Darkstone, but we'll need it to craft the forge."]
@@ -8852,6 +8974,7 @@
 		"This serves as the base for all the microprocessor circuits"
 	]
 	quest.5FB29F3F4DF17765.quest_desc: ["Sometimes you don't want every Module to move multiple stacks at a time, so when you just want 1 Modules to do so use an Augment! This does not stack with Upgrades though... infact it overrides them."]
+	quest.5FC92F3794004A98.quest_subtitle: "Rippling Willow + Soul Tree"
 	quest.5FD3C68D5F218D02.quest_desc: [
 		"If you like playing with plants, but wished they could do a little more than create dyes, &dBotania&r has you covered. You'll need to advance through the mod to make the &6Star&r!"
 		""
@@ -9075,6 +9198,7 @@
 	quest.62161044F3F3AB87.quest_desc: ["That liquid &bcyan dye&r plus the Glass Lens in this machine will dye it into a &bGlass Lens (Cyan)&r"]
 	quest.6244032FE2E5F1E1.quest_desc: ["The &dDraconic Shelf&r is the last Shelf we'll need for perfect set up. It might only give &aEterna&r but it has the Max Max &aEterna&r of &a50&r."]
 	quest.6244032FE2E5F1E1.title: "&dDraconic Endshelf&r"
+	quest.6255E2FE6DD4084A.quest_subtitle: "Holly + Alder"
 	quest.625B5E3CDDAECFFD.quest_desc: [
 		"Im sure you have made a whole lot of EBF's during your journey to get here."
 		""
@@ -9098,6 +9222,8 @@
 	quest.627A39E62DD49CD8.quest_desc: ["In order to get the Mini End Portal you'll need a Mini Stronghold, kidding but you'll need an Ender Infused Teleportation Core. To infuse the Teleportation Core you'll need &a50 Eterna&r, between &c8.5%%-13.5%% Quanta&r, and between &532.5%%-37.5%% Arcana&r. To get that you'll need a complicated set up of &d5 Draconic Endshelves&r, &13 Echoing Sculkshelves&r, 2 Melonshelves, and a single Stoneshelf. Craft the Ender Infused Teleportation Core, 4 Eyes of Ender, and 4 End Stone Fire Pits to create the Mini End Portal."]
 	quest.627A39E62DD49CD8.title: "Miniature End Portal"
 	quest.627D6FDC3D8C42F6.quest_desc: ["Can convert liquids into items or other useful liquids."]
+	quest.6280748583C62E05.quest_subtitle: "Red Maple + Jungle"
+	quest.62991D7431A48F6D.quest_subtitle: "Banana + Cacao"
 	quest.629DC8DED0F6B578.quest_desc: ["Distilling biomass results in ethanol, which is alcohol, but don't tell anyone I told you"]
 	quest.629DC8DED0F6B578.quest_subtitle: "Not for drinking"
 	quest.62A262A706CFCAF0.quest_desc: [
@@ -9245,6 +9371,7 @@
 	]
 	quest.63F6F4EBCEB914B0.quest_subtitle: "Pressurizing!"
 	quest.63F6F4EBCEB914B0.title: "The Pressure Chamber"
+	quest.640D6ADA17709D3A.quest_subtitle: "Yellow Meranti + Kapok"
 	quest.6410CE6C57CA5B54.quest_desc: [
 		"Obviously with a process like Fusion Reaction, you need some good support materials. But what happens when you still want to see whats happening inside?"
 		""
@@ -9290,6 +9417,8 @@
 	quest.649167FC31EB916E.quest_desc: ["&3Vegetable Oil&r can be made by putting either crops or seeds into a &3Thermopneumatic Processing Plant&r."]
 	quest.649167FC31EB916E.quest_subtitle: "Better Oil"
 	quest.649167FC31EB916E.title: "Vegetable Oil"
+	quest.6497A255E427A5EB.quest_subtitle: "Balsam Fir + Bull Pine"
+	quest.64A09E2E3EF16C31.quest_subtitle: "Banana + Teak"
 	quest.64AB1E133E218173.quest_desc: [
 		"You can't use template boards forever!!! "
 		""
@@ -9450,6 +9579,7 @@
 	quest.6674270897997BF7.quest_subtitle: "Max: 1"
 	quest.66762A4743104157.quest_desc: ["Another craftable &eSpellbook&r, this one's a little more expensive! It'll need Hogskin which is a drop from Hoglins. \\n\\nThis one can hold 8 &3Spells&r which is technically still on the low side but it's better!"]
 	quest.66762A4743104157.title: "Apprentice's Spell Book"
+	quest.6678AB58930F4B91.quest_subtitle: "White Willow + Aspen"
 	quest.66815AB6FDACCAB7.quest_desc: [
 		"Stores items in the multi-block kitchen. Stack them on top of each other! "
 		""
@@ -9528,6 +9658,7 @@
 	quest.67422A235EBAD4CF.title: "Affixed Items"
 	quest.67482ED4B18F828D.quest_subtitle: "Iron + Neon Cuckoo"
 	quest.67482ED4B18F828D.title: "Osmium Bee"
+	quest.674A6B0EDA0D348B.quest_subtitle: "Teak + Mangrove"
 	quest.674E2690D66ECD6E.quest_desc: [
 		"When it's a thunderstorm, throwing in a &aWeather Container&r into the &aEnvironmental Accumulator&r will harness the power of the storm."
 		""
@@ -9604,7 +9735,7 @@
 	quest.67AFCBCE7AAC3089.title: "Creating The Turbine Shaft"
 	quest.67B73449A59467C5.quest_desc: ["Once you've got at least two hundred mahou you might want to make a boundary of drain life. For every mob that dies in that boundary, you get 10 mahou back, but this is a SLOW process."]
 	quest.67B73449A59467C5.title: "Boundary of Life Drain"
-	quest.67B87570C340C243.title: "Armour Upgrades"
+	quest.67B87570C340C243.title: "Armor Upgrades"
 	quest.67C4A4D6DD93DB0E.quest_desc: ["Place this under the soil to allow magical seeds to grow"]
 	quest.67C4A4D6DD93DB0E.title: "&bMagical Soil&r"
 	quest.67C9D2712EA1F637.title: "ULV Tier"
@@ -9664,6 +9795,7 @@
 	quest.683B58B699D4D381.quest_subtitle: "Spawns in a nest that has a Blue Banded Bee"
 	quest.683C260C854C5AA3.quest_desc: ["The Mechanical Fusion Anvil will be needed to make the void and fused weapons. It places like a normal anvil but does not have durability."]
 	quest.683C260C854C5AA3.title: "Mechanical Fusion Anvil"
+	quest.684BB9D2F2AC87A6.quest_subtitle: "Wenge + Cocobolo"
 	quest.68526BA198AADD8E.quest_desc: ["If you cannot find &belectrotine&r in the Nether, you can create it by mixing electrum and redstone in a &eMixer&r on &aProgram 1&r"]
 	quest.6856A5572B239D10.quest_subtitle: "&f16&r &4Damage&r"
 	quest.685C4A646E092A82.title: "&cAwakened Armor&r"
@@ -9948,6 +10080,7 @@
 		""
 		"We can now use these to make a block of &dInanite&r."
 	]
+	quest.6AE0A69DB3CDBCAA.quest_subtitle: "Sweet Crabapple + Flowering Azalea"
 	quest.6AF6A1985C103D9C.quest_desc: [
 		"&9Refined Storage&r is a mass storage mod that offers a simple network-based storage system."
 		""
@@ -9994,6 +10127,7 @@
 	quest.6BE928FE24539D4B.quest_subtitle: "EV"
 	quest.6BEE3578BD2C713C.quest_subtitle: "Spawns from a Dirt Nest"
 	quest.6BF6B00BC21CA547.quest_subtitle: "RF-Powered Handsaw!"
+	quest.6BF6C7C04F26D8BA.quest_subtitle: "Black Ember + Soul Tree"
 	quest.6BFD7854F078BF16.quest_subtitle: "Get a Grip."
 	quest.6BFD7854F078BF16.title: "Grip Blueprint"
 	quest.6C001E18093FC037.title: "Plants"
@@ -10102,6 +10236,7 @@
 	quest.6D09511D64DDC282.title: "&5Kill The Warden&r"
 	quest.6D124ACF4AE80490.quest_desc: ["With Micromissiles you can shoot explosions from far away! Now nobody can escape!"]
 	quest.6D124ACF4AE80490.quest_subtitle: "Firing Explosions from afar!"
+	quest.6D14ACECD2084456.quest_subtitle: "Wenge + Oak"
 	quest.6D232F6D8E8DA546.quest_desc: [
 		"Very popular around Halloween!"
 		"{image:atm:textures/questpics/iron_spells/spells_outfit_plagued.png width:60 height:100 align:center}"
@@ -10138,6 +10273,7 @@
 	quest.6D81DF90E9C2C049.quest_desc: ["Has 18 filter slots and works 2x faster."]
 	quest.6D81DF90E9C2C049.title: "Elite Destructor"
 	quest.6D88C19F47D0D469.title: "Tier: &7Tiny&r"
+	quest.6D95CB7906C0DC84.quest_subtitle: "Beech + Cacao"
 	quest.6D9CDB4D81DC164D.title: "Bow Blueprint"
 	quest.6D9CFCD81A23BB3B.quest_desc: [
 		"&lAbility Type:&r Passive"
@@ -10153,6 +10289,7 @@
 	]
 	quest.6DA0ABBC89711536.quest_subtitle: "Neutron Reflectors?? Things are getting serious..."
 	quest.6DAA82B5F94AF9F8.quest_desc: ["The &9Jar of Light&r summons a floating light source that follows you. \\n\\nThe &6Jar of Voiding&r destroys items you pick up in exchange for mana. This can be filtered. \\n\\nTo add or remove an item to be destroyed by the jar, use the jar with the item in your off hand, or use an item on the Scribe's Table with the jar placed on it. \\n\\nThe jar must be on your hotbar to function."]
+	quest.6DAECA44E28DA9BA.quest_subtitle: "Beech + Birch"
 	quest.6DB06E3984D0CF97.quest_desc: ["Has 2 slots for Constructing."]
 	quest.6DB06E3984D0CF97.title: "Elite Constructor"
 	quest.6DB1AAAD926486BC.quest_desc: [
@@ -10190,6 +10327,7 @@
 	quest.6E093D16B12E12B3.title: "Quarry Bee"
 	quest.6E0D16C7036E81C1.quest_desc: ["Or, make a durability exchange and toss strong (but not too strong, no chisels because the mod normalizes things to around a netherite shovel in terms of durability)"]
 	quest.6E0D16C7036E81C1.title: "Durability Exchange"
+	quest.6E0DF05DEF48D2EB.quest_subtitle: "Almond + Cashew"
 	quest.6E0E13806F388D7E.quest_desc: ["Welcome to &aArs Nouveau&f! \\n\\nArs Nouveau is a magic mod that allows you to create custom spells with the different Glyphs made within the mod!"]
 	quest.6E0E13806F388D7E.title: "Welcome to &aArs Nouveau&f!"
 	quest.6E15447FC3D678E0.quest_desc: ["The &bFuzzy Card&f allows a filtered item to be matched regardless of any (NBT) metadata such as damage or enchantments, while the &bInverter Card&f toggles the filter on such buses from being a whitelist to being a blacklist."]
@@ -10382,6 +10520,7 @@
 		"By combining a Mana Lens with specific runes and items, we can use them to upgrade our Spreaders. You can also combine 2 lenses together with a &aSlime Ball&r to create &9Composite Lenses&r, combining the powers to create even stronger effects."
 	]
 	quest.6FBE0BF8A7ADBB26.title: "Upgrading Mana Spreaders"
+	quest.6FBF112811FB707C.quest_subtitle: "Ash + Birch"
 	quest.6FC4146E534C51DA.quest_desc: ["By combining a Netherite Upgrade Template, a Netherite Helmet, and a Monstrous Horn to make the Monstrous Helm. It has better stats and when you're at half health it'll do knockback everything close to you and increase defense stats."]
 	quest.6FC4146E534C51DA.title: "Monstrous Helm"
 	quest.6FC7DC1F856A748D.quest_desc: ["Okay this is a long one just stick with me. First Ability allows two modes,  &6Sancity&r and &7Unholiness&r. &6Sancity&r takes some of your Healing and uses it as Damage against enemies. &7Unholiness&r does the opposite, it takes the enemies Healing to help you deal more damage. Mobs like &dEnder Dragon&r and &5Wither&r both regenerate Health. \\n \\nThe Second Ability is Repentance, while active it will Burn Undead Mobs (Zombie, Skeleton, and their cousins). \\n \\nThe Third Ability grants a small time period of Invincibility."]
@@ -10464,6 +10603,7 @@
 	quest.70494167486FB2BF.quest_desc: ["The UV Emitter is one part of 2 very important blocks. We will go over these blocks later."]
 	quest.70494167486FB2BF.quest_subtitle: "Part 1 of 2"
 	quest.707EBA5717938515.quest_desc: ["A necessary component for the &bMV Cutter&r"]
+	quest.708129CB530BAC67.quest_subtitle: "Wild Cherry + Cacao"
 	quest.709118898CF960BE.quest_desc: [
 		"Found randomly in loot chests from the End City."
 		""
@@ -10476,6 +10616,7 @@
 	]
 	quest.709344CCB273856F.title: "Indoor Farms"
 	quest.709F1FA492703463.title: "Obsidian 5X"
+	quest.70A4E2B0491634FA.quest_subtitle: "Sugar Apple + Banana"
 	quest.70ACECAEEE8947A5.quest_subtitle: "&9Tier 1&r"
 	quest.70AD088336748892.quest_desc: ["Just a simple coal generator."]
 	quest.70B518EC050678AE.quest_desc: ["Tier 3 Ender IO Exchanger Core. This is the top of the line when it comes to the EnderIO Exchanger Cores."]
@@ -10508,6 +10649,7 @@
 	quest.70CDA5F1593DB4B2.title: "&eCursed Pyramid&r: Home of &eAncient Remnant&r"
 	quest.70D60687AAB145FE.quest_subtitle: "Common"
 	quest.70ED849A2EB44DEE.quest_subtitle: "&bTier 3&r"
+	quest.70F7B018CD61E946.quest_subtitle: "Dark Oak + Jungle"
 	quest.71060904C6A86C68.quest_desc: [
 		"These Naquadah Frames will have a lot of uses as a component and building block. "
 		""
@@ -10553,6 +10695,7 @@
 	quest.71941882F9E2ADAC.quest_subtitle: "Lab Testing"
 	quest.7198ED7E97A256A4.quest_desc: ["The first special crafted Divination Rod is the Abundant Material Rod! \\n\\nWhen you craft the Rod with an &eAlchemical Sulfur&r of an Item, the Rod will be attuned to that Item. \\n\\nYou can see the list for Abundant Materials in the Tags, it's too big for me to read off in Quests.  "]
 	quest.71A1FD0772453B51.quest_desc: ["Don't you hate Right Clicking everything? From Sheeps with Shears to Cows with Buckets? It's the 21st Century we should have Robots to everything! Or atleast Routers do everything. \\n\\nWith Activator Module it will act as if it were you Right Clicking things. \\n\\nYou can set what it will Right Click, if it will Attack or Use the Mob or Block, if you Shift Right Click, and how close they need to be in the Module."]
+	quest.71AA40CB2948A8D7.quest_subtitle: "Blue Yonder + Soul Tree"
 	quest.71B1416A45FBBE40.quest_desc: [
 		"You can find sulfur ore in the nether and then smelt it to get sulfur dust. There are also bees!"
 		""
@@ -10698,9 +10841,9 @@
 	quest.730130CCF1CF5119.title: "&2Overworld&r"
 	quest.7305EE0F7D73C231.quest_desc: [
 		"Blank Upgrades are the base of all abilities. Abilities are seperated into two types, passive and active. "
-		"Passive abilities require no active input by the player to work, however Active abilities only work when triggered by a keybind players set in the configuration menu, also active abilities consume durability / power when used. When installed on higher tier armour Active abilities have reduced cooldowns and Passived abilities have greater effects."
+		"Passive abilities require no active input by the player to work, however Active abilities only work when triggered by a keybind players set in the configuration menu, also active abilities consume durability/power when used. When installed on higher tier armor Active abilities have reduced cooldowns and Passived abilities have greater effects."
 		""
-		"The smithing table is used to apply upgrades to JDT tools and armour. Holding shift when hovering over JDT tools or armour shows what upgrades are valid."
+		"The smithing table is used to apply upgrades to JDT tools and armor. Holding shift when hovering over JDT tools or armor shows what upgrades are valid."
 	]
 	quest.730AF9210F00018E.quest_desc: ["This is a drop from the Minoshroom. It deals more damage when sprinting."]
 	quest.730F2D3329C4FF88.quest_desc: ["&nFermentation&r: \\nThe chemical process by which molecules such as glucose are broken down anaerobically. \\n\\nAKA &9Water&r and time change thing! \\n\\nTo use the Fermentation Vat put the Items and Fluid into the Vat then Shift Right Click to close it. \\n\\nAfter awhile it should ferment! This is how we turn &eAlchemical Sulfur&r into &3Alchemical Niter&r which can be turned into more Items!"]
@@ -10790,6 +10933,7 @@
 	quest.7408CCF998D9CD37.title: "Ancient Codex"
 	quest.74200A48498DD7F8.quest_desc: ["Generates power from the sun!"]
 	quest.74200A48498DD7F8.quest_subtitle: "Produces about 17.6FE/t"
+	quest.74297A72584F5D7B.quest_subtitle: "Alder + Wild Cherry"
 	quest.7439CFAD20E3E2BF.quest_desc: [
 		"Using this bone meal on Farmland will convert it to Magical Farmland."
 		""
@@ -10830,6 +10974,7 @@
 	quest.74726A2DD4BBDA7B.quest_subtitle: "Now thats Stronk"
 	quest.747B62A955D0C629.quest_desc: ["&4The Ancient Factory&r lies deep underground in the &2Overworld&r. With many redstone machines including &4The Watchers&r, &4The Prowler&r, and &4The Harbinger&r. You'll also find EMPs which when powered with redstone will damage things around it."]
 	quest.747B62A955D0C629.title: "&4Ancient Factory&r: Home of &4The Harbinger&r"
+	quest.747BA0DB44A49A4F.quest_subtitle: "Red Delicious Apple + Sand Pear"
 	quest.748A01B5607C475B.quest_desc: ["Holds Talismans... not much else. Might also hold your Pants up but haven't tested it yet."]
 	quest.748A01B5607C475B.quest_subtitle: "Found in Mineshafts or Strongholds"
 	quest.748A01B5607C475B.title: "&6Leather Belt&r"
@@ -10843,6 +10988,7 @@
 		"However, items repaired might become &dCursed&r...."
 	]
 	quest.74B0308336F5E017.title: "Repairing Tools with &cBlood&r"
+	quest.74CD3FC35F245DF2.quest_subtitle: "Blue Yonder + Flickering Sun"
 	quest.74D47A8DF93294E4.quest_desc: [
 		"Now you need that &aLarge Chemical Reactor&r to make this"
 		""
@@ -10917,6 +11063,7 @@
 	quest.75CBB5BD8C1DFEA1.quest_desc: ["The &n&5Basin&r is used for recipes, mainly including the &n&5Mechanical Press&r and the &n&5Mechanical Mixer&r."]
 	quest.75CD4EE6A542D687.quest_subtitle: "Crystalline + Ashy Mining"
 	quest.75CD4EE6A542D687.title: "Copper Bees"
+	quest.75CE67D3AA75C798.quest_subtitle: "Red Delicious Apple + Granny Smith Apple"
 	quest.75CF9EAB75C3907E.quest_desc: [
 		"Using the power of &9Dark Gems&r, we can create &aDark Tanks&r."
 		""
@@ -10956,6 +11103,7 @@
 	quest.762B8309E1A31B99.quest_subtitle: "Max: 4"
 	quest.762BD49C9589EB3F.quest_desc: ["The need for Coils is never ending. While we may not be utilizing these in a multiblock, you can be assured they are going to a good source."]
 	quest.762BD49C9589EB3F.quest_subtitle: "More Coils?"
+	quest.762C54C261ED5D29.quest_subtitle: "Teak + Mahogany"
 	quest.76406EFFF8CBA6B4.quest_desc: ["Diamonds are one of the best materials to use for tool crafting, but also allows you to visit new dimensions like the Nether!"]
 	quest.76406EFFF8CBA6B4.title: "We've Struck &bDiamonds&r!"
 	quest.76558D23A70AFF78.title: "&bIce&r Upgrade Orb"
@@ -10992,7 +11140,16 @@
 	]
 	quest.768951FBE8A5C934.quest_subtitle: "Hyperconductivity"
 	quest.768B5E3633A76ED0.quest_subtitle: "&eTier 5&r"
-	quest.768C07D1B5EB1FEB.quest_subtitle: "Found in Cold Ocean Ruins Sus Blocks."
+	quest.768C07D1B5EB1FEB.quest_desc: ["These can be found in Suspicious Sand and Gravel inside Cold Ocean Ruins."]
+	quest.768C07D1B5EB1FEB.quest_subtitle: "Cold Ocean Ruin Sus Blocks"
+	quest.76A0592F4C294545.quest_desc: [
+		"The Sawmill cuts Logs into Sawdust and more Planks than you would get from crafting. Sawdust can be used to make Paper."
+		""
+		"- Fustic Logs will also give you Fustic."
+		"- Brazilwood Logs and Logwood Logs will also give you Haematoxylin."
+	]
+	quest.76A0592F4C294545.quest_subtitle: "I Wood too"
+	quest.76A0592F4C294545.title: "Sawing"
 	quest.76A38CCA5816CDAD.quest_desc: ["Combining Oxygen, Ethylene, and a Substrate in a &aPressurized Reaction Chamber&r will create an HDPE Pellet."]
 	quest.76A38CCA5816CDAD.title: "HDPE Pellets"
 	quest.76A4FCDF04AD6656.quest_desc: ["Can drop skulls from certain mobs or players when dealing the finishing blow. Can also be enchanted with Looting."]
@@ -11021,7 +11178,7 @@
 	]
 	quest.76ECB0EF7A5E410A.quest_subtitle: "Using water as a fuel in cars?"
 	quest.76F675A898EAB4E8.quest_desc: ["&dSal Ammoniac&r is a critical part of &eAlchemical Sulfur&r which is what we will use to make and reproduce Items. \\n\\nTo get &dSal Ammoniac&r we'll need some &9Water&r. "]
-	quest.76F675A898EAB4E8.title: "Getting &dSal Ammoniac&r"
+	quest.76F675A898EAB4E8.title: "&dSal Ammoniac&r"
 	quest.770ED8E5FEC6D59A.quest_desc: ["These blocks are Corrosion proof, and its a good thing, as they will be used to make the Large Brewing Vat. "]
 	quest.770ED8E5FEC6D59A.quest_subtitle: "Corrosive Materials? No thanks."
 	quest.77145113CD5B26FB.quest_desc: ["Source Berries produce more Source than other sources. \\n\\nThis will also convert grass or dirt into Mycelium in a 3x3 area around it. It will also grow mushrooms around it if the space is empty."]
@@ -11080,6 +11237,7 @@
 		"However, unlike regular cells, their contents can also be accessed standalone via the cell item itself, a bit like a digital ME-flavoured backpack."
 	]
 	quest.77C9EE701F72586D.title: "Portable Storage"
+	quest.77D3546953550E39.quest_subtitle: "Bull Pine + Spruce"
 	quest.77F241BEE9902751.quest_desc: ["Even MORE slots for storage and upgrades."]
 	quest.77F241BEE9902751.quest_subtitle: "So much room for activities!"
 	quest.77F241BEE9902751.title: "&5Netherite Chest&r"
@@ -11262,6 +11420,7 @@
 		""
 		"Energium Batteries hold up to &a10 minutes&r of HV power"
 	]
+	quest.799CC9FEEDE471B1.quest_subtitle: "Mango + Star Anise"
 	quest.79A19D0B2F94EFDC.quest_desc: ["Allows a Mana Burst to home in on any nearby blocks that can receive Mana. This also slightly decreases the speed of the burst."]
 	quest.79AD74A863EA43CB.quest_desc: [
 		"Flux Networks does provide a way to store the power you generate for your network! "
@@ -11336,6 +11495,7 @@
 		"Note: The Mana Pool stores a massive amount of mana. To see how much Mana is stored, try looking at one while holding the &2Wand of the Forest&r."
 	]
 	quest.7A359C1F5E041C4F.title: "&bMana&r"
+	quest.7A3DD8CAD6A5692D.quest_subtitle: "Red Delicious Apple + Sugar Maple"
 	quest.7A514E27E1A7FE32.quest_desc: [
 		"Diamonds also allow us to create some cool gadgets to help us build using the mod &aBuilding Gadgets&r. "
 		""
@@ -11413,6 +11573,7 @@
 	]
 	quest.7B0DFA55B4D8B16D.quest_subtitle: "Teleportation at its finest."
 	quest.7B0DFA55B4D8B16D.title: "Custom Portals!"
+	quest.7B1693793419B769.quest_subtitle: "Silver Lime + Cherry"
 	quest.7B2008977702D0C8.quest_desc: [
 		"When making pressure in an Air Compressor, if you don't have anywhere for the pressure to go. it will just disappear. Make sure you have somewhere for the pressure to go before making some."
 		""
@@ -11426,6 +11587,7 @@
 		"It can be powered, allowing for Elytra-like flight! It also protects you from Acid Rain. :)"
 	]
 	quest.7B2A7B2298DAE8EC.title: "Jet Suit"
+	quest.7B3920DE6306A94A.quest_subtitle: "Mandarin + Kumquat"
 	quest.7B3FAF5CA4DD217C.quest_desc: [
 		"Using the Petal Apothecary, we can create several different types of flowers that can help us on our journey, and these are broken down into two different categories: &9Functional Flowers&r and &aGenerating Flowers&r."
 		""
@@ -11561,7 +11723,7 @@
 	]
 	quest.7C4E4793DA887DE4.title: "Welcome to &9Extreme Reactors&r!"
 	quest.7C4F1012F5B6532F.quest_desc: ["&lProductive Trees&r is a sister Mod to &lProductive Bees&r. \\n\\nIn order to get the different Trees you will need Pollinated Leaves. To get Pollinated Leaves you need Pollen. For Pollen you need Bees. \\n\\nBees flowering near the Trees will automatically Pollinate Leaves, or you can use a Pollen Sieve Upgrade in the Hive to get and use Pollen yourself! Have one on the house!"]
-	quest.7C4F1012F5B6532F.title: "Vanilla Saplings"
+	quest.7C4F1012F5B6532F.title: "Productive Trees"
 	quest.7C61906C6C87C97D.quest_desc: [
 		"The &9Electromagnetic Coil&r is placed directly on top of the &aRotational Complex&r to convert the kinetic energy into power."
 		""
@@ -11631,6 +11793,7 @@
 	]
 	quest.7CFA92CC48D1E7E3.title: "Wither Skeleton Seeds"
 	quest.7CFEE836C68B3903.quest_subtitle: "&f7.5&r &4Damage&r"
+	quest.7D0AE6FCB0996218.quest_subtitle: "Teak + Ipe"
 	quest.7D12B3ECC3E3AC7B.quest_desc: [
 		"Cables can only go so far, which means you'll eventually want to transfer your power wirelessly. "
 		""
@@ -11672,6 +11835,7 @@
 	quest.7D6B4AEF806AF62E.quest_desc: ["100% way too fast! Try not to die!"]
 	quest.7D6B4AEF806AF62E.quest_subtitle: "Max: 1"
 	quest.7D7983F39E6E818D.title: "Tier: &9Niotic&r"
+	quest.7D7DC3C695CD7236.quest_subtitle: "Silver Lime + Spruce"
 	quest.7D81F2381516204D.quest_subtitle: "Needed for Finished PCBs"
 	quest.7D81F2381516204D.title: "Transistors"
 	quest.7D8ECACF214324D6.quest_desc: [
@@ -11702,6 +11866,7 @@
 		"Naquadah or Naq in short is used in its many various forms from ZPM and onwards. If you know the origins of Naquadah, then all of these references make sense."
 	]
 	quest.7D972F334DCE5626.quest_subtitle: "Must Make More Naq!"
+	quest.7DA48EDCF28DBE03.quest_subtitle: "Ginkgo + Hazel"
 	quest.7DC798518DDAAD26.quest_desc: [
 		"The Gatekeeper knows all about the dimensions of Blue Skies. As you journey through the mod, your &9Blue Journal&r will expand to help guide you."
 		""
@@ -11752,6 +11917,7 @@
 	quest.7E407CDBFD85E65F.quest_desc: ["Oxygen + Ethylene on &aProgram 2&r in your &eChemical Reactor&r is one way to make Acetic Acid"]
 	quest.7E697FE6A6C8B4EE.quest_desc: ["These LuV Tier Superconductor ingots will serve us well in making Superconductor Wires, and Fine Wire. "]
 	quest.7E697FE6A6C8B4EE.quest_subtitle: "With Ingots we have options!"
+	quest.7E7637DAD2C242CB.quest_subtitle: "European Larch + Spruce"
 	quest.7E79F52147B606F9.quest_desc: [
 		"To start collecting blood, we need to craft the &cBlood Extractor&r."
 		""
@@ -11812,6 +11978,7 @@
 	quest.7EC8814940C4C3D7.quest_desc: ["Use this item to shrink. Helpful for working on automation and also just overall fun."]
 	quest.7EC8814940C4C3D7.quest_subtitle: "Honey I Shrunk Myself"
 	quest.7EC8814940C4C3D7.title: "Personal Shrinking Device"
+	quest.7EC89242980768B3.quest_subtitle: "Pecan + Wild Chery"
 	quest.7EDF2CC08FC774F9.quest_subtitle: "&f10&r &4Damage&r"
 	quest.7EE14ED04C64E2AA.quest_desc: ["If we take the Fiber Reinforced Circuit Boards we made in the LuV tier, and change the recipe a bit, we can create a Multi-Layered Fiber Reinforced Circuit Board"]
 	quest.7EE14ED04C64E2AA.quest_subtitle: "Change up"
@@ -12046,6 +12213,7 @@
 	task.1DCE7B9772542FDB.title: "&dUpgrading The Forge&r"
 	task.1E0593F1AA073CFD.title: "Flux Efficiency"
 	task.1E28BFC0AB5CF2FE.title: "Experience Comb"
+	task.1E77B21EA9F2E9A7.title: "Fueled Fireboxes"
 	task.1E8B8C302718AFB5.title: "Any Blue Skies Wooden Pickaxe"
 	task.1EEC7B67E037F766.title: "Understanding Pressure"
 	task.1F1A69738DE70DB6.title: "Mycelial Reactor, huh?"
@@ -12278,6 +12446,7 @@
 	task.695EA135D2B5FDC8.title: "Enter the Twilight Forest"
 	task.6962BAEF473C8C18.title: "Valid Ores"
 	task.69ED2BD3D6D30648.title: "Valid Ores"
+	task.6A4FADC04E1C9DA7.title: "Steam Boiler Tanks"
 	task.6A623C45C3A556B6.title: "Valid Ores"
 	task.6A965CD027BF762F.title: "AllRightsReserved"
 	task.6C12449632AD53DC.title: "Track Kits"
@@ -12313,6 +12482,7 @@
 	task.75924053D6F5B242.title: "Spatial Storage Cells"
 	task.76B722B1AE7B6CF2.title: "AllRightsReserved"
 	task.76EEAE9313F68334.title: "AllRightsReserved"
+	task.76F6BC2EC054BD3C.title: "Alchemical Sulfurs"
 	task.770B8B984F85AB73.title: "AllRightsReserved"
 	task.775A7E11D20688CD.title: "High-Flux RF Coil"
 	task.778C0EDD0752F465.title: "Valid Ores"

--- a/config/ftbquests/quests/lang/es_es.snbt
+++ b/config/ftbquests/quests/lang/es_es.snbt
@@ -10118,7 +10118,6 @@
 	task.30FE30A7FA067459.title: "Brown Shroombee Comb"
 	task.3153288DCE1C4FEF.title: "&aMekanism&r: &dAdvanced&r"
 	task.3165B02F2BFFEDDA.title: "Chemical Reactor"
-	task.31A1425AA09C33F8.title: "Polvo de Litio"
 	task.31A7661D828CB33C.title: "Minerales Validos"
 	task.3202568944BCBF77.title: "Magmatic Comb"
 	task.335D80E83360A7DB.title: "Ether Gas? Huh?"

--- a/config/ftbquests/quests/lang/ja_jp.snbt
+++ b/config/ftbquests/quests/lang/ja_jp.snbt
@@ -10046,7 +10046,6 @@
 	task.30FE30A7FA067459.title: "ブラウンシュルームミツバチコーム"
 	task.3153288DCE1C4FEF.title: "&aメカニズム&r: &d高度&r"
 	task.3165B02F2BFFEDDA.title: "化学リアクター"
-	task.31A1425AA09C33F8.title: "リチウムダスト"
 	task.31A7661D828CB33C.title: "有効な鉱石"
 	task.3202568944BCBF77.title: "マグマティックコーム"
 	task.335D80E83360A7DB.title: "エーテルガス？ね？"

--- a/config/ftbquests/quests/lang/nb_no.snbt
+++ b/config/ftbquests/quests/lang/nb_no.snbt
@@ -10118,7 +10118,6 @@
 	task.30FE30A7FA067459.title: "Brown Shroombee Comb"
 	task.3153288DCE1C4FEF.title: "&aMekanism&r: &dAdvanced&r"
 	task.3165B02F2BFFEDDA.title: "Chemical Reactor"
-	task.31A1425AA09C33F8.title: "Lithium Dust"
 	task.31A7661D828CB33C.title: "Valid Ores"
 	task.3202568944BCBF77.title: "Magmatic Comb"
 	task.335D80E83360A7DB.title: "Ether Gas? Huh?"

--- a/config/ftbquests/quests/lang/pt_br.snbt
+++ b/config/ftbquests/quests/lang/pt_br.snbt
@@ -10117,7 +10117,6 @@
 	task.30FE30A7FA067459.title: "Pente Shroombee Marrom"
 	task.3153288DCE1C4FEF.title: "&aMekanismo&r: &dAvançado&r"
 	task.3165B02F2BFFEDDA.title: "Reator Químico"
-	task.31A1425AA09C33F8.title: "Pó de lítio"
 	task.31A7661D828CB33C.title: "Minérios Válidos"
 	task.3202568944BCBF77.title: "Pente Magmático"
 	task.335D80E83360A7DB.title: "Gás Éter? Huh?"

--- a/config/ftbquests/quests/reward_tables/1DB1EEDA7B79672B.snbt
+++ b/config/ftbquests/quests/reward_tables/1DB1EEDA7B79672B.snbt
@@ -10,4 +10,5 @@
 		{ count: 16, item: { count: 1, id: "railcraft:high_speed_track" } }
 		{ count: 16, item: { count: 1, id: "railcraft:high_speed_electric_track" } }
 	]
+	use_title: true
 }

--- a/config/ftbquests/quests/reward_tables/3602F483568B92BA.snbt
+++ b/config/ftbquests/quests/reward_tables/3602F483568B92BA.snbt
@@ -34,4 +34,5 @@
 		{ item: { count: 1, id: "chisel:chisel" } }
 		{ item: { count: 1, id: "minecraft:lava_bucket" } }
 	]
+	use_title: true
 }

--- a/config/ftbquests/quests/reward_tables/5832C9BCFDB476AF.snbt
+++ b/config/ftbquests/quests/reward_tables/5832C9BCFDB476AF.snbt
@@ -8,4 +8,5 @@
 		{ count: 5, item: { count: 1, id: "ars_nouveau:source_berry_roll" } }
 		{ item: { count: 1, id: "ars_nouveau:source_jar" } }
 	]
+	use_title: true
 }

--- a/config/ftbquests/quests/reward_tables/75FE7CDF68581EDE.snbt
+++ b/config/ftbquests/quests/reward_tables/75FE7CDF68581EDE.snbt
@@ -9,4 +9,5 @@
 		{ count: 6, item: { count: 1, id: "minecraft:copper_ingot" } }
 		{ count: 6, item: { count: 1, id: "minecraft:redstone" } }
 	]
+	use_title: true
 }

--- a/config/ftbquests/quests/reward_tables/7609CF2A167B45C8.snbt
+++ b/config/ftbquests/quests/reward_tables/7609CF2A167B45C8.snbt
@@ -8,4 +8,5 @@
 		{ count: 3, item: { count: 1, id: "theurgy:alchemical_salt_plant" } }
 		{ count: 2, item: { count: 1, id: "theurgy:alchemical_salt_creature" } }
 	]
+	use_title: true
 }

--- a/config/ftbquests/quests/reward_tables/epic.snbt
+++ b/config/ftbquests/quests/reward_tables/epic.snbt
@@ -5,7 +5,14 @@
 	rewards: [
 		{ item: { count: 1, id: "powah:thermo_generator_spirited" } }
 		{ item: { count: 1, id: "mekanism:elite_energy_cube" } }
-		{ item: { count: 1, id: "functionalstorage:netherite_upgrade" }, weight: 2.0f }
+		{
+			item: {
+				count: 1
+				id: "functionalstorage:netherite_upgrade"
+			}
+			random_bonus: 1
+			weight: 2.0f
+		}
 		{
 			item: {
 				count: 1
@@ -17,7 +24,7 @@
 		{ item: { count: 1, id: "mekanism:ultimate_tier_installer" } }
 		{ item: { count: 1, id: "ironfurnaces:netherite_furnace" } }
 		{ item: { count: 1, id: "mekanism:quantum_entangloporter" } }
-		{ type: "xp_levels", xp_levels: 50 }
+		{ type: "xp_levels", xp_levels: 30 }
 	]
 	use_title: true
 }

--- a/config/ftbquests/quests/reward_tables/pnc_advanced_rewards.snbt
+++ b/config/ftbquests/quests/reward_tables/pnc_advanced_rewards.snbt
@@ -47,4 +47,5 @@
 		{ item: { count: 1, id: "pneumaticcraft:jet_boots_upgrade_1" } }
 		{ item: { count: 1, id: "pneumaticcraft:jet_boots_upgrade_2" }, weight: 0.5f }
 	]
+	use_title: true
 }

--- a/config/ftbquests/quests/reward_tables/pnc_basic_rewards.snbt
+++ b/config/ftbquests/quests/reward_tables/pnc_basic_rewards.snbt
@@ -125,4 +125,5 @@
 		}
 		{ item: { count: 1, id: "pneumaticcraft:manual_compressor" }, weight: 1.5f }
 	]
+	use_title: true
 }

--- a/config/ftbquests/quests/reward_tables/pnc_pcb_rewards.snbt
+++ b/config/ftbquests/quests/reward_tables/pnc_pcb_rewards.snbt
@@ -22,4 +22,5 @@
 			random_bonus: 4
 		}
 	]
+	use_title: true
 }

--- a/config/ftbquests/quests/reward_tables/pnc_plastic_tier.snbt
+++ b/config/ftbquests/quests/reward_tables/pnc_plastic_tier.snbt
@@ -178,4 +178,5 @@
 		{ item: { count: 1, id: "pneumaticcraft:pcb_blueprint" }, weight: 0.5f }
 		{ item: { count: 1, id: "pneumaticcraft:solar_wafer" } }
 	]
+	use_title: true
 }


### PR DESCRIPTION
Lots of work to the Productive Trees quest chapter, adds subtitles for almost every quest and makes a mini tree next to the main one for saplings found in chests or bred from them.
Adds quests for the Stripper and Woodcutter.
Fixes some Smart Filters names.
Adds subtitles for Food and Farming Quests,
Reward Fixes
Makes Reward Tables show their names

-(Toblerone0508)