### PR TITLE
Mek reactors Advanced Power Storage english text fix. 

### DIFF
--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -1645,7 +1645,7 @@
 		""
 		"We're going to create a customizable multiblock used to store large amounts of power, but first, we need to make some Lithium Dust!"
 		""
-		"You should have some Brine being made from a previous quest using the &aThermal Evaporation Plants&r. Run the &eBrine&r through another &aThermal Evaporation Plant&r to get Lithium, then through a &9Chemical Crystallizer&r to get &aLithium Dust&r."
+		"You should have some Brine being made from a previous quest using the &aThermal Evaporation Plants&r. Run the &eBrine&r through another &aThermal Evaporation Plant&r to get Liquid Lithium, then use a &9Rotary Condensentrator&r to get Lithium which you can run through a &9Chemical Crystallizer&r to get &aLithium Dust&r."
 	]
 	quest.0FF852DE33E41C90.title: "Advanced Power Storage"
 	quest.0FFF2BEE5D8EBE12.title: "Reactor (Niotic)"


### PR DESCRIPTION
Advanced Power Storage quest in Mekanism reactor questline, says you get Lithium from the Thermal Evaporation Plant but you actually get Liquid Lithium. 

This fix updates the quest text hinting that you should use a Rotary Condensentrator to get the lithium itself.

Fixes #513 