### PR TITLE
Redo the sawing unification

### DIFF
--- a/kubejs/server_scripts/Tweaks/tags.js
+++ b/kubejs/server_scripts/Tweaks/tags.js
@@ -12,6 +12,33 @@ ServerEvents.tags('item', allthemods => {
   //Extreme Reactors
   allthemods.add('c:ingots/yellorium', 'alltheores:uranium_ingot' )
   allthemods.add('c:storage_blocks/yellorium', 'alltheores:uranium_block' )
+
+  //regions_unexplored
+  allthemods.add('regions_unexplored:magnolia_logs', [
+    'regions_unexplored:magnolia_log',
+    'regions_unexplored:stripped_magnolia_log',
+    'regions_unexplored:magnolia_wood',
+    'regions_unexplored:stripped_magnolia_wood',
+  ])
+
+  //allthemodium
+  allthemods.add('allthemodium:ancient_logs', [
+    'allthemodium:ancient_log_0',
+    'allthemodium:ancient_log_1',
+    'allthemodium:ancient_log_2',
+    'allthemodium:stripped_ancient_log'
+  ])
+  allthemods.add('allthemodium:soul_logs', [
+    'allthemodium:soul_log',
+    'allthemodium:soul_log_0',
+    'allthemodium:soul_log_1',
+    'allthemodium:soul_log_2',
+    'allthemodium:stripped_soul_log'
+  ])
+  allthemods.add('allthemodium:demonic_logs', [
+    'allthemodium:demonic_log',
+    'allthemodium:stripped_demonic_log',
+  ])
 })
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 9.
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.

--- a/kubejs/server_scripts/Tweaks/tags.js
+++ b/kubejs/server_scripts/Tweaks/tags.js
@@ -13,32 +13,6 @@ ServerEvents.tags('item', allthemods => {
   allthemods.add('c:ingots/yellorium', 'alltheores:uranium_ingot' )
   allthemods.add('c:storage_blocks/yellorium', 'alltheores:uranium_block' )
 
-  //regions_unexplored
-  allthemods.add('regions_unexplored:magnolia_logs', [
-    'regions_unexplored:magnolia_log',
-    'regions_unexplored:stripped_magnolia_log',
-    'regions_unexplored:magnolia_wood',
-    'regions_unexplored:stripped_magnolia_wood',
-  ])
-
-  //allthemodium
-  allthemods.add('allthemodium:ancient_logs', [
-    'allthemodium:ancient_log_0',
-    'allthemodium:ancient_log_1',
-    'allthemodium:ancient_log_2',
-    'allthemodium:stripped_ancient_log'
-  ])
-  allthemods.add('allthemodium:soul_logs', [
-    'allthemodium:soul_log',
-    'allthemodium:soul_log_0',
-    'allthemodium:soul_log_1',
-    'allthemodium:soul_log_2',
-    'allthemodium:stripped_soul_log'
-  ])
-  allthemods.add('allthemodium:demonic_logs', [
-    'allthemodium:demonic_log',
-    'allthemodium:stripped_demonic_log',
-  ])
 })
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 9.
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.

--- a/kubejs/server_scripts/Unification/sawing.js
+++ b/kubejs/server_scripts/Unification/sawing.js
@@ -1,6 +1,35 @@
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
 
+ServerEvents.tags('item', allthemods => {
+    //regions_unexplored
+    allthemods.add('regions_unexplored:magnolia_logs', [
+        'regions_unexplored:magnolia_log',
+        'regions_unexplored:stripped_magnolia_log',
+        'regions_unexplored:magnolia_wood',
+        'regions_unexplored:stripped_magnolia_wood',
+    ])
+
+    //allthemodium
+    allthemods.add('allthemodium:ancient_logs', [
+        'allthemodium:ancient_log_0',
+        'allthemodium:ancient_log_1',
+        'allthemodium:ancient_log_2',
+        'allthemodium:stripped_ancient_log'
+    ])
+    allthemods.add('allthemodium:soul_logs', [
+        'allthemodium:soul_log',
+        'allthemodium:soul_log_0',
+        'allthemodium:soul_log_1',
+        'allthemodium:soul_log_2',
+        'allthemodium:stripped_soul_log'
+    ])
+    allthemods.add('allthemodium:demonic_logs', [
+        'allthemodium:demonic_log',
+        'allthemodium:stripped_demonic_log',
+    ])
+})
+
 ServerEvents.recipes(allthemods => {
     function mekSawing(output, input, extraOutput, id) {
         let inputObject = {

--- a/kubejs/server_scripts/Unification/sawing.js
+++ b/kubejs/server_scripts/Unification/sawing.js
@@ -1,0 +1,90 @@
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
+
+ServerEvents.recipes(allthemods => {
+    function mekSawing(output, input, extraOutput, id) {
+        let inputObject = {
+            "count": input.count || 1
+        };
+
+        if (input.item) {
+            inputObject["item"] = input.item;
+        } else if (input.tag) {
+            inputObject["tag"] = input.tag;
+        }
+
+        let recipe = {
+            "type": "mekanism:sawing",
+            "input": inputObject,
+            "main_output": {
+                "count": output.count || 1,
+                "id": output.item
+            },
+            "secondary_chance": extraOutput.chance,
+            "secondary_output": {
+                "count": extraOutput.count,
+                "id": extraOutput.item
+            }
+        };
+
+        allthemods.custom(recipe).id(`allthemods:mekanism/sawing/${id}`);
+    }
+
+    function prodSawing(log, planks, secondary, id) {
+        allthemods.custom({
+            "type": "productivetrees:sawmill",
+            "log": {
+                "tag": log.tag
+            },
+            "planks": {
+                "count": planks.count || 6,
+                "id": planks.item
+            },
+            "secondary": {
+                "count": secondary.count || 2,
+                "id": secondary.item
+            }
+        }).id(`allthemods:productivetrees/sawing/${id}`);
+    }
+
+    let logs  = Ingredient.of('#minecraft:logs').stacks.toArray().map(item => String(item.getId().split(' ').pop()));
+    const logTypes = ['log.*', 'stem.*'];
+    const logReg = new RegExp(`(_(?:${logTypes.join('|')})(?!.*_(?:${logTypes.join('|')})).*?)$`);
+
+    logs.forEach(log => {
+        mekSawing(
+            {item: log.replace(logReg, '_planks'), count: 6},
+            {tag: log.replace(logReg, '_logs'), count: 1},
+            {chance: 0.25, item: 'mekanism:sawdust', count: 1},
+            log.split(':')[0] + '/' + log.split(':')[1] + '_to_planks'
+        );
+    });
+
+    //ars wants to be special
+    mekSawing(
+        {item: 'ars_nouveau:archwood_planks', count: 6},
+        {tag: 'c:logs/archwood', count: 1},
+        {chance: 0.25, item: 'mekanism:sawdust', count: 1},
+        'ars_nouveau/archwood_log_to_planks'
+    );
+
+    logs.forEach(log => {
+        prodSawing(
+            {tag: log.replace(logReg, '_logs')},
+            {item: log.replace(logReg, '_planks'), count: 6},
+            {item: 'productivetrees:sawdust', count: 2},
+            log.split(':')[0] + '/' + log.split(':')[1] + '_to_planks'
+        )
+    })
+
+    //ars yet again
+    prodSawing(
+        {tag: 'ars_nouveau:archwood_planks'},
+        {item: 'c:logs/archwood', count: 6},
+        {item: 'productivetrees:sawdust', count: 2},
+        'ars_nouveau/archwood_log_to_planks'
+    )
+})
+
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.

--- a/kubejs/server_scripts/mods/Mekanism/Recipes.js
+++ b/kubejs/server_scripts/mods/Mekanism/Recipes.js
@@ -84,25 +84,6 @@ ServerEvents.recipes(allthemods => {
     allthemods.custom(recipe).id(`allthemods:mekanism/sawing/${id}`);
   }
 
-  //list of all the mods to add recipes for
-  const mods = ['croptopia', 'evilcraft', 'eternal_starlight', 'allthemodium',
-    'integrateddynamics', 'ars_nouveau', 'regions_unexplored', 'productivetrees']
-
-  mods.forEach(mod => {
-    //gets all items from the mod with the #minecraft:logs tag
-    let logs = Ingredient.of(`#minecraft:logs`).stacks.toArray().filter(item => item.getId().startsWith(mod + ':')) .map(item => item.getId());
-
-    if(logs.length > 0) {
-      logs.forEach(log => {
-        mekSawing(
-            {item: log.toString().replace('log', 'planks'), count: 6}, //gets the name of the log and replaces the 'log' with 'planks' to generate an output
-            {tag: log + 's', count: 1}, //adds an 's' to the log name to get the tag
-            {chance: 0.25, item: 'mekanism:sawdust', count: 1},
-            mod + '/' + log.toString().split(':').pop() + '_to_planks'); //generates the id by adding the mod name in front of the log and adding a 'to planks' at the end
-      })
-    }
-  });
-
   [['gravel','cobblestone'], ['sand','gravel']].forEach(recipe => {
     for (let count = 1; count < 10; count++) {
       mekCrushing(


### PR DESCRIPTION
Redoes the sawing recipes added in #366 again...
- fixes broken some broken log tags
- fixes broken recipes for `mekanism:sawing`
- adds recipes for `productivetrees:sawing`
- adds a way too complicated way of generating all those recipes