### PR TITLE
made all the AllRightsReserved quests optional

### DIFF
--- a/config/ftbquests/quests/chapters/apotheosis_2.snbt
+++ b/config/ftbquests/quests/chapters/apotheosis_2.snbt
@@ -225,6 +225,7 @@
 		{
 			id: "2FE4B7B70D90A455"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/applied_energistics_2.snbt
+++ b/config/ftbquests/quests/chapters/applied_energistics_2.snbt
@@ -1937,6 +1937,7 @@
 		{
 			id: "5034A9137E0F3D3D"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/ars_nouveau.snbt
+++ b/config/ftbquests/quests/chapters/ars_nouveau.snbt
@@ -2745,6 +2745,7 @@
 		{
 			id: "36CDA39C23D3AA2B"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/artifacts.snbt
+++ b/config/ftbquests/quests/chapters/artifacts.snbt
@@ -955,6 +955,7 @@
 		{
 			id: "5FD6A738754F6013"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/basic_logistics.snbt
+++ b/config/ftbquests/quests/chapters/basic_logistics.snbt
@@ -1017,6 +1017,7 @@
 		{
 			id: "230582AAFC0A1632"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/bounty_board.snbt
+++ b/config/ftbquests/quests/chapters/bounty_board.snbt
@@ -1240,6 +1240,7 @@
 		{
 			id: "08B60D8A25008CCC"
 			invisible: true
+			optional: true
 			tasks: [
 				{
 					id: "00CBF98DE4E9CC90"

--- a/config/ftbquests/quests/chapters/building_tips.snbt
+++ b/config/ftbquests/quests/chapters/building_tips.snbt
@@ -1965,6 +1965,7 @@
 		{
 			id: "01516BC726013B7C"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/bumblezone.snbt
+++ b/config/ftbquests/quests/chapters/bumblezone.snbt
@@ -2917,6 +2917,7 @@
 		{
 			id: "565EBD340595EAC4"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/elmystical_agriculturerr.snbt
+++ b/config/ftbquests/quests/chapters/elmystical_agriculturerr.snbt
@@ -4704,6 +4704,7 @@
 		{
 			id: "23C36E4B5DCEBFDD"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/extreme_reactors.snbt
+++ b/config/ftbquests/quests/chapters/extreme_reactors.snbt
@@ -1069,6 +1069,7 @@
 		{
 			id: "19DE6EBEA8219E8E"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/food_and_farming.snbt
+++ b/config/ftbquests/quests/chapters/food_and_farming.snbt
@@ -927,6 +927,7 @@
 		{
 			id: "55C4824DAD905512"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/generators.snbt
+++ b/config/ftbquests/quests/chapters/generators.snbt
@@ -1591,6 +1591,7 @@
 		{
 			id: "39605F1FEB1A5A1C"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/hostile_neural_networks.snbt
+++ b/config/ftbquests/quests/chapters/hostile_neural_networks.snbt
@@ -1376,6 +1376,7 @@
 		{
 			id: "12AE2856444996F6"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/industrial_foregoing.snbt
+++ b/config/ftbquests/quests/chapters/industrial_foregoing.snbt
@@ -1792,6 +1792,7 @@
 		{
 			id: "2F69010E1FA2787D"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/iron_spells_and_spellbooks.snbt
+++ b/config/ftbquests/quests/chapters/iron_spells_and_spellbooks.snbt
@@ -1896,6 +1896,7 @@
 		{
 			id: "2D84DA544D7A24FA"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/justdirethings.snbt
+++ b/config/ftbquests/quests/chapters/justdirethings.snbt
@@ -2991,6 +2991,7 @@
 		{
 			id: "441F37A95AB66E6B"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/mainquestline_part_1.snbt
+++ b/config/ftbquests/quests/chapters/mainquestline_part_1.snbt
@@ -1053,6 +1053,7 @@
 		{
 			id: "110BF3A2BE85F911"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/mekanism.snbt
+++ b/config/ftbquests/quests/chapters/mekanism.snbt
@@ -2608,6 +2608,7 @@
 		{
 			id: "4A1C8125896F7F1A"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/mekanism_reactors.snbt
+++ b/config/ftbquests/quests/chapters/mekanism_reactors.snbt
@@ -1475,6 +1475,7 @@
 		{
 			id: "066F78936C8F943B"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/modular_router.snbt
+++ b/config/ftbquests/quests/chapters/modular_router.snbt
@@ -1150,6 +1150,7 @@
 		{
 			id: "2BB5769119BA2472"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/occultism.snbt
+++ b/config/ftbquests/quests/chapters/occultism.snbt
@@ -948,6 +948,7 @@
 		{
 			id: "6CCDEEDA2C99DA66"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/pneumaticcraft.snbt
+++ b/config/ftbquests/quests/chapters/pneumaticcraft.snbt
@@ -3277,6 +3277,7 @@
 		{
 			id: "325483DEB0C602F8"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/powah.snbt
+++ b/config/ftbquests/quests/chapters/powah.snbt
@@ -3242,6 +3242,7 @@
 		{
 			id: "08245411AFDB63DB"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/productive_bees.snbt
+++ b/config/ftbquests/quests/chapters/productive_bees.snbt
@@ -3144,6 +3144,7 @@
 		{
 			id: "0A11725B41AB45F6"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/productive_trees.snbt
+++ b/config/ftbquests/quests/chapters/productive_trees.snbt
@@ -4102,6 +4102,7 @@
 		{
 			id: "25D8BE0280B6E7F1"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/pylons.snbt
+++ b/config/ftbquests/quests/chapters/pylons.snbt
@@ -359,6 +359,7 @@
 		{
 			id: "5E02AE661945306C"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/railcraft.snbt
+++ b/config/ftbquests/quests/chapters/railcraft.snbt
@@ -1438,6 +1438,7 @@
 		{
 			id: "5F458D79D43D8842"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/relics.snbt
+++ b/config/ftbquests/quests/chapters/relics.snbt
@@ -889,6 +889,7 @@
 		{
 			id: "3E99F4CD379DE9D7"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/theurgy.snbt
+++ b/config/ftbquests/quests/chapters/theurgy.snbt
@@ -1108,6 +1108,7 @@
 		{
 			id: "41ABC09C798CA8BE"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/tips_and_tricks.snbt
+++ b/config/ftbquests/quests/chapters/tips_and_tricks.snbt
@@ -273,6 +273,7 @@
 		{
 			id: "0152938EE5651409"
 			invisible: true
+			optional: true
 			shape: "circle"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/welcome.snbt
+++ b/config/ftbquests/quests/chapters/welcome.snbt
@@ -166,6 +166,7 @@
 		{
 			id: "49EDAA2F57D3BF1D"
 			invisible: true
+			optional: true
 			tasks: [
 				{
 					id: "2C816285392535F0"


### PR DESCRIPTION
the AllRightsReserved quests prevent chapter completion for players
those that would go into the source will see it anyways, and regular players shouldn't be expected to enable edit mode just to complete the chapters