### PR TITLE
Disable Spark's default background profiler

### DIFF
--- a/config/spark/config.json
+++ b/config/spark/config.json
@@ -1,0 +1,4 @@
+{
+  "_header": "spark configuration file - https://spark.lucko.me/docs/Configuration",
+  "backgroundProfiler": false
+}


### PR DESCRIPTION
There are some instances that it is causing lag, **specially** on Windows (majority of players)