### PR TITLE
Honeycomb compression fix

### DIFF
--- a/kubejs/server_scripts/mods/minecraft/tags.js
+++ b/kubejs/server_scripts/mods/minecraft/tags.js
@@ -5,6 +5,8 @@ ServerEvents.tags('item', event => {
     event.add('functionalstorage:ignore_crafting_check', 'minecraft:snowball')
     event.add('functionalstorage:ignore_crafting_check', 'minecraft:string')
     event.add('megacells:compression_overrides', 'minecraft:string')
+    event.add('megacells:compression_overrides', 'minecraft:honeycomb')
+    event.add('functionalstorage:ignore_crafting_check', 'minecraft:honeycomb')
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.

--- a/kubejs/server_scripts/mods/minecraft/tags.js
+++ b/kubejs/server_scripts/mods/minecraft/tags.js
@@ -7,6 +7,7 @@ ServerEvents.tags('item', event => {
     event.add('megacells:compression_overrides', 'minecraft:string')
     event.add('megacells:compression_overrides', 'minecraft:honeycomb')
     event.add('functionalstorage:ignore_crafting_check', 'minecraft:honeycomb')
+    event.add('functionalstorage:ignore_crafting_check', 'minecraft:magma_cream')
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.


### PR DESCRIPTION
Add honeycomb tags back to fix them no longer working in compacting drawers as well as a discepency for megacells as well