### PR TITLE
Remove redstone dupe

### DIFF
--- a/kubejs/server_scripts/Tweaks/recipes.js
+++ b/kubejs/server_scripts/Tweaks/recipes.js
@@ -46,6 +46,9 @@ ServerEvents.recipes(allthemods => {
             }
         )
     });
+    
+    // Remove The Raw Redstone Block Recipe As It Allows A Redstone Dupe
+    allthemods.remove({id: 'regions_unexplored:raw_redstone_block'});
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 9.


### PR DESCRIPTION
Remove the raw redstone block recipe because it allows for a redstone dupe through putting it in an enrichment chamber, squeezer, mechanical squeezer, crusher or a macerator.
This has also been reported in issue #190 