### PR TITLE
MA Essence Recipes

### DIFF
--- a/kubejs/server_scripts/mods/MysticalAgriculture/Recipes.js
+++ b/kubejs/server_scripts/mods/MysticalAgriculture/Recipes.js
@@ -2,25 +2,52 @@
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
 
 ServerEvents.recipes(allthemods => {
-    allthemods.shaped('8x ae2:silicon', ['   ', 'SSS', '   '], {
-        S: 'mysticalagriculture:silicon_essence'
-    })
-})
+allthemods.shaped('8x ae2:silicon', ['   ', 'SSS', '   '], {
+    S: 'mysticalagriculture:silicon_essence'
+}).id('allthemods:ae2/silicon')
 
-ServerEvents.recipes(allthemods => {
-    allthemods.shaped('kubejs:magical_soil', ['ABC', 'DEF', 'GHI'], {
-        A: 'mysticalagradditions:insanium_block',
-        B: 'allthecompressed:nether_star_block_2x',
-        C: 'allthecompressed:dirt_3x',
-        D: 'mysticalagriculture:awakened_supremium_growth_accelerator',
-        E: 'mysticalagradditions:insanium_farmland',
-        F: 'minecraft:dragon_head',
-        G: 'allthemodium:piglich_heart',
-        H: 'allthecompressed:ender_pearl_block_3x',
-        I: 'productivetrees:moonlight_magic_crepe_myrtle_sapling'
-    })
-})
+allthemods.shaped('kubejs:magical_soil', ['ABC', 'DEF', 'GHI'], {
+    A: 'mysticalagradditions:insanium_block',
+    B: 'allthecompressed:nether_star_block_2x',
+    C: 'allthecompressed:dirt_3x',
+    D: 'mysticalagriculture:awakened_supremium_growth_accelerator',
+    E: 'mysticalagradditions:insanium_farmland',
+    F: 'minecraft:dragon_head',
+    G: 'allthemodium:piglich_heart',
+    H: 'allthecompressed:ender_pearl_block_3x',
+    I: 'productivetrees:moonlight_magic_crepe_myrtle_sapling'
+}).id('allthemods:kjs/magical_soil')
 
+// Warped Wart Blocks
+allthemods.shaped('8x minecraft:warped_wart_block', [' A ', 'A  ', 'AAA'], {
+    A: 'mysticalagriculture:nether_essence'
+}).id('allthemods:minecraft/warped_wart_block')
+
+// Shroomlights
+allthemods.shaped('6x minecraft:shroomlight', ['AGA', 'GAG', 'AGA'],{
+    A: 'mysticalagriculture:nether_essence',
+    G: 'mysticalagriculture:glowstone_essence'
+}).id('allthemods:minecraft/shroomlight')
+
+// Froglights
+allthemods.shaped('8x minecraft:ochre_froglight', ['NDG', 'GDN', 'NDG'],{
+    N: 'mysticalagriculture:nature_essence',
+    D: 'mysticalagriculture:dye_essence',
+    G: 'mysticalagriculture:glowstone_essence'
+}).id('allthemods:minecraft/ochre_froglight')
+
+allthemods.shaped('8x minecraft:pearlescent_froglight', ['DDD', 'GNG', 'NGN'],{
+    N: 'mysticalagriculture:nature_essence',
+    D: 'mysticalagriculture:dye_essence',
+    G: 'mysticalagriculture:glowstone_essence'
+}).id('allthemods:minecraft/pearlescent_froglight')
+
+allthemods.shaped('8x minecraft:verdant_froglight', ['NGD', 'GND', 'NGD'],{
+    N: 'mysticalagriculture:nature_essence',
+    D: 'mysticalagriculture:dye_essence',
+    G: 'mysticalagriculture:glowstone_essence'
+}).id('allthemods:minecraft/verdant_froglight')
+})
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.


### PR DESCRIPTION
Adds essence recipe for  `Shroomlights`.
Adds essence recipe for `Warped Wart Blocks`.
Adds essence recipes for the 3 `Froglight` blocks.
Adds a new recipe ID for Magical Soil and Silicon.
Edits a few indents slightly to save a bit of wasted space.

All recipes work in game.