### PR TITLE
Removes Duplicate Paper Recipe

### DIFF
--- a/kubejs/server_scripts/Tweaks/recipes.js
+++ b/kubejs/server_scripts/Tweaks/recipes.js
@@ -28,7 +28,10 @@ ServerEvents.recipes(allthemods => {
         }
     )
 
-    // makes recipes for concrete from concrete powder usingg water buckets
+    // Remove Duplicate Paper Recipe
+    allthemods.remove({ id: 'minecraft:paper' })
+
+    // Concrete from Concrete Powder using Water Buckets
     const colors = [
         'white', 'yellow', 'orange', 'red', 'pink', 'magenta', 'purple', 'light_blue', 'cyan', 'blue', 'lime', 'green', 'brown', 'light_gray', 'gray', 'black'
     ];


### PR DESCRIPTION
Utilitarian adds a shapeless recipe for paper which covers the vanilla recipe, so this isn't needed.