### PR TITLE
Silent Gear Quests & Quest Work

### DIFF
--- a/config/ftbquests/quests/chapters/allthemodium.snbt
+++ b/config/ftbquests/quests/chapters/allthemodium.snbt
@@ -13,80 +13,96 @@
 			image: "atm:textures/questpics/allthemodium/all_allthemodium.png"
 			rotation: 0.0d
 			width: 26.666666666666668d
-			x: 3.5d
-			y: -4.0d
+			x: 10.5d
+			y: -5.0d
 		}
 		{
 			height: 1.5d
 			image: "allthemodium:item/allthemodium_upgrade_smithing_template"
 			rotation: 0.0d
 			width: 1.5d
-			x: -3.5d
-			y: -1.5d
+			x: 3.5d
+			y: -2.5d
 		}
 		{
 			height: 1.5d
 			image: "allthemodium:item/vibranium_upgrade_smithing_template"
 			rotation: 0.0d
 			width: 1.5d
-			x: 2.5d
-			y: -1.5d
+			x: 9.5d
+			y: -2.5d
 		}
 		{
 			height: 1.5d
 			image: "allthemodium:item/unobtainium_upgrade_smithing_template"
 			rotation: 0.0d
 			width: 1.5d
-			x: 5.5d
-			y: -1.5d
+			x: 12.5d
+			y: -2.5d
 		}
 		{
 			height: 2.0d
 			image: "atm:textures/questpics/allthemodium/all_1.png"
 			rotation: 0.0d
 			width: 2.0d
-			x: -3.5d
-			y: 4.0d
+			x: 3.5d
+			y: 3.0d
 		}
 		{
 			height: 2.0d
 			image: "atm:textures/questpics/allthemodium/all_2.png"
 			rotation: 0.0d
 			width: 2.0842105263157893d
-			x: 2.5d
-			y: 4.0d
+			x: 9.5d
+			y: 3.0d
 		}
 		{
 			height: 2.0d
 			image: "atm:textures/questpics/allthemodium/all_3.png"
 			rotation: 0.0d
 			width: 1.9365079365079365d
-			x: 5.5d
-			y: 4.0d
+			x: 12.5d
+			y: 3.0d
 		}
 		{
 			height: 3.0d
 			image: "atm:textures/questpics/allthemodium/all_armor_all.png"
 			rotation: 0.0d
 			width: 1.7203125000000001d
-			x: -1.5d
-			y: 5.5d
+			x: 5.5d
+			y: 4.5d
 		}
 		{
 			height: 3.0d
 			image: "atm:textures/questpics/allthemodium/all_armor_vib.png"
 			rotation: 0.0d
 			width: 2.08d
-			x: 4.0d
-			y: 5.5d
+			x: 11.0d
+			y: 4.5d
 		}
 		{
 			height: 3.0d
 			image: "atm:textures/questpics/allthemodium/all_armor_uno.png"
 			rotation: 0.0d
 			width: 1.5406626506024095d
-			x: 7.0d
-			y: 5.5d
+			x: 14.0d
+			y: 4.5d
+		}
+		{
+			height: 0.3d
+			image: "allthetweaks:item/atm_star"
+			rotation: 0.0d
+			width: 0.3d
+			x: 21.0d
+			y: -2.5d
+		}
+		{
+			height: 0.3d
+			image: "allthetweaks:item/atm_star"
+			rotation: 0.0d
+			width: 0.3d
+			x: 15.5d
+			y: -0.5999999999999996d
 		}
 	]
 	order_index: 1
@@ -118,8 +134,8 @@
 				item: { count: 1, id: "minecraft:netherite_ingot" }
 				type: "item"
 			}]
-			x: -7.0d
-			y: 1.0d
+			x: 0.0d
+			y: 0.0d
 		}
 		{
 			dependencies: ["201EE3566D4D3123"]
@@ -140,8 +156,8 @@
 				item: { count: 1, id: "allthemodium:teleport_pad" }
 				type: "item"
 			}]
-			x: -1.5d
-			y: 1.0d
+			x: 5.5d
+			y: 0.0d
 		}
 		{
 			dependencies: ["2C4299D33D419AA0"]
@@ -170,8 +186,8 @@
 				id: "681CB7DF06F2F506"
 				type: "dimension"
 			}]
-			x: 1.0d
-			y: -2.5d
+			x: 8.0d
+			y: -3.5d
 		}
 		{
 			dependencies: ["0CC0632E8276C787"]
@@ -198,8 +214,8 @@
 				id: "0F9FCFCEE795FD41"
 				type: "dimension"
 			}]
-			x: 3.5d
-			y: 1.0d
+			x: 10.5d
+			y: 0.0d
 		}
 		{
 			dependencies: ["2EDE91023F7924FB"]
@@ -221,8 +237,8 @@
 				id: "6514595CBD4DE6C6"
 				type: "dimension"
 			}]
-			x: 1.0d
-			y: 4.5d
+			x: 8.0d
+			y: 3.5d
 		}
 		{
 			dependencies: ["4B2146C9527C54E7"]
@@ -245,8 +261,8 @@
 				structure: "minecraft:ancient_city"
 				type: "structure"
 			}]
-			x: -5.0d
-			y: 1.0d
+			x: 2.0d
+			y: 0.0d
 		}
 		{
 			dependencies: ["111E4ACF7D570EE8"]
@@ -273,8 +289,8 @@
 				item: { count: 1, id: "allthemodium:allthemodium_ingot" }
 				type: "item"
 			}]
-			x: -3.5d
-			y: 2.0d
+			x: 3.5d
+			y: 1.0d
 		}
 		{
 			dependencies: ["111E4ACF7D570EE8"]
@@ -294,8 +310,8 @@
 				item: { count: 1, id: "allthemodium:allthemodium_upgrade_smithing_template" }
 				type: "item"
 			}]
-			x: -3.5d
-			y: 0.0d
+			x: 3.5d
+			y: -1.0d
 		}
 		{
 			dependencies: ["0CC0632E8276C787"]
@@ -315,8 +331,8 @@
 				item: { count: 1, id: "allthemodium:vibranium_upgrade_smithing_template" }
 				type: "item"
 			}]
-			x: 2.5d
-			y: 0.0d
+			x: 9.5d
+			y: -1.0d
 		}
 		{
 			dependencies: [
@@ -338,8 +354,8 @@
 				item: { components: { "ftbfiltersystem:filter": "or(item(allthemodium:allthemodium_helmet)item(allthemodium:allthemodium_chestplate)item(allthemodium:allthemodium_leggings)item(allthemodium:allthemodium_boots))" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 				type: "item"
 			}]
-			x: -1.5d
-			y: 2.5d
+			x: 5.5d
+			y: 1.5d
 		}
 		{
 			dependencies: [
@@ -361,8 +377,8 @@
 				item: { components: { "ftbfiltersystem:filter": "or(item(allthearcanistgear:allthemodium_hat)item(allthearcanistgear:allthemodium_robes)item(allthearcanistgear:allthemodium_leggings)item(allthearcanistgear:allthemodium_boots))" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 				type: "item"
 			}]
-			x: -2.0d
-			y: 3.0d
+			x: 5.0d
+			y: 2.0d
 		}
 		{
 			dependencies: [
@@ -384,8 +400,8 @@
 				item: { components: { "ftbfiltersystem:filter": "or(item(allthewizardgear:allthemodium_mage_helmet)item(allthewizardgear:allthemodium_mage_chestplate)item(allthewizardgear:allthemodium_mage_leggings)item(allthewizardgear:allthemodium_mage_boots))" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 				type: "item"
 			}]
-			x: -1.0d
-			y: 3.0d
+			x: 6.0d
+			y: 2.0d
 		}
 		{
 			dependencies: [
@@ -407,8 +423,8 @@
 				item: { components: { "ftbfiltersystem:filter": "or(item(allthemodium:allthemodium_sword)item(allthemodium:allthemodium_pickaxe)item(allthemodium:allthemodium_axe)item(allthemodium:allthemodium_shovel)item(allthemodium:allthemodium_hoe))" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 				type: "item"
 			}]
-			x: -1.5d
-			y: -1.5d
+			x: 5.5d
+			y: -2.5d
 		}
 		{
 			dependencies: [
@@ -425,8 +441,8 @@
 				item: { count: 1, id: "allthemodium:allthemodium_bow" }
 				type: "item"
 			}]
-			x: -1.0d
-			y: -1.0d
+			x: 6.0d
+			y: -2.0d
 		}
 		{
 			dependencies: [
@@ -448,8 +464,8 @@
 				item: { count: 1, id: "allthemodium:allthemodium_mace" }
 				type: "item"
 			}]
-			x: -1.5d
-			y: -0.5d
+			x: 5.5d
+			y: -1.5d
 		}
 		{
 			dependencies: [
@@ -471,8 +487,8 @@
 				item: { components: { "ftbfiltersystem:filter": "or(item(allthemodium:unobtainium_helmet)item(allthemodium:unobtainium_chestplate)item(allthemodium:unobtainium_leggings)item(allthemodium:unobtainium_boots))" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 				type: "item"
 			}]
-			x: 7.0d
-			y: 2.5d
+			x: 14.0d
+			y: 1.5d
 		}
 		{
 			dependencies: [
@@ -494,8 +510,8 @@
 				item: { components: { "ftbfiltersystem:filter": "or(item(allthearcanistgear:unobtainium_hat)item(allthearcanistgear:unobtainium_robes)item(allthearcanistgear:unobtainium_leggings)item(allthearcanistgear:unobtainium_boots))" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 				type: "item"
 			}]
-			x: 6.5d
-			y: 3.0d
+			x: 13.5d
+			y: 2.0d
 		}
 		{
 			dependencies: [
@@ -509,8 +525,8 @@
 				item: { components: { "irons_spellbooks:spell_container": { data: [ ], maxSpells: 13, mustEquip: 1b, spellWheel: 1b } }, count: 1, id: "allthewizardgear:allthemodium_spell_book" }
 				type: "item"
 			}]
-			x: -2.0d
-			y: -1.0d
+			x: 5.0d
+			y: -2.0d
 		}
 		{
 			dependencies: [
@@ -532,8 +548,8 @@
 				item: { components: { "ftbfiltersystem:filter": "or(item(allthewizardgear:unobtainium_mage_helmet)item(allthewizardgear:unobtainium_mage_chestplate)item(allthewizardgear:unobtainium_mage_leggings)item(allthewizardgear:unobtainium_mage_boots))" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 				type: "item"
 			}]
-			x: 7.5d
-			y: 3.0d
+			x: 14.5d
+			y: 2.0d
 		}
 		{
 			dependencies: [
@@ -547,8 +563,8 @@
 				item: { components: { "irons_spellbooks:spell_container": { data: [ ], maxSpells: 15, mustEquip: 1b, spellWheel: 1b } }, count: 1, id: "allthewizardgear:unobtainium_spell_book" }
 				type: "item"
 			}]
-			x: 6.5d
-			y: -1.0d
+			x: 13.5d
+			y: -2.0d
 		}
 		{
 			dependencies: [
@@ -570,8 +586,8 @@
 				item: { components: { "ftbfiltersystem:filter": "or(item(allthemodium:unobtainium_sword)item(allthemodium:unobtainium_pickaxe)item(allthemodium:unobtainium_axe)item(allthemodium:unobtainium_shovel)item(allthemodium:unobtainium_hoe))" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 				type: "item"
 			}]
-			x: 7.0d
-			y: -1.5d
+			x: 14.0d
+			y: -2.5d
 		}
 		{
 			dependencies: [
@@ -587,8 +603,8 @@
 				item: { count: 1, id: "allthemodium:unobtainium_crossbow" }
 				type: "item"
 			}]
-			x: 7.5d
-			y: -1.0d
+			x: 14.5d
+			y: -2.0d
 		}
 		{
 			dependencies: [
@@ -610,8 +626,8 @@
 				item: { count: 1, id: "allthemodium:unobtainium_mace" }
 				type: "item"
 			}]
-			x: 7.0d
-			y: -0.5d
+			x: 14.0d
+			y: -1.5d
 		}
 		{
 			dependencies: [
@@ -633,8 +649,8 @@
 				item: { components: { "ftbfiltersystem:filter": "or(item(allthemodium:vibranium_helmet)item(allthemodium:vibranium_chestplate)item(allthemodium:vibranium_leggings)item(allthemodium:vibranium_boots))" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 				type: "item"
 			}]
-			x: 4.0d
-			y: 2.5d
+			x: 11.0d
+			y: 1.5d
 		}
 		{
 			dependencies: [
@@ -656,8 +672,8 @@
 				item: { components: { "ftbfiltersystem:filter": "or(item(allthearcanistgear:vibranium_hat)item(allthearcanistgear:vibranium_robes)item(allthearcanistgear:vibranium_leggings)item(allthearcanistgear:vibranium_boots))" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 				type: "item"
 			}]
-			x: 3.5d
-			y: 3.0d
+			x: 10.5d
+			y: 2.0d
 		}
 		{
 			dependencies: [
@@ -679,8 +695,8 @@
 				item: { components: { "ftbfiltersystem:filter": "or(item(allthewizardgear:vibranium_mage_helmet)item(allthewizardgear:vibranium_mage_chestplate)item(allthewizardgear:vibranium_mage_leggings)item(allthewizardgear:vibranium_mage_boots))" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 				type: "item"
 			}]
-			x: 4.5d
-			y: 3.0d
+			x: 11.5d
+			y: 2.0d
 		}
 		{
 			dependencies: [
@@ -702,8 +718,8 @@
 				item: { components: { "ftbfiltersystem:filter": "or(item(allthemodium:vibranium_sword)item(allthemodium:vibranium_pickaxe)item(allthemodium:vibranium_axe)item(allthemodium:vibranium_shovel)item(allthemodium:vibranium_hoe))" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 				type: "item"
 			}]
-			x: 4.0d
-			y: -1.5d
+			x: 11.0d
+			y: -2.5d
 		}
 		{
 			dependencies: [
@@ -719,8 +735,8 @@
 				item: { count: 1, id: "allthemodium:vibranium_shield" }
 				type: "item"
 			}]
-			x: 4.5d
-			y: -1.0d
+			x: 11.5d
+			y: -2.0d
 		}
 		{
 			dependencies: [
@@ -742,8 +758,8 @@
 				item: { count: 1, id: "allthemodium:vibranium_mace" }
 				type: "item"
 			}]
-			x: 4.0d
-			y: -0.5d
+			x: 11.0d
+			y: -1.5d
 		}
 		{
 			dependencies: [
@@ -757,8 +773,8 @@
 				item: { components: { "irons_spellbooks:spell_container": { data: [ ], maxSpells: 14, mustEquip: 1b, spellWheel: 1b } }, count: 1, id: "allthewizardgear:vibranium_spell_book" }
 				type: "item"
 			}]
-			x: 3.5d
-			y: -1.0d
+			x: 10.5d
+			y: -2.0d
 		}
 		{
 			dependencies: ["07FDA46D83F8360D"]
@@ -785,8 +801,8 @@
 				id: "46B42667B6BC1A3C"
 				type: "dimension"
 			}]
-			x: 0.5d
-			y: 1.0d
+			x: 7.5d
+			y: 0.0d
 		}
 		{
 			dependencies: ["07FDA46D83F8360D"]
@@ -800,8 +816,8 @@
 				id: "00DDA48F9632A5C1"
 				type: "dimension"
 			}]
-			x: 1.0d
-			y: -1.0d
+			x: 8.0d
+			y: -2.0d
 		}
 		{
 			dependencies: ["07FDA46D83F8360D"]
@@ -828,8 +844,8 @@
 				id: "32447C5882610D6C"
 				type: "dimension"
 			}]
-			x: 1.0d
-			y: 3.0d
+			x: 8.0d
+			y: 2.0d
 		}
 		{
 			dependencies: ["0CC0632E8276C787"]
@@ -856,8 +872,8 @@
 				item: { count: 1, id: "allthemodium:vibranium_ingot" }
 				type: "item"
 			}]
-			x: 2.5d
-			y: 2.0d
+			x: 9.5d
+			y: 1.0d
 		}
 		{
 			dependencies: ["15FEA03A2CDBA33B"]
@@ -877,8 +893,8 @@
 				item: { count: 1, id: "allthemodium:unobtainium_upgrade_smithing_template" }
 				type: "item"
 			}]
-			x: 5.5d
-			y: 0.0d
+			x: 12.5d
+			y: -1.0d
 		}
 		{
 			dependencies: ["2EDE91023F7924FB"]
@@ -906,8 +922,8 @@
 				item: { count: 1, id: "allthemodium:unobtainium_ingot" }
 				type: "item"
 			}]
-			x: 5.5d
-			y: 2.0d
+			x: 12.5d
+			y: 1.0d
 		}
 		{
 			id: "762581CAE5F5DDC1"
@@ -926,8 +942,8 @@
 				item: { count: 1, id: "ars_nouveau:enchanting_apparatus" }
 				type: "item"
 			}]
-			x: 13.5d
-			y: -2.45d
+			x: 20.5d
+			y: -3.45d
 		}
 		{
 			id: "7B3613C01F0B1373"
@@ -946,8 +962,8 @@
 				item: { count: 1, id: "powah:energizing_orb" }
 				type: "item"
 			}]
-			x: 17.0d
-			y: 1.0d
+			x: 24.0d
+			y: 0.0d
 		}
 		{
 			id: "15DC6770B112EE69"
@@ -966,8 +982,8 @@
 				item: { count: 1, id: "industrialforegoing:dissolution_chamber" }
 				type: "item"
 			}]
-			x: 13.5d
-			y: 4.4d
+			x: 20.5d
+			y: 3.4000000000000004d
 		}
 		{
 			dependencies: [
@@ -1002,8 +1018,8 @@
 				item: { count: 1, id: "allthemodium:unobtainium_allthemodium_alloy_ingot" }
 				type: "item"
 			}]
-			x: 13.5d
-			y: -1.0d
+			x: 20.5d
+			y: -2.0d
 		}
 		{
 			dependencies: [
@@ -1038,8 +1054,8 @@
 				item: { count: 1, id: "allthemodium:unobtainium_vibranium_alloy_ingot" }
 				type: "item"
 			}]
-			x: 13.5d
-			y: 3.0d
+			x: 20.5d
+			y: 2.0d
 		}
 		{
 			dependencies: [
@@ -1074,8 +1090,8 @@
 				item: { count: 1, id: "allthemodium:vibranium_allthemodium_alloy_ingot" }
 				type: "item"
 			}]
-			x: 15.5d
-			y: 1.0d
+			x: 22.5d
+			y: 0.0d
 		}
 		{
 			dependencies: ["24934231538B6492"]
@@ -1096,8 +1112,8 @@
 				item: { count: 1, id: "allthemodium:piglich_heart" }
 				type: "item"
 			}]
-			x: 8.5d
-			y: 1.0d
+			x: 15.5d
+			y: 0.0d
 		}
 		{
 			dependencies: ["15FEA03A2CDBA33B"]
@@ -1120,8 +1136,8 @@
 				structure: "allthemodium:ancient_pyramid"
 				type: "structure"
 			}]
-			x: 7.0d
-			y: 1.0d
+			x: 14.0d
+			y: 0.0d
 		}
 		{
 			dependencies: [
@@ -1187,8 +1203,8 @@
 				item: { count: 1, id: "allthemodium:alloy_paxel" }
 				type: "item"
 			}]
-			x: 13.5d
-			y: 1.0d
+			x: 20.5d
+			y: 0.0d
 		}
 		{
 			dependencies: [
@@ -1227,8 +1243,8 @@
 				item: { count: 1, id: "allthemodium:alloy_axe" }
 				type: "item"
 			}]
-			x: 14.5d
-			y: 0.0d
+			x: 21.5d
+			y: -1.0d
 		}
 		{
 			dependencies: [
@@ -1267,8 +1283,8 @@
 				item: { count: 1, id: "allthemodium:alloy_shovel" }
 				type: "item"
 			}]
-			x: 14.5d
-			y: 2.0d
+			x: 21.5d
+			y: 1.0d
 		}
 		{
 			dependencies: [
@@ -1307,8 +1323,8 @@
 				item: { count: 1, id: "allthemodium:alloy_pick" }
 				type: "item"
 			}]
-			x: 12.5d
-			y: 2.0d
+			x: 19.5d
+			y: 1.0d
 		}
 		{
 			dependencies: [
@@ -1347,8 +1363,8 @@
 				item: { count: 1, id: "allthemodium:alloy_sword" }
 				type: "item"
 			}]
-			x: 12.5d
-			y: 0.0d
+			x: 19.5d
+			y: -1.0d
 		}
 		{
 			dependencies: [
@@ -1365,8 +1381,8 @@
 				item: { count: 1, id: "allthemodium:alloy_trident" }
 				type: "item"
 			}]
-			x: 18.0d
-			y: 1.0d
+			x: 25.0d
+			y: 0.0d
 		}
 		{
 			id: "552F0B9B00F4F914"
@@ -1383,8 +1399,8 @@
 					type: "checkmark"
 				}
 			]
-			x: -7.0d
-			y: -0.5d
+			x: 0.0d
+			y: -1.5d
 		}
 		{
 			dependencies: ["7CC96CE9901F25BB"]
@@ -1404,8 +1420,8 @@
 				item: { count: 1, id: "forbidden_arcanus:eternal_stella" }
 				type: "item"
 			}]
-			x: 11.5d
-			y: 1.0d
+			x: 18.5d
+			y: 0.0d
 		}
 		{
 			id: "7CC96CE9901F25BB"
@@ -1454,8 +1470,8 @@
 				item: { count: 1, id: "forbidden_arcanus:hephaestus_forge_tier_1" }
 				type: "item"
 			}]
-			x: 10.0d
-			y: 1.0d
+			x: 17.0d
+			y: 0.0d
 		}
 	]
 }

--- a/config/ftbquests/quests/chapters/artifacts.snbt
+++ b/config/ftbquests/quests/chapters/artifacts.snbt
@@ -117,7 +117,6 @@
 	quest_links: [ ]
 	quests: [
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "19B393433FB0C62F"
 			rewards: [{
 				id: "1D6B80A0E1346CA8"
@@ -134,7 +133,6 @@
 			y: 11.5d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "010607466D565B53"
 			rewards: [{
 				id: "67AFD1C6A9878176"
@@ -151,7 +149,6 @@
 			y: 11.5d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "3EC8A0B89788D079"
 			rewards: [{
 				id: "0CA5EB7B12A44248"
@@ -168,7 +165,6 @@
 			y: 10.5d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			hide_details_until_startable: false
 			id: "2215FB0777D7029D"
 			rewards: [{
@@ -186,7 +182,6 @@
 			y: 11.5d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "74B352457BF1541B"
 			rewards: [{
 				id: "66FA05EA0440A12F"
@@ -203,7 +198,6 @@
 			y: 11.5d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "4A7AEBEB87CEC274"
 			rewards: [{
 				id: "27A249F2662A57B2"
@@ -220,7 +214,6 @@
 			y: 10.5d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "122E6E7CABCB17E7"
 			rewards: [{
 				id: "4BB64F9FF51DBA77"
@@ -237,7 +230,6 @@
 			y: 10.5d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "5040B3D29F238BC0"
 			rewards: [{
 				id: "4B23025A3DF6FED3"
@@ -254,7 +246,6 @@
 			y: 11.5d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "4D3379D38237F830"
 			rewards: [{
 				id: "61AF877D7328B938"
@@ -271,7 +262,6 @@
 			y: 10.5d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "11C5F17C6BB1237B"
 			rewards: [{
 				id: "0BC4239F313D6CC9"
@@ -288,7 +278,6 @@
 			y: 5.0d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "62622137648A4F56"
 			rewards: [{
 				id: "4D0311D0E6C9EE09"
@@ -305,7 +294,6 @@
 			y: 4.0d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "50A32AC6EDBC5854"
 			rewards: [{
 				id: "32ECEBDD3FC9EFCD"
@@ -321,7 +309,6 @@
 			y: 5.0d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "7188DC06A28AE30E"
 			rewards: [{
 				id: "0F118F21E3912277"
@@ -337,7 +324,6 @@
 			y: 3.0d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "73FC51144FC2DA52"
 			rewards: [{
 				id: "6D6A664B87EA7794"
@@ -353,7 +339,6 @@
 			y: 5.0d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "3B3BD39BA02DCA13"
 			rewards: [{
 				id: "067713AF0F04CB00"
@@ -370,7 +355,6 @@
 			y: 3.0d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "427014BDE06DE631"
 			rewards: [{
 				id: "0012D00B951BDB21"
@@ -386,7 +370,6 @@
 			y: 4.0d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "3705D303CF423804"
 			rewards: [{
 				id: "2F22132F2DCE4DBD"
@@ -403,7 +386,6 @@
 			y: 5.0d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "6A452BFC8A967C39"
 			rewards: [{
 				id: "7897EE0226BBAEFB"
@@ -420,7 +402,6 @@
 			y: 3.0d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "3525D5DCC3A534D9"
 			rewards: [{
 				id: "50F3D3094E068198"
@@ -436,7 +417,6 @@
 			y: 3.0d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "321F16645640C462"
 			rewards: [{
 				id: "1BA6843536347774"
@@ -453,7 +433,6 @@
 			y: 6.5d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "5DE7C4FD5FA29236"
 			rewards: [{
 				id: "3DD92AF42189207A"
@@ -470,7 +449,6 @@
 			y: 6.5d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "589F1D502F680075"
 			rewards: [{
 				id: "2AEE686084EFFE16"
@@ -487,7 +465,6 @@
 			y: 6.5d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "623796B1D7981E59"
 			rewards: [{
 				id: "2DD1B2EB53FA1B06"
@@ -504,7 +481,6 @@
 			y: 8.5d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "1E40ACF3E69A4100"
 			rewards: [{
 				id: "47FAD59E3EB18EB3"
@@ -521,7 +497,6 @@
 			y: 8.5d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "5EB7CE3A1DCD3E9B"
 			rewards: [{
 				id: "27705590C2DBFCBE"
@@ -538,7 +513,6 @@
 			y: 8.5d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "4933CF4675E77D50"
 			rewards: [{
 				id: "6262D735C724ACC5"
@@ -555,7 +529,6 @@
 			y: 7.5d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "436E4E3515BCCDE9"
 			rewards: [{
 				id: "695CA7D1EFB035F3"
@@ -572,7 +545,6 @@
 			y: 7.5d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "0A1D4228271DECA3"
 			rewards: [{
 				id: "740BE05C2E4F0058"
@@ -589,7 +561,6 @@
 			y: 2.0d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "221C9EDA651144BA"
 			rewards: [{
 				id: "2613BC08CDB9516F"
@@ -606,7 +577,6 @@
 			y: 2.0d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "3446803FB59D8875"
 			rewards: [{
 				id: "25B13403204151CF"
@@ -623,7 +593,6 @@
 			y: 2.0d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "27E951F4F4F6F847"
 			rewards: [{
 				id: "78E44C67B75C7237"
@@ -640,7 +609,6 @@
 			y: 3.5d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "70C7D92844089DEB"
 			rewards: [{
 				id: "624BB858D3CB0912"
@@ -657,7 +625,6 @@
 			y: 4.5d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "0E716B90E60C486B"
 			rewards: [{
 				id: "59599CA4761C5FE5"
@@ -674,7 +641,6 @@
 			y: 4.5d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "72D6265E35814927"
 			rewards: [{
 				id: "244EB416BE853DED"
@@ -691,7 +657,6 @@
 			y: 2.5d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "7503823ACDDB0491"
 			rewards: [{
 				id: "271F86DD9828F8D6"
@@ -708,7 +673,6 @@
 			y: 3.5d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "145E7D1A88B83DDD"
 			rewards: [{
 				id: "4AFFDBA7D63244B6"
@@ -725,7 +689,6 @@
 			y: 2.5d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "29448D08C8777425"
 			rewards: [{
 				id: "738FEBB9C29A0B70"
@@ -742,7 +705,6 @@
 			y: -2.0d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "6FBE5B5D5027B32C"
 			rewards: [{
 				id: "3BAE1E0F292410A8"
@@ -759,7 +721,6 @@
 			y: -2.0d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "5F5E43B3F51CAE9E"
 			rewards: [{
 				id: "29087C6E2B87AD00"
@@ -776,7 +737,6 @@
 			y: -2.0d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "73B73870B29DFAD9"
 			rewards: [{
 				id: "068B300389DB2FA0"
@@ -793,7 +753,6 @@
 			y: -2.0d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "2AD78E22988A92D3"
 			rewards: [{
 				id: "688DBF188490BF6D"
@@ -810,7 +769,6 @@
 			y: -4.0d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "16255FB20F35A9D9"
 			rewards: [{
 				id: "012EC765D75BE091"
@@ -827,7 +785,6 @@
 			y: -3.0d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "3E0643EA9183CDAE"
 			rewards: [{
 				id: "226C5CDF795A026A"
@@ -844,7 +801,6 @@
 			y: -4.0d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "2607F3DC07049785"
 			rewards: [{
 				id: "779361BFB6009F94"
@@ -861,7 +817,6 @@
 			y: -3.0d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "789AF6D0A6321945"
 			rewards: [{
 				id: "7F76ED98F73DF59F"
@@ -878,7 +833,6 @@
 			y: 4.0d
 		}
 		{
-			dependencies: ["4564B577CB4EC046"]
 			id: "161A90E134592D0E"
 			rewards: [{
 				id: "47E93F58F4876901"
@@ -895,7 +849,6 @@
 			y: 4.0d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "4564B577CB4EC046"
 			rewards: [{
 				id: "628ED3546A3712E7"
@@ -912,7 +865,6 @@
 			y: 4.0d
 		}
 		{
-			dependencies: ["5CE44C58A470E48E"]
 			id: "3E1A3BC8642390B3"
 			rewards: [{
 				id: "74CAAAE55F9C1000"
@@ -929,7 +881,6 @@
 			y: 4.0d
 		}
 		{
-			hide_dependent_lines: true
 			id: "5CE44C58A470E48E"
 			rewards: [{
 				id: "4124A7CA30FAB48B"

--- a/config/ftbquests/quests/chapters/basic_tools.snbt
+++ b/config/ftbquests/quests/chapters/basic_tools.snbt
@@ -1329,5 +1329,23 @@
 			x: 2.0d
 			y: 4.0d
 		}
+		{
+			id: "16AAC61729C44881"
+			invisible: true
+			optional: true
+			shape: "circle"
+			tasks: [
+				{
+					id: "66ACCF967C939342"
+					type: "checkmark"
+				}
+				{
+					id: "3C16EE29B250B557"
+					type: "checkmark"
+				}
+			]
+			x: 0.0d
+			y: -1.5d
+		}
 	]
 }

--- a/config/ftbquests/quests/chapters/chapter_2_the_star.snbt
+++ b/config/ftbquests/quests/chapters/chapter_2_the_star.snbt
@@ -97,10 +97,10 @@
 			y: 14.0d
 		}
 		{
-			height: 6.0d
+			height: 7.0d
 			image: "atm:textures/questpics/gettingstarted/getting_started.png"
 			rotation: 0.0d
-			width: 10.819672131147541d
+			width: 12.62d
 			x: 0.0d
 			y: -20.5d
 		}
@@ -150,7 +150,7 @@
 			rotation: 0.0d
 			width: 3.527114967462039d
 			x: -2.0d
-			y: -14.5d
+			y: -14.4d
 		}
 		{
 			height: 2.0d
@@ -223,11 +223,6 @@
 			id: "05850541675B2493"
 			rewards: [
 				{
-					id: "5D73D5CCF2391108"
-					type: "xp_levels"
-					xp_levels: 1000
-				}
-				{
 					id: "793BE7D88D964B86"
 					item: {
 						count: 1
@@ -276,12 +271,9 @@
 					type: "item"
 				}
 				{
-					id: "0B2871584CE6A7F7"
-					item: {
-						count: 1
-						id: "allthemodium:unobtainium_mace"
-					}
-					type: "item"
+					id: "742C5FF1748A263D"
+					type: "xp"
+					xp: 10000
 				}
 			]
 			shape: "pentagon"
@@ -309,11 +301,6 @@
 			id: "217DF3B66A07A8DE"
 			rewards: [
 				{
-					id: "50C9A2C1CA31873E"
-					type: "xp_levels"
-					xp_levels: 25
-				}
-				{
 					id: "629431C711506167"
 					item: {
 						count: 1
@@ -336,6 +323,11 @@
 						id: "allthemodium:unobtainium_block"
 					}
 					type: "item"
+				}
+				{
+					id: "442EEF0960628838"
+					type: "xp"
+					xp: 1000
 				}
 			]
 			shape: "octagon"
@@ -363,11 +355,6 @@
 			id: "4E82E843737045D9"
 			rewards: [
 				{
-					id: "6F6458FBC17DF883"
-					type: "xp_levels"
-					xp_levels: 25
-				}
-				{
 					id: "10C9F22A761E7CB3"
 					item: {
 						count: 1
@@ -391,6 +378,11 @@
 					}
 					type: "item"
 				}
+				{
+					id: "7BB208C6B82496E6"
+					type: "xp"
+					xp: 1000
+				}
 			]
 			shape: "octagon"
 			size: 2.5d
@@ -407,18 +399,13 @@
 				"5869E198DA416346"
 				"42AF4EBDA5D6CC36"
 				"39F9C825B03DA317"
-				"7D972A3C4211EB26"
 				"45D10F53CA18B8EE"
 				"0923C941A9696122"
 				"0848056FDD3F9BDA"
+				"6A12188E50EAEB78"
 			]
 			id: "36DF0D83EBC2B6A9"
 			rewards: [
-				{
-					id: "51484454BF7BFFF7"
-					type: "xp_levels"
-					xp_levels: 25
-				}
 				{
 					id: "27B9039F5119A16E"
 					item: {
@@ -443,6 +430,11 @@
 					}
 					type: "item"
 				}
+				{
+					id: "23F6C94DB7F4BCB1"
+					type: "xp"
+					xp: 1000
+				}
 			]
 			shape: "octagon"
 			size: 2.5d
@@ -465,11 +457,6 @@
 			]
 			id: "6CAD67D21E1EA861"
 			rewards: [
-				{
-					id: "717CCFAD2FC72DEF"
-					type: "xp_levels"
-					xp_levels: 25
-				}
 				{
 					id: "53C3940EAF08482C"
 					item: {
@@ -494,6 +481,11 @@
 					}
 					type: "item"
 				}
+				{
+					id: "2C8AF636A49EE9F4"
+					type: "xp"
+					xp: 1000
+				}
 			]
 			shape: "octagon"
 			size: 2.5d
@@ -513,11 +505,6 @@
 			]
 			id: "54B1A876E9F6707A"
 			rewards: [
-				{
-					id: "30D04AA6CFD5FDA9"
-					type: "xp_levels"
-					xp_levels: 25
-				}
 				{
 					id: "314F862D824E9567"
 					item: {
@@ -542,6 +529,11 @@
 					}
 					type: "item"
 				}
+				{
+					id: "20A335C3847555BD"
+					type: "xp"
+					xp: 1000
+				}
 			]
 			shape: "octagon"
 			size: 2.5d
@@ -565,11 +557,6 @@
 			]
 			id: "17542D7633FBF098"
 			rewards: [
-				{
-					id: "65DFC0A9BC6E5E97"
-					type: "xp_levels"
-					xp_levels: 25
-				}
 				{
 					id: "57154693C64ED404"
 					item: {
@@ -603,6 +590,11 @@
 					}
 					type: "item"
 				}
+				{
+					id: "1310877029C692EE"
+					type: "xp"
+					xp: 1000
+				}
 			]
 			shape: "octagon"
 			size: 2.5d
@@ -623,16 +615,11 @@
 				"3145B847A15F97F2"
 				"2B0C3AAAA6D0B0D2"
 				"561B5FB009744D2B"
-				"6A12188E50EAEB78"
 				"59EC02C1FBCF14EA"
+				"7D972A3C4211EB26"
 			]
 			id: "2188C52C1F384DE4"
 			rewards: [
-				{
-					id: "5939E89D276926BA"
-					type: "xp_levels"
-					xp_levels: 25
-				}
 				{
 					id: "6E40EC46E76292C4"
 					item: {
@@ -656,6 +643,11 @@
 						id: "allthemodium:unobtainium_block"
 					}
 					type: "item"
+				}
+				{
+					id: "06B1079356C53DEF"
+					type: "xp"
+					xp: 1000
 				}
 			]
 			shape: "octagon"
@@ -683,11 +675,6 @@
 			id: "1CE7B24E7E62C25B"
 			rewards: [
 				{
-					id: "291A912F5F53CC49"
-					type: "xp_levels"
-					xp_levels: 25
-				}
-				{
 					id: "66AD762025E899FB"
 					item: {
 						count: 1
@@ -710,6 +697,11 @@
 						id: "allthemodium:unobtainium_block"
 					}
 					type: "item"
+				}
+				{
+					id: "1F948BAA83EA88B0"
+					type: "xp"
+					xp: 1000
 				}
 			]
 			shape: "octagon"
@@ -737,11 +729,6 @@
 			id: "39B4F361EF611927"
 			rewards: [
 				{
-					id: "3A6DADFA5D97D9F2"
-					type: "xp_levels"
-					xp_levels: 25
-				}
-				{
 					id: "60F8A57A965AD08B"
 					item: {
 						count: 1
@@ -765,6 +752,11 @@
 					}
 					type: "item"
 				}
+				{
+					id: "7314EBD68A1DB0E5"
+					type: "xp"
+					xp: 1000
+				}
 			]
 			shape: "octagon"
 			size: 2.5d
@@ -784,11 +776,6 @@
 			]
 			id: "0C7D96DB3573EF9C"
 			rewards: [
-				{
-					id: "67E12EA85D5CC8B3"
-					type: "xp_levels"
-					xp_levels: 25
-				}
 				{
 					id: "68602985A6FF095E"
 					item: {
@@ -812,6 +799,11 @@
 						id: "allthemodium:unobtainium_block"
 					}
 					type: "item"
+				}
+				{
+					id: "310BD956724BCB44"
+					type: "xp"
+					xp: 1000
 				}
 			]
 			shape: "octagon"
@@ -1396,6 +1388,7 @@
 			tasks: [{
 				id: "74A239A04A05168A"
 				item: { components: { "productivebees:bee_type": "productivebees:withered" }, count: 1, id: "productivebees:configurable_comb" }
+				match_components: "fuzzy"
 				type: "item"
 			}]
 			x: -8.0d
@@ -1535,21 +1528,11 @@
 			dependencies: ["7377C657CED885AC"]
 			hide_dependent_lines: true
 			id: "3145B847A15F97F2"
-			rewards: [
-				{
-					id: "63994E23E2EC005F"
-					type: "xp_levels"
-					xp_levels: 1
-				}
-				{
-					id: "36388ECE44ABDB15"
-					item: {
-						count: 1
-						id: "ironfurnaces:rainbow_coal"
-					}
-					type: "item"
-				}
-			]
+			rewards: [{
+				id: "63994E23E2EC005F"
+				type: "xp_levels"
+				xp_levels: 1
+			}]
 			size: 1.25d
 			tasks: [{
 				id: "43A26135F8A4F2FD"
@@ -1648,6 +1631,7 @@
 			]
 			size: 1.25d
 			tasks: [{
+				count: 2L
 				id: "35506B0CD08BC722"
 				item: { components: { "minecraft:custom_name": "{\"extra\":[{\"color\":\"light_purple\",\"text\":\"R\"},{\"color\":\"red\",\"text\":\"a\"},{\"color\":\"light_purple\",\"text\":\"i\"},{\"color\":\"light_purple\",\"text\":\"n\"},{\"color\":\"aqua\",\"text\":\"b\"},{\"color\":\"green\",\"text\":\"o\"},{\"color\":\"yellow\",\"text\":\"w\"},{\"color\":\"green\",\"text\":\" \"},{\"color\":\"light_purple\",\"text\":\"F\"},{\"color\":\"light_purple\",\"text\":\"u\"},{\"color\":\"red\",\"text\":\"r\"},{\"color\":\"green\",\"text\":\"n\"},{\"color\":\"light_purple\",\"text\":\"a\"},{\"color\":\"green\",\"text\":\"c\"},{\"color\":\"blue\",\"text\":\"e\"}],\"text\":\"\"}" }, count: 1, id: "ironfurnaces:million_furnace" }
 				type: "item"
@@ -2023,6 +2007,7 @@
 			tasks: [{
 				id: "5F1BB488E5FF56E5"
 				item: { components: { "minecraft:entity_data": { id: "productivebees:configurable_bee", type: "productivebees:soul_lava" } }, count: 1, id: "productivebees:spawn_egg_configurable_bee" }
+				match_components: "fuzzy"
 				type: "item"
 			}]
 			x: -10.0d
@@ -2222,9 +2207,8 @@
 			]
 			size: 1.25d
 			tasks: [{
-				count: 2L
-				id: "798C3D6D1FAB5909"
-				item: { components: { "minecraft:custom_name": "{\"extra\":[{\"color\":\"green\",\"text\":\"R\"},{\"color\":\"red\",\"text\":\"a\"},{\"color\":\"aqua\",\"text\":\"i\"},{\"color\":\"green\",\"text\":\"n\"},{\"color\":\"red\",\"text\":\"b\"},{\"color\":\"green\",\"text\":\"o\"},{\"color\":\"yellow\",\"text\":\"w\"},{\"color\":\"red\",\"text\":\" \"},{\"color\":\"yellow\",\"text\":\"F\"},{\"color\":\"red\",\"text\":\"u\"},{\"color\":\"red\",\"text\":\"r\"},{\"color\":\"blue\",\"text\":\"n\"},{\"color\":\"aqua\",\"text\":\"a\"},{\"color\":\"red\",\"text\":\"c\"},{\"color\":\"light_purple\",\"text\":\"e\"}],\"text\":\"\"}" }, count: 1, id: "ironfurnaces:million_furnace" }
+				id: "5F21D5BF403BDCEF"
+				item: { count: 1, id: "ironfurnaces:rainbow_coal" }
 				type: "item"
 			}]
 			x: 6.0d
@@ -2930,11 +2914,6 @@
 			id: "4485C4ABD57874EB"
 			rewards: [
 				{
-					id: "1B83E3C659487F14"
-					type: "xp"
-					xp: 100
-				}
-				{
 					count: 4
 					id: "6398B8057CD662F9"
 					item: {
@@ -2942,6 +2921,11 @@
 						id: "ae2:charged_certus_quartz_crystal"
 					}
 					type: "item"
+				}
+				{
+					id: "0FC7CB43F44F5A47"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "rsquare"
@@ -2961,11 +2945,6 @@
 			id: "216DA9782EBDFF34"
 			rewards: [
 				{
-					id: "6069A7B3AD6DC9AC"
-					type: "xp"
-					xp: 100
-				}
-				{
 					count: 5
 					id: "6488CAF3EB5587AF"
 					item: {
@@ -2973,6 +2952,11 @@
 						id: "occultism:datura"
 					}
 					type: "item"
+				}
+				{
+					id: "52211DC3A6C43188"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "rsquare"
@@ -2989,11 +2973,6 @@
 			id: "21AB14A8553896E9"
 			rewards: [
 				{
-					id: "530E3CEB4653C941"
-					type: "xp"
-					xp: 100
-				}
-				{
 					count: 2
 					id: "047A7F3E8677A6B7"
 					item: {
@@ -3001,6 +2980,11 @@
 						id: "productivetrees:pollen"
 					}
 					type: "item"
+				}
+				{
+					id: "4ECA70BB0B9A1DB5"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "rsquare"
@@ -3017,17 +3001,17 @@
 			id: "0573B6F1BE5110FD"
 			rewards: [
 				{
-					id: "317C7516E439436D"
-					type: "xp"
-					xp: 100
-				}
-				{
 					id: "425AE9EE38821639"
 					item: {
 						count: 1
 						id: "minecraft:honeycomb_block"
 					}
 					type: "item"
+				}
+				{
+					id: "688803E72EB255C6"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "rsquare"
@@ -3091,11 +3075,6 @@
 			id: "3AAB71E9BDFD4C1E"
 			rewards: [
 				{
-					id: "66243CFB057B3611"
-					type: "xp"
-					xp: 100
-				}
-				{
 					count: 3
 					id: "3D51FB3501E2BBD3"
 					item: {
@@ -3103,6 +3082,11 @@
 						id: "pneumaticcraft:ingot_iron_compressed"
 					}
 					type: "item"
+				}
+				{
+					id: "48BF5C36004F02D4"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "rsquare"
@@ -3119,11 +3103,6 @@
 			id: "11374A3B5BD644F5"
 			rewards: [
 				{
-					id: "3232E42F2C93C818"
-					type: "xp"
-					xp: 100
-				}
-				{
 					count: 3
 					id: "2A9011532E27C3D4"
 					item: {
@@ -3131,6 +3110,11 @@
 						id: "industrialforegoing:dryrubber"
 					}
 					type: "item"
+				}
+				{
+					id: "10167EDD2212EAD4"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "rsquare"
@@ -3178,17 +3162,17 @@
 			id: "7377C657CED885AC"
 			rewards: [
 				{
-					id: "310E5BAD59045AF6"
-					type: "xp"
-					xp: 100
-				}
-				{
 					id: "2AD8F6EAE8EF2A73"
 					item: {
 						count: 1
 						id: "mysticalagriculture:inferium_block"
 					}
 					type: "item"
+				}
+				{
+					id: "6019B82199039FAD"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "rsquare"
@@ -3236,17 +3220,17 @@
 			id: "3331EBE1BB4BF64D"
 			rewards: [
 				{
-					id: "52AD0CD2BCBB7346"
-					type: "xp"
-					xp: 100
-				}
-				{
 					id: "4C4717AB0D510404"
 					item: {
 						count: 1
 						id: "alltheores:uranium_block"
 					}
 					type: "item"
+				}
+				{
+					id: "0D227CD4C7E3E084"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "rsquare"
@@ -3266,17 +3250,17 @@
 			id: "372B5BF416CA83A4"
 			rewards: [
 				{
-					id: "257472F5EBA7F2EE"
-					type: "xp"
-					xp: 100
-				}
-				{
 					id: "667534F77B0D08A0"
 					item: {
 						count: 1
 						id: "alltheores:steel_block"
 					}
 					type: "item"
+				}
+				{
+					id: "1FAEEED2AA6A76A1"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "rsquare"
@@ -3296,11 +3280,6 @@
 			id: "7E4367252A39BE6C"
 			rewards: [
 				{
-					id: "24EC74D897FF9793"
-					type: "xp"
-					xp: 100
-				}
-				{
 					count: 16
 					id: "4796F69D08F840AF"
 					item: {
@@ -3308,6 +3287,11 @@
 						id: "powah:dielectric_paste"
 					}
 					type: "item"
+				}
+				{
+					id: "7386B11172F598B4"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "rsquare"
@@ -3327,11 +3311,6 @@
 			id: "3CFD27F273B97FDD"
 			rewards: [
 				{
-					id: "31FDA09642AD969C"
-					type: "xp"
-					xp: 100
-				}
-				{
 					count: 2
 					id: "509E6D8B500C555F"
 					item: {
@@ -3339,6 +3318,11 @@
 						id: "minecraft:bookshelf"
 					}
 					type: "item"
+				}
+				{
+					id: "2BD31DE66546CFDA"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "rsquare"
@@ -3358,11 +3342,6 @@
 			id: "3F5B5D6B788E0A73"
 			rewards: [
 				{
-					id: "4CA75A8BDF46D44C"
-					type: "xp"
-					xp: 100
-				}
-				{
 					count: 3
 					id: "17AE3958527A6B92"
 					item: {
@@ -3370,6 +3349,11 @@
 						id: "evilcraft:dark_gem"
 					}
 					type: "item"
+				}
+				{
+					id: "4F7446244FFB8094"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "rsquare"
@@ -3406,11 +3390,6 @@
 			id: "76C63670624C3C56"
 			rewards: [
 				{
-					id: "1C21427FE7E735C8"
-					type: "xp"
-					xp: 100
-				}
-				{
 					count: 2
 					id: "1409306D81BE3A18"
 					item: {
@@ -3418,6 +3397,11 @@
 						id: "minecraft:coal_block"
 					}
 					type: "item"
+				}
+				{
+					id: "54C82B7BE56A13B4"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "rsquare"
@@ -3434,11 +3418,6 @@
 			id: "24F3E90C14BFD1B4"
 			rewards: [
 				{
-					id: "7664D34CDB6ECB93"
-					type: "xp"
-					xp: 100
-				}
-				{
 					count: 3
 					id: "36EC69FAACF2B547"
 					item: {
@@ -3446,6 +3425,11 @@
 						id: "minecraft:iron_ingot"
 					}
 					type: "item"
+				}
+				{
+					id: "319DF8E475914EFA"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "rsquare"
@@ -3462,17 +3446,17 @@
 			id: "7154D73516548149"
 			rewards: [
 				{
-					id: "0C23B92577875089"
-					type: "xp"
-					xp: 100
-				}
-				{
 					id: "6FA9F7622C3EE1FA"
 					item: {
 						count: 1
 						id: "minecraft:netherite_ingot"
 					}
 					type: "item"
+				}
+				{
+					id: "6643F39EBB3D8696"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "rsquare"
@@ -3489,11 +3473,6 @@
 			id: "2171DC0B13C4BD43"
 			rewards: [
 				{
-					id: "67C52A815FAB6D0E"
-					type: "xp"
-					xp: 100
-				}
-				{
 					count: 5
 					id: "7801AEE59EB6FAB8"
 					item: {
@@ -3501,6 +3480,11 @@
 						id: "rootsclassic:verdant_sprig"
 					}
 					type: "item"
+				}
+				{
+					id: "1524A05A8654DAFD"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "rsquare"
@@ -3520,11 +3504,6 @@
 			id: "6A46A9F04D2A0748"
 			rewards: [
 				{
-					id: "63A2B61DDD61B9F3"
-					type: "xp"
-					xp: 100
-				}
-				{
 					id: "2966D52F3D6E929F"
 					item: {
 						components: {
@@ -3534,6 +3513,11 @@
 						id: "patchouli:guide_book"
 					}
 					type: "item"
+				}
+				{
+					id: "4DBA5B99D03386A8"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "rsquare"
@@ -3550,17 +3534,17 @@
 			id: "7A579E233C69871F"
 			rewards: [
 				{
-					id: "4A74B3D580F5A99E"
-					type: "xp"
-					xp: 100
-				}
-				{
 					id: "3487C6C94496EA7D"
 					item: {
 						count: 1
 						id: "hostilenetworks:blank_data_model"
 					}
 					type: "item"
+				}
+				{
+					id: "6AAD0A45A4F4F5E9"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "rsquare"
@@ -3577,11 +3561,6 @@
 			id: "2E88CCBC7B97A1F0"
 			rewards: [
 				{
-					id: "39E2AB61F77F4B08"
-					type: "xp"
-					xp: 100
-				}
-				{
 					count: 16
 					id: "62CAE9FAD4E85B20"
 					item: {
@@ -3589,6 +3568,11 @@
 						id: "minecraft:white_wool"
 					}
 					type: "item"
+				}
+				{
+					id: "065596103366C98C"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "rsquare"
@@ -3608,11 +3592,6 @@
 			id: "022C38096F79EF07"
 			rewards: [
 				{
-					id: "7E93845DCFA9BC40"
-					type: "xp"
-					xp: 100
-				}
-				{
 					count: 5
 					id: "5920FF9F85E86EB6"
 					item: {
@@ -3620,6 +3599,11 @@
 						id: "forbidden_arcanus:arcane_crystal"
 					}
 					type: "item"
+				}
+				{
+					id: "2AE7BDD533E3F839"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "rsquare"
@@ -3636,11 +3620,6 @@
 			id: "2B57C8D2F98A9279"
 			rewards: [
 				{
-					id: "125166C88C9F8C8F"
-					type: "xp"
-					xp: 100
-				}
-				{
 					count: 4
 					id: "15E699D768E8E21D"
 					item: {
@@ -3648,6 +3627,11 @@
 						id: "minecraft:gold_ingot"
 					}
 					type: "item"
+				}
+				{
+					id: "330198AA1A42860D"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "rsquare"

--- a/config/ftbquests/quests/chapters/elmystical_agriculturerr.snbt
+++ b/config/ftbquests/quests/chapters/elmystical_agriculturerr.snbt
@@ -4385,6 +4385,7 @@
 			tasks: [{
 				id: "231C01B33E5B4FF0"
 				item: { components: { "minecraft:entity_data": { id: "productivebees:configurable_bee", type: "productivebees:awakened_supremium" } }, count: 1, id: "productivebees:spawn_egg_configurable_bee" }
+				match_components: "fuzzy"
 				type: "item"
 			}]
 			x: 18.5d
@@ -5103,6 +5104,19 @@
 		{
 			dependencies: ["202B1F54D3F06DAB"]
 			id: "552335ED867D6EFA"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "6B13F22B6DCE3023"
+					table_id: 8775109450478234580L
+					type: "random"
+				}
+				{
+					id: "1337FA158A38DB13"
+					type: "xp"
+					xp: 200
+				}
+			]
 			tasks: [{
 				id: "3519BA3E872F1239"
 				item: { count: 1, id: "mysticalagradditions:insanium_coal_block" }
@@ -5114,6 +5128,19 @@
 		{
 			dependencies: ["7A103577EAE7B3F1"]
 			id: "3C9F5EB59D72AC90"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "59926247CE071F35"
+					table_id: 8775109450478234580L
+					type: "random"
+				}
+				{
+					id: "687521FF9379DF1E"
+					type: "xp"
+					xp: 150
+				}
+			]
 			tasks: [{
 				id: "042BEC73CB140FA8"
 				item: { count: 1, id: "mysticalagriculture:awakened_supremium_ingot_block" }

--- a/config/ftbquests/quests/chapters/extreme_reactors.snbt
+++ b/config/ftbquests/quests/chapters/extreme_reactors.snbt
@@ -51,6 +51,14 @@
 			x: -0.5d
 			y: 9.5d
 		}
+		{
+			height: 0.3d
+			image: "allthetweaks:item/atm_star"
+			rotation: 0.0d
+			width: 0.3d
+			x: -2.0d
+			y: 16.5d
+		}
 	]
 	order_index: 0
 	progression_mode: "flexible"

--- a/config/ftbquests/quests/chapters/food_and_farming.snbt
+++ b/config/ftbquests/quests/chapters/food_and_farming.snbt
@@ -117,17 +117,17 @@
 			id: "1827DEEA2DF1B144"
 			rewards: [
 				{
-					id: "28C108EC59F6E7D9"
-					type: "xp"
-					xp: 10
-				}
-				{
 					id: "2EFEA345691F570D"
 					item: {
 						count: 1
 						id: "minecraft:wheat_seeds"
 					}
 					type: "item"
+				}
+				{
+					id: "769A50AFA27134F2"
+					type: "xp"
+					xp: 10
 				}
 			]
 			shape: "square"
@@ -219,17 +219,17 @@
 			id: "635620A03E3505BF"
 			rewards: [
 				{
-					id: "7914440DB4E0A801"
-					type: "xp"
-					xp: 10
-				}
-				{
 					id: "0B497B4A001CFFC0"
 					item: {
 						count: 1
 						id: "minecraft:leather"
 					}
 					type: "item"
+				}
+				{
+					id: "0A3A156D2D6F48F2"
+					type: "xp"
+					xp: 10
 				}
 			]
 			tasks: [{
@@ -406,11 +406,11 @@
 			id: "0A1C2A7A8617D3E4"
 			rewards: [
 				{
-					count: 2
+					count: 3
 					id: "6EE0FD0DCE6CEEDE"
 					item: {
 						count: 1
-						id: "minecraft:bread"
+						id: "minecraft:wheat_seeds"
 					}
 					type: "item"
 				}
@@ -465,7 +465,6 @@
 				}
 			]
 			tasks: [{
-				count: 10L
 				id: "6118A776B40507B7"
 				item: { count: 1, id: "minecraft:sugar_cane" }
 				type: "item"
@@ -503,15 +502,15 @@
 					type: "item"
 				}
 				{
-					id: "18610A9BCEA465F8"
-					type: "xp"
-					xp: 10
-				}
-				{
 					exclude_from_claim_all: true
 					id: "40EA2F27F5E8685D"
 					table_id: 487623848494439020L
 					type: "random"
+				}
+				{
+					id: "459BD2969BBA3578"
+					type: "xp"
+					xp: 10
 				}
 			]
 			tasks: [{
@@ -565,15 +564,15 @@
 					type: "item"
 				}
 				{
-					id: "1C499560DF40E2FC"
-					type: "xp"
-					xp: 10
-				}
-				{
 					exclude_from_claim_all: true
 					id: "22943343AA0140AF"
 					table_id: 487623848494439020L
 					type: "random"
+				}
+				{
+					id: "27E1847753DE5130"
+					type: "xp"
+					xp: 10
 				}
 			]
 			shape: "diamond"
@@ -599,15 +598,15 @@
 					type: "item"
 				}
 				{
-					id: "0B13ECD292D7D073"
-					type: "xp"
-					xp: 10
-				}
-				{
 					exclude_from_claim_all: true
 					id: "17F23B9B65A62413"
 					table_id: 487623848494439020L
 					type: "random"
+				}
+				{
+					id: "799F38EE6543C226"
+					type: "xp"
+					xp: 10
 				}
 			]
 			shape: "diamond"
@@ -633,15 +632,15 @@
 					type: "item"
 				}
 				{
-					id: "2390EE9B8E964CCA"
-					type: "xp"
-					xp: 10
-				}
-				{
 					exclude_from_claim_all: true
 					id: "285E04C219E15BE2"
 					table_id: 487623848494439020L
 					type: "random"
+				}
+				{
+					id: "2D3D6433753DF10E"
+					type: "xp"
+					xp: 10
 				}
 			]
 			shape: "diamond"
@@ -667,15 +666,15 @@
 					type: "item"
 				}
 				{
-					id: "19945E72467070D2"
-					type: "xp"
-					xp: 10
-				}
-				{
 					exclude_from_claim_all: true
 					id: "3F871506DE4A9E43"
 					table_id: 487623848494439020L
 					type: "random"
+				}
+				{
+					id: "0EE6D40390D4DE5D"
+					type: "xp"
+					xp: 10
 				}
 			]
 			shape: "diamond"
@@ -702,15 +701,15 @@
 					type: "item"
 				}
 				{
-					id: "7F98CDC2EA641EF7"
-					type: "xp"
-					xp: 10
-				}
-				{
 					exclude_from_claim_all: true
 					id: "7D1016D39347DFD3"
 					table_id: 487623848494439020L
 					type: "random"
+				}
+				{
+					id: "25BB1334DA126634"
+					type: "xp"
+					xp: 10
 				}
 			]
 			shape: "diamond"
@@ -837,8 +836,8 @@
 		}
 		{
 			dependencies: [
-				"659A903F97F93BE2"
 				"1D48298525EEADC9"
+				"0A1C2A7A8617D3E4"
 			]
 			id: "0893EFCAC7031FEA"
 			rewards: [
@@ -851,15 +850,15 @@
 					type: "item"
 				}
 				{
-					id: "7F528DE479E680AE"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "688019DBD32BF755"
 					table_id: 487623848494439020L
 					type: "random"
+				}
+				{
+					id: "67C04C8A891CB4DD"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "rsquare"
@@ -913,15 +912,15 @@
 					type: "item"
 				}
 				{
-					id: "62FB77230F1D9F9B"
-					type: "xp"
-					xp: 10
-				}
-				{
 					exclude_from_claim_all: true
 					id: "139855B12BA13469"
 					table_id: 487623848494439020L
 					type: "random"
+				}
+				{
+					id: "7F38B63C5879EF11"
+					type: "xp"
+					xp: 10
 				}
 			]
 			shape: "diamond"
@@ -957,6 +956,19 @@
 				id: "cookingforblockheads:white_fridge"
 			}
 			id: "791AE62ACACBD5BA"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "4C3114E267797DC4"
+					table_id: 487623848494439020L
+					type: "random"
+				}
+				{
+					id: "252681E3107767E7"
+					type: "xp"
+					xp: 10
+				}
+			]
 			shape: "diamond"
 			tasks: [{
 				id: "669DEA201002793D"
@@ -969,6 +981,19 @@
 		{
 			dependencies: ["28C9EDBF6607E180"]
 			id: "2786D5AC19163524"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "001D146FA176A7CE"
+					table_id: 5564196992594175882L
+					type: "random"
+				}
+				{
+					id: "3F16B93CAB0B6ECA"
+					type: "xp"
+					xp: 10
+				}
+			]
 			shape: "diamond"
 			tasks: [{
 				id: "758CA2EB2C92A6AA"
@@ -977,6 +1002,60 @@
 			}]
 			x: -0.5d
 			y: 8.5d
+		}
+		{
+			dependencies: ["72717D1135486D7F"]
+			id: "56550CD12C681B0F"
+			rewards: [
+				{
+					id: "5BAD03B93921DAE9"
+					item: {
+						count: 1
+						id: "silentgear:flax_string"
+					}
+					type: "item"
+				}
+				{
+					id: "0D8DEA2CB39DB998"
+					type: "xp"
+					xp: 10
+				}
+			]
+			tasks: [{
+				id: "39856D5B1340F958"
+				item: { count: 1, id: "silentgear:flax_seeds" }
+				type: "item"
+			}]
+			x: -5.5d
+			y: -1.0d
+		}
+		{
+			dependencies: ["56550CD12C681B0F"]
+			id: "04D0543FE2820F64"
+			rewards: [
+				{
+					count: 3
+					id: "62205F6BB445FAD2"
+					item: {
+						count: 1
+						id: "silentgear:flax_seeds"
+					}
+					type: "item"
+				}
+				{
+					id: "380633A1C13A3B2C"
+					type: "xp"
+					xp: 10
+				}
+			]
+			tasks: [{
+				count: 3L
+				id: "6D9DE56C95427085"
+				item: { count: 1, id: "silentgear:flax_string" }
+				type: "item"
+			}]
+			x: -7.0d
+			y: -1.0d
 		}
 	]
 }

--- a/config/ftbquests/quests/chapters/generators.snbt
+++ b/config/ftbquests/quests/chapters/generators.snbt
@@ -304,6 +304,14 @@
 			x: 5.7d
 			y: 3.0d
 		}
+		{
+			height: 0.3d
+			image: "allthetweaks:item/atm_star"
+			rotation: 0.0d
+			width: 0.3d
+			x: -3.6d
+			y: 3.0d
+		}
 	]
 	order_index: 1
 	quest_links: [ ]

--- a/config/ftbquests/quests/chapters/hostile_neural_networks.snbt
+++ b/config/ftbquests/quests/chapters/hostile_neural_networks.snbt
@@ -273,6 +273,7 @@
 			tasks: [{
 				id: "1F4B02AFDFD7CDBE"
 				item: { components: { "hostilenetworks:data_model": "hostilenetworks:chicken" }, count: 1, id: "hostilenetworks:prediction" }
+				match_components: "strict"
 				type: "item"
 			}]
 			x: 3.0d
@@ -411,6 +412,7 @@
 			tasks: [{
 				id: "1AEFD81CDB3EA4CD"
 				item: { components: { "hostilenetworks:data_model": "hostilenetworks:allthemodium/piglich" }, count: 1, id: "hostilenetworks:prediction" }
+				match_components: "strict"
 				type: "item"
 			}]
 			x: 0.0d

--- a/config/ftbquests/quests/chapters/mekanism_reactors.snbt
+++ b/config/ftbquests/quests/chapters/mekanism_reactors.snbt
@@ -251,15 +251,15 @@
 			min_width: 300
 			rewards: [
 				{
-					id: "0792BEFF2D7C604C"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "251D1877952196CD"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "1E17AE337B09AD79"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "square"
@@ -1168,15 +1168,15 @@
 			min_width: 300
 			rewards: [
 				{
-					id: "0963F21E8369E149"
-					type: "xp"
-					xp: 100
-				}
-				{
 					exclude_from_claim_all: true
 					id: "6427E149BC34AD20"
 					table_id: 8364958827326577211L
 					type: "loot"
+				}
+				{
+					id: "3982DCB00838CF79"
+					type: "xp"
+					xp: 100
 				}
 			]
 			shape: "gear"

--- a/config/ftbquests/quests/chapters/pneumaticcraft.snbt
+++ b/config/ftbquests/quests/chapters/pneumaticcraft.snbt
@@ -15,16 +15,16 @@
 			height: 7.0d
 			image: "atm:textures/questpics/pneumaticcraft/pressure_chamber.png"
 			rotation: 0.0d
-			width: 12.413333333333334d
-			x: 2.0d
+			width: 12.41d
+			x: 2.5d
 			y: 7.0d
 		}
 		{
 			height: 8.0d
 			image: "atm:textures/questpics/pneumaticcraft/assembly_line.png"
 			rotation: 0.0d
-			width: 15.21514629948365d
-			x: 27.0d
+			width: 15.21d
+			x: 26.5d
 			y: 8.0d
 		}
 		{

--- a/config/ftbquests/quests/chapters/relics.snbt
+++ b/config/ftbquests/quests/chapters/relics.snbt
@@ -183,15 +183,26 @@
 		{
 			dependencies: ["2B08B19B35EEBCBA"]
 			id: "54822638CC243004"
-			rewards: [{
-				count: 10
-				id: "58922C75496BC851"
-				item: {
-					count: 1
-					id: "relics:relic_experience_bottle"
+			rewards: [
+				{
+					count: 10
+					id: "58922C75496BC851"
+					item: {
+						count: 1
+						id: "relics:relic_experience_bottle"
+					}
+					type: "item"
 				}
-				type: "item"
-			}]
+				{
+					count: 10
+					id: "1B597F71FEE2546F"
+					item: {
+						count: 1
+						id: "ars_nouveau:mirrorweave"
+					}
+					type: "item"
+				}
+			]
 			shape: "rsquare"
 			tasks: [{
 				id: "71E030C34CAAE9B6"
@@ -215,7 +226,7 @@
 					type: "item"
 				}
 				{
-					count: 5
+					count: 10
 					id: "284124825828E1A3"
 					item: {
 						count: 1
@@ -447,15 +458,26 @@
 		{
 			dependencies: ["5D82340E9BED9C79"]
 			id: "1E2A9446594638E2"
-			rewards: [{
-				count: 10
-				id: "2553B55660B1DFC6"
-				item: {
-					count: 1
-					id: "relics:relic_experience_bottle"
+			rewards: [
+				{
+					count: 10
+					id: "2553B55660B1DFC6"
+					item: {
+						count: 1
+						id: "relics:relic_experience_bottle"
+					}
+					type: "item"
 				}
-				type: "item"
-			}]
+				{
+					count: 10
+					id: "09C26A86B0BF0ADA"
+					item: {
+						count: 1
+						id: "minecraft:chorus_fruit"
+					}
+					type: "item"
+				}
+			]
 			shape: "rsquare"
 			tasks: [{
 				id: "3B5C71C7F3798A0E"
@@ -520,15 +542,26 @@
 		{
 			dependencies: ["5D82340E9BED9C79"]
 			id: "60CECAAE2D43EC6E"
-			rewards: [{
-				count: 10
-				id: "70BE3CE7991B95EF"
-				item: {
-					count: 1
-					id: "relics:relic_experience_bottle"
+			rewards: [
+				{
+					count: 10
+					id: "70BE3CE7991B95EF"
+					item: {
+						count: 1
+						id: "relics:relic_experience_bottle"
+					}
+					type: "item"
 				}
-				type: "item"
-			}]
+				{
+					count: 10
+					id: "5D73F77CF23B0B0B"
+					item: {
+						count: 1
+						id: "minecraft:end_stone"
+					}
+					type: "item"
+				}
+			]
 			shape: "rsquare"
 			tasks: [{
 				id: "6B6BA467225122A8"
@@ -552,11 +585,11 @@
 					type: "item"
 				}
 				{
-					count: 3
+					count: 10
 					id: "22AE0D3972332FC3"
 					item: {
 						count: 1
-						id: "minecraft:coal_block"
+						id: "minecraft:coal"
 					}
 					type: "item"
 				}
@@ -604,15 +637,26 @@
 		{
 			dependencies: ["730130CCF1CF5119"]
 			id: "3E8BA5E075ABD136"
-			rewards: [{
-				count: 10
-				id: "16174D4BD699A6AE"
-				item: {
-					count: 1
-					id: "relics:relic_experience_bottle"
+			rewards: [
+				{
+					count: 10
+					id: "16174D4BD699A6AE"
+					item: {
+						count: 1
+						id: "relics:relic_experience_bottle"
+					}
+					type: "item"
 				}
-				type: "item"
-			}]
+				{
+					count: 10
+					id: "6C5485F12C775270"
+					item: {
+						count: 1
+						id: "minecraft:ice"
+					}
+					type: "item"
+				}
+			]
 			shape: "rsquare"
 			tasks: [{
 				id: "565C55FF7E131F17"
@@ -636,7 +680,7 @@
 					type: "item"
 				}
 				{
-					count: 25
+					count: 10
 					id: "4444C12BA43710E2"
 					item: {
 						count: 1
@@ -657,15 +701,26 @@
 		{
 			dependencies: ["730130CCF1CF5119"]
 			id: "7A32C50A6125E566"
-			rewards: [{
-				count: 10
-				id: "37A470F3AC9B875C"
-				item: {
-					count: 1
-					id: "relics:relic_experience_bottle"
+			rewards: [
+				{
+					count: 10
+					id: "37A470F3AC9B875C"
+					item: {
+						count: 1
+						id: "relics:relic_experience_bottle"
+					}
+					type: "item"
 				}
-				type: "item"
-			}]
+				{
+					count: 10
+					id: "4764874900DFFE6C"
+					item: {
+						count: 1
+						id: "minecraft:spore_blossom"
+					}
+					type: "item"
+				}
+			]
 			shape: "rsquare"
 			tasks: [{
 				id: "44F35B7913D884D2"
@@ -720,15 +775,26 @@
 		{
 			dependencies: ["730130CCF1CF5119"]
 			id: "6451D5022BCB5E7E"
-			rewards: [{
-				count: 10
-				id: "5DEDEDFE38AA4B89"
-				item: {
-					count: 1
-					id: "relics:relic_experience_bottle"
+			rewards: [
+				{
+					count: 10
+					id: "5DEDEDFE38AA4B89"
+					item: {
+						count: 1
+						id: "relics:relic_experience_bottle"
+					}
+					type: "item"
 				}
-				type: "item"
-			}]
+				{
+					count: 10
+					id: "6C27703503C7F794"
+					item: {
+						count: 1
+						id: "farmersdelight:ham"
+					}
+					type: "item"
+				}
+			]
 			shape: "rsquare"
 			tasks: [{
 				id: "3F89CE7A444FC6C1"
@@ -741,15 +807,26 @@
 		{
 			dependencies: ["730130CCF1CF5119"]
 			id: "748A01B5607C475B"
-			rewards: [{
-				count: 10
-				id: "1E734CA95E740CFB"
-				item: {
-					count: 1
-					id: "relics:relic_experience_bottle"
+			rewards: [
+				{
+					count: 10
+					id: "1E734CA95E740CFB"
+					item: {
+						count: 1
+						id: "relics:relic_experience_bottle"
+					}
+					type: "item"
 				}
-				type: "item"
-			}]
+				{
+					count: 10
+					id: "11CACCA0B152405A"
+					item: {
+						count: 1
+						id: "minecraft:leather"
+					}
+					type: "item"
+				}
+			]
 			shape: "rsquare"
 			tasks: [{
 				id: "244B401B38A179AF"

--- a/config/ftbquests/quests/chapters/silent_gear.snbt
+++ b/config/ftbquests/quests/chapters/silent_gear.snbt
@@ -1,0 +1,1708 @@
+{
+	default_hide_dependency_lines: false
+	default_quest_shape: ""
+	filename: "silent_gear"
+	group: "15E5B587D291A4AA"
+	icon: {
+		id: "silentgear:pickaxe_blueprint"
+	}
+	id: "1D42B373285DEF81"
+	images: [
+		{
+			height: 4.0d
+			image: "silentgear:textures/item/blueprint_package.png"
+			rotation: 0.0d
+			width: 4.0d
+			x: 11.0d
+			y: -3.0d
+		}
+		{
+			height: 1.5d
+			image: "silentgear:item/azure_repair_kit"
+			rotation: 0.0d
+			width: 1.5d
+			x: 15.0d
+			y: 3.0d
+		}
+	]
+	order_index: 1
+	progression_mode: "flexible"
+	quest_links: [ ]
+	quests: [
+		{
+			icon: {
+				id: "minecraft:wooden_pickaxe"
+			}
+			id: "52EB902E76829EBB"
+			rewards: [{
+				id: "383D184AE6F5236A"
+				type: "xp"
+				xp: 10
+			}]
+			shape: "square"
+			size: 1.5d
+			tasks: [
+				{
+					id: "0B10BF3641629974"
+					item: { components: { "ftbfiltersystem:filter": "ftbfiltersystem:item_tag(c:tools)" }, count: 1, id: "ftbfiltersystem:smart_filter" }
+					type: "item"
+				}
+				{
+					id: "498AA33867046334"
+					item: { components: { "ftbfiltersystem:filter": "ftbfiltersystem:item_tag(c:armors)" }, count: 1, id: "ftbfiltersystem:smart_filter" }
+					type: "item"
+				}
+			]
+			x: 0.0d
+			y: 0.0d
+		}
+		{
+			dependencies: ["15DE3BF0CBD8E0B4"]
+			id: "64AB1E133E218173"
+			rewards: [
+				{
+					id: "3B33A6AFBCBD24E2"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_package"
+					}
+					type: "item"
+				}
+				{
+					id: "7CB2F2AB63F23D27"
+					type: "xp"
+					xp: 50
+				}
+			]
+			size: 1.5d
+			tasks: [{
+				count: 8L
+				id: "28223BD9AC4D64EA"
+				item: { count: 1, id: "silentgear:blueprint_paper" }
+				type: "item"
+			}]
+			x: 7.0d
+			y: 0.0d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			id: "0DF4B01CC5B49E4E"
+			rewards: [
+				{
+					id: "5ABB7C89AC45EFA3"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "1B67A6B9A9ACA1F7"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "circle"
+			tasks: [{
+				id: "6916F3E24E09B0BE"
+				item: { count: 1, id: "silentgear:sword_blueprint" }
+				type: "item"
+			}]
+			x: 7.0d
+			y: -1.5d
+		}
+		{
+			dependencies: ["0DF4B01CC5B49E4E"]
+			id: "3722B43822F80470"
+			optional: true
+			rewards: [
+				{
+					id: "362958C2AC948343"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "774618BB6A0324A0"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "diamond"
+			tasks: [{
+				id: "7929CED2B31B3355"
+				item: { count: 1, id: "silentgear:katana_blueprint" }
+				type: "item"
+			}]
+			x: 8.5d
+			y: -2.0d
+		}
+		{
+			dependencies: ["0DF4B01CC5B49E4E"]
+			id: "39B85DB54B1037FE"
+			optional: true
+			rewards: [
+				{
+					id: "0ABF666C4BB065A2"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "5D79DA61255D8615"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "diamond"
+			tasks: [{
+				id: "5849539271864159"
+				item: { count: 1, id: "silentgear:machete_blueprint" }
+				type: "item"
+			}]
+			x: 5.5d
+			y: -2.0d
+		}
+		{
+			dependencies: ["0DF4B01CC5B49E4E"]
+			id: "405DCD3E36232EEA"
+			optional: true
+			rewards: [
+				{
+					id: "06CBAF48B1492F26"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "79C4D78886412643"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "diamond"
+			tasks: [{
+				id: "233073F39E676B83"
+				item: { count: 1, id: "silentgear:spear_blueprint" }
+				type: "item"
+			}]
+			x: 7.0d
+			y: -3.5d
+		}
+		{
+			dependencies: ["0DF4B01CC5B49E4E"]
+			id: "0D26E5EF6CFCFDBF"
+			optional: true
+			rewards: [
+				{
+					id: "7D4EF6BF5323E39E"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "23DF70BA1D762BF8"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "diamond"
+			tasks: [{
+				id: "27B86914A7EC8AFB"
+				item: { count: 1, id: "silentgear:knife_blueprint" }
+				type: "item"
+			}]
+			x: 6.0d
+			y: -2.5d
+		}
+		{
+			dependencies: ["0DF4B01CC5B49E4E"]
+			id: "3D2C6FF462B17205"
+			optional: true
+			rewards: [
+				{
+					id: "05143032CA342033"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "5616A1FE9E1C9876"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "diamond"
+			tasks: [{
+				id: "07A58F926DAA9F86"
+				item: { count: 1, id: "silentgear:dagger_blueprint" }
+				type: "item"
+			}]
+			x: 8.0d
+			y: -2.5d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			hide_dependency_lines: true
+			id: "766C80E5D7B7A916"
+			optional: true
+			rewards: [
+				{
+					id: "0B1F0F5F46165A85"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "64BCBA21E74A713F"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "hexagon"
+			tasks: [{
+				id: "5456E2D6253496B4"
+				item: { count: 1, id: "silentgear:pickaxe_blueprint" }
+				type: "item"
+			}]
+			x: 2.5d
+			y: 2.0d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			hide_dependency_lines: true
+			id: "52CDB46F6CBF007B"
+			optional: true
+			rewards: [
+				{
+					id: "1F854EBD7AD576D3"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "1D5665CD23D7577B"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "hexagon"
+			tasks: [{
+				id: "3BA93EF95C2D2AC7"
+				item: { count: 1, id: "silentgear:shovel_blueprint" }
+				type: "item"
+			}]
+			x: 4.5d
+			y: 2.0d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			hide_dependency_lines: true
+			id: "69383DA579901E7E"
+			optional: true
+			rewards: [
+				{
+					id: "1668B5E793DE0F61"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "16393CF47150B551"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "hexagon"
+			tasks: [{
+				id: "75DA720893D281E2"
+				item: { count: 1, id: "silentgear:axe_blueprint" }
+				type: "item"
+			}]
+			x: 3.5d
+			y: 1.5d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			hide_dependency_lines: true
+			id: "63CAD77A4488F2CE"
+			optional: true
+			rewards: [
+				{
+					id: "681CB416CA5878CF"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "77DCC9A9861155D7"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "hexagon"
+			tasks: [{
+				id: "05E69F9C3D0DC0DD"
+				item: { count: 1, id: "silentgear:paxel_blueprint" }
+				type: "item"
+			}]
+			x: 3.5d
+			y: 2.5d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			hide_dependency_lines: true
+			id: "262036FE8E87F50A"
+			optional: true
+			rewards: [
+				{
+					id: "65283560F23A0D29"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "3AFEFB85FE987FA9"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "hexagon"
+			tasks: [{
+				id: "640B83A35EB10103"
+				item: { count: 1, id: "silentgear:hammer_blueprint" }
+				type: "item"
+			}]
+			x: 3.5d
+			y: 3.5d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			hide_dependency_lines: true
+			id: "3F39BEB788175CEF"
+			optional: true
+			rewards: [
+				{
+					id: "4CDEE269556A0BE9"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "088211DEA6EB3D2D"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "hexagon"
+			tasks: [{
+				id: "0378C9FD1C97FC8E"
+				item: { count: 1, id: "silentgear:excavator_blueprint" }
+				type: "item"
+			}]
+			x: 2.5d
+			y: 3.0d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			hide_dependency_lines: true
+			id: "427516AA3E8C9442"
+			optional: true
+			rewards: [
+				{
+					id: "3A6484F9A66E77F5"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "42C8C40193610537"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "hexagon"
+			tasks: [{
+				id: "7BAEC1CCE541863A"
+				item: { count: 1, id: "silentgear:mattock_blueprint" }
+				type: "item"
+			}]
+			x: 2.5d
+			y: 4.0d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			hide_dependency_lines: true
+			id: "083ABBA1C45FF960"
+			optional: true
+			rewards: [
+				{
+					id: "77F356076080AD45"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "257FF1BA98D65896"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "hexagon"
+			tasks: [{
+				id: "1BD87FE9B7C97844"
+				item: { count: 1, id: "silentgear:sickle_blueprint" }
+				type: "item"
+			}]
+			x: 4.5d
+			y: 3.0d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			hide_dependency_lines: true
+			id: "67216EC5274F08B9"
+			optional: true
+			rewards: [
+				{
+					id: "3B978A34B39E1B39"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "302E24E8590FDCA0"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "hexagon"
+			tasks: [{
+				id: "71F08CAC734CFABA"
+				item: { count: 1, id: "silentgear:shears_blueprint" }
+				type: "item"
+			}]
+			x: 4.5d
+			y: 4.0d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			hide_dependency_lines: true
+			id: "462C1F75A2FB9F02"
+			optional: true
+			rewards: [
+				{
+					id: "25B30EB9C41D4456"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "0EB9FB31D73388A3"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "hexagon"
+			tasks: [{
+				id: "2BC129A5A112714B"
+				item: { count: 1, id: "silentgear:fishing_rod_blueprint" }
+				type: "item"
+			}]
+			x: 3.5d
+			y: 4.5d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			hide_dependency_lines: true
+			id: "6D9CDB4D81DC164D"
+			optional: true
+			rewards: [
+				{
+					id: "617E5D1AC6CA1FD4"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "470D389BAA51DCC9"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "hexagon"
+			tasks: [{
+				id: "7C2EB1E97E1F7C9D"
+				item: { count: 1, id: "silentgear:bow_blueprint" }
+				type: "item"
+			}]
+			x: 3.0d
+			y: -2.5d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			hide_dependency_lines: true
+			id: "1E8357755479E259"
+			optional: true
+			rewards: [
+				{
+					id: "78A662E99673E575"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "7B0B4D15215BEAF3"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "hexagon"
+			tasks: [{
+				id: "49B566024C78B433"
+				item: { count: 1, id: "silentgear:crossbow_blueprint" }
+				type: "item"
+			}]
+			x: 4.0d
+			y: -2.5d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			hide_dependency_lines: true
+			id: "1E2F1E036716C031"
+			optional: true
+			rewards: [
+				{
+					id: "01C930C0208E3224"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "3E6D2A16FABED66D"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "hexagon"
+			tasks: [{
+				id: "3F4C79848F8548D5"
+				item: { count: 1, id: "silentgear:slingshot_blueprint" }
+				type: "item"
+			}]
+			x: 4.0d
+			y: -1.5d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			hide_dependency_lines: true
+			id: "78C112170E17FBF4"
+			rewards: [
+				{
+					id: "1E3357F0E80C31A8"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "6C17A5CC017DDC28"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "hexagon"
+			tasks: [{
+				id: "3DA37B5163894911"
+				item: { count: 1, id: "silentgear:shield_blueprint" }
+				type: "item"
+			}]
+			x: 14.0d
+			y: -3.0d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			hide_dependency_lines: true
+			id: "6E2806D8DC61C46F"
+			rewards: [
+				{
+					id: "45A863CDD0C82A51"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "7B4EF6238B4520E7"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "square"
+			tasks: [{
+				id: "359631F5009F3B9F"
+				item: { count: 1, id: "silentgear:helmet_blueprint" }
+				type: "item"
+			}]
+			x: 15.0d
+			y: -4.5d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			hide_dependency_lines: true
+			id: "35E8C65CCA676E76"
+			rewards: [
+				{
+					id: "4272B99C9482C059"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "45EE4219EF65A85B"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "square"
+			tasks: [{
+				id: "583FCEF23D524EB6"
+				item: { count: 1, id: "silentgear:chestplate_blueprint" }
+				type: "item"
+			}]
+			x: 15.0d
+			y: -3.5d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			hide_dependency_lines: true
+			id: "22C51025DC42CDE2"
+			rewards: [
+				{
+					id: "58408A2BDEAF177A"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "6D6C3AA717281F3D"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "square"
+			tasks: [{
+				id: "7379282EA5C084B4"
+				item: { count: 1, id: "silentgear:leggings_blueprint" }
+				type: "item"
+			}]
+			x: 15.0d
+			y: -2.5d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			hide_dependency_lines: true
+			id: "6912C0E3D092DD27"
+			rewards: [
+				{
+					id: "705BF05416EAB5E3"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "76EA9F0800AA2307"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "square"
+			tasks: [{
+				id: "6C02D97660F0347C"
+				item: { count: 1, id: "silentgear:boots_blueprint" }
+				type: "item"
+			}]
+			x: 15.0d
+			y: -1.5d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			hide_dependency_lines: true
+			id: "5AB8651FCB1E2F72"
+			rewards: [
+				{
+					id: "0EA6ED38DEEC8055"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "702E736A797F5CE1"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "hexagon"
+			tasks: [{
+				id: "761B3590C99B461E"
+				item: { count: 1, id: "silentgear:elytra_blueprint" }
+				type: "item"
+			}]
+			x: 16.0d
+			y: -3.0d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			hide_dependency_lines: true
+			id: "3844877F6C1AFE77"
+			optional: true
+			rewards: [
+				{
+					id: "60D8B3C365878973"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "329CA3E0EB88E22F"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "hexagon"
+			tasks: [{
+				id: "19547966CF66B82B"
+				item: { count: 1, id: "silentgear:arrow_blueprint" }
+				type: "item"
+			}]
+			x: 3.5d
+			y: -3.5d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			hide_dependency_lines: true
+			id: "74FA25B2E087BEC4"
+			optional: true
+			rewards: [
+				{
+					id: "444412D6D63E5DC0"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "3E232C19703B8A8C"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "hexagon"
+			tasks: [{
+				id: "316B266E606B709C"
+				item: { count: 1, id: "silentgear:ring_blueprint" }
+				type: "item"
+			}]
+			x: 14.0d
+			y: -2.0d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			hide_dependency_lines: true
+			id: "21234BB40DB05C78"
+			optional: true
+			rewards: [
+				{
+					id: "5959241CDB0A69BF"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "0527B73775761460"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "hexagon"
+			tasks: [{
+				id: "6F72BC1DF6CBCDED"
+				item: { count: 1, id: "silentgear:bracelet_blueprint" }
+				type: "item"
+			}]
+			x: 16.0d
+			y: -2.0d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			id: "2EB96FF06627FD9A"
+			rewards: [
+				{
+					count: 3
+					id: "4A6DD2BFE7AB5AA1"
+					item: {
+						count: 1
+						id: "silentgear:crimson_iron_ingot"
+					}
+					type: "item"
+				}
+				{
+					id: "5BFFD11D35583183"
+					type: "xp"
+					xp: 100
+				}
+			]
+			shape: "square"
+			size: 1.25d
+			tasks: [{
+				id: "0A289918540442AE"
+				item: { count: 1, id: "silentgear:salvager" }
+				type: "item"
+			}]
+			x: 11.0d
+			y: 0.0d
+		}
+		{
+			dependencies: ["2EB96FF06627FD9A"]
+			id: "6A393C7A24899E3E"
+			rewards: [
+				{
+					count: 4
+					id: "2E59EBB44FCD4372"
+					item: {
+						count: 1
+						id: "minecraft:iron_ingot"
+					}
+					type: "item"
+				}
+				{
+					id: "426DA90F446231C4"
+					type: "xp"
+					xp: 100
+				}
+			]
+			shape: "hexagon"
+			size: 1.25d
+			tasks: [{
+				id: "202BA9A48D4D4B79"
+				item: { count: 1, id: "silentgear:material_grader" }
+				type: "item"
+			}]
+			x: 15.0d
+			y: 0.0d
+		}
+		{
+			dependencies: ["6A393C7A24899E3E"]
+			id: "6B78378BC8036227"
+			rewards: [
+				{
+					count: 3
+					id: "64AC530B334F9AD3"
+					item: {
+						count: 1
+						id: "silentgear:glowing_dust"
+					}
+					type: "item"
+				}
+				{
+					id: "5A302D12635EF77B"
+					type: "xp"
+					xp: 5
+				}
+			]
+			shape: "diamond"
+			tasks: [{
+				id: "53E64C8F26258C07"
+				item: { count: 1, id: "silentgear:glowing_dust" }
+				type: "item"
+			}]
+			x: 14.5d
+			y: 1.0d
+		}
+		{
+			dependencies: ["6A393C7A24899E3E"]
+			id: "002D65E4D7E8F62B"
+			rewards: [
+				{
+					count: 3
+					id: "256E614120A82059"
+					item: {
+						count: 1
+						id: "silentgear:blazing_dust"
+					}
+					type: "item"
+				}
+				{
+					id: "12A3F753875AE51A"
+					type: "xp"
+					xp: 5
+				}
+			]
+			shape: "diamond"
+			tasks: [{
+				id: "425E8DACC9DD35E7"
+				item: { count: 1, id: "silentgear:blazing_dust" }
+				type: "item"
+			}]
+			x: 15.0d
+			y: 1.5d
+		}
+		{
+			dependencies: ["6A393C7A24899E3E"]
+			id: "7D690A7D0FF6E328"
+			rewards: [
+				{
+					count: 3
+					id: "02ADE8B6A9044835"
+					item: {
+						count: 1
+						id: "silentgear:glittery_dust"
+					}
+					type: "item"
+				}
+				{
+					id: "7CDD443193BF52FB"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "diamond"
+			tasks: [{
+				id: "699AAD43DA73386D"
+				item: { count: 1, id: "silentgear:glittery_dust" }
+				type: "item"
+			}]
+			x: 15.5d
+			y: 1.0d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			id: "7860FD3D3273351F"
+			rewards: [
+				{
+					count: 5
+					id: "704BACF5602FB682"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "151BDF4BB67DB85D"
+					type: "xp"
+					xp: 25
+				}
+			]
+			tasks: [{
+				id: "2226DC0E053E8631"
+				item: { count: 1, id: "silentgear:blueprint_book" }
+				type: "item"
+			}]
+			x: 7.0d
+			y: 1.5d
+		}
+		{
+			dependencies: ["3930404D5C8B44EB"]
+			id: "7C3D763CF22D167A"
+			rewards: [
+				{
+					count: 3
+					id: "514A9B0ACDD05365"
+					item: {
+						count: 1
+						id: "silentgear:blaze_gold_ingot"
+					}
+					type: "item"
+				}
+				{
+					id: "5920F91CCD994BE4"
+					type: "xp"
+					xp: 100
+				}
+			]
+			shape: "diamond"
+			size: 1.75d
+			tasks: [{
+				id: "03C944C082828C47"
+				item: { count: 1, id: "silentgear:starlight_charger" }
+				type: "item"
+			}]
+			x: 20.5d
+			y: 0.0d
+		}
+		{
+			dependencies: ["657B3116A6419420"]
+			id: "158B24939A269D83"
+			rewards: [
+				{
+					id: "1A8ED8E2D648AA60"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "0015CE0C0E03D273"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "diamond"
+			tasks: [{
+				id: "4ECD1D119E695CBD"
+				item: { count: 1, id: "silentgear:tip_blueprint" }
+				type: "item"
+			}]
+			x: 6.0d
+			y: 4.0d
+		}
+		{
+			dependencies: ["657B3116A6419420"]
+			id: "0947B4ED95B0267E"
+			rewards: [
+				{
+					id: "32D1C12F611934DA"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "65AF9DF07F572E74"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "diamond"
+			tasks: [{
+				id: "3179733D8ACBDA86"
+				item: { count: 1, id: "silentgear:coating_blueprint" }
+				type: "item"
+			}]
+			x: 6.5d
+			y: 4.5d
+		}
+		{
+			dependencies: ["657B3116A6419420"]
+			id: "6BFD7854F078BF16"
+			rewards: [
+				{
+					id: "089D17012703D035"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "2D13A1F9FE3FE897"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "diamond"
+			tasks: [{
+				id: "14B8204814A42B33"
+				item: { count: 1, id: "silentgear:grip_blueprint" }
+				type: "item"
+			}]
+			x: 7.5d
+			y: 4.5d
+		}
+		{
+			dependencies: ["657B3116A6419420"]
+			id: "22A0A9C81A5C85A1"
+			rewards: [
+				{
+					id: "6B13898B0660D806"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "260328468BF2267C"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "diamond"
+			tasks: [{
+				id: "551DBAFE45DC4804"
+				item: { count: 1, id: "silentgear:binding_blueprint" }
+				type: "item"
+			}]
+			x: 8.0d
+			y: 4.0d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			hide_dependency_lines: true
+			id: "2098D8BFADB55D2A"
+			optional: true
+			rewards: [
+				{
+					id: "72FDE25C9429EE01"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "4538A6EE91CF91C0"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "hexagon"
+			tasks: [{
+				id: "3CB5441C8E4480CC"
+				item: { count: 1, id: "silentgear:lining_blueprint" }
+				type: "item"
+			}]
+			x: 16.0d
+			y: -4.0d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			hide_dependency_lines: true
+			id: "3F56A5253D477B97"
+			optional: true
+			rewards: [
+				{
+					id: "3B42B6C82B9DC336"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "7B359A77985016A0"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "hexagon"
+			tasks: [{
+				id: "58407186583371FA"
+				item: { count: 1, id: "silentgear:fletching_blueprint" }
+				type: "item"
+			}]
+			x: 3.0d
+			y: -1.5d
+		}
+		{
+			dependencies: ["7860FD3D3273351F"]
+			id: "657B3116A6419420"
+			rewards: [
+				{
+					id: "0ECB82A5E60CB3D7"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "7D4E5FA98A8C8DC8"
+					type: "xp"
+					xp: 10
+				}
+			]
+			tasks: [{
+				id: "146DFBC42B522A36"
+				item: { count: 1, id: "silentgear:rod_blueprint" }
+				type: "item"
+			}]
+			x: 7.0d
+			y: 3.0d
+		}
+		{
+			dependencies: ["6A393C7A24899E3E"]
+			id: "3930404D5C8B44EB"
+			rewards: [
+				{
+					count: 3
+					id: "02BF731EB9C877A9"
+					item: {
+						count: 1
+						id: "silentgear:crimson_steel_ingot"
+					}
+					type: "item"
+				}
+				{
+					id: "2A50AB8483F114F2"
+					type: "xp"
+					xp: 100
+				}
+			]
+			size: 1.25d
+			tasks: [{
+				id: "7F18323AEA5BF486"
+				item: { count: 1, id: "silentgear:alloy_forge" }
+				type: "item"
+			}]
+			x: 17.5d
+			y: 0.0d
+		}
+		{
+			dependencies: ["7C3D763CF22D167A"]
+			id: "7E13007340A818C5"
+			rewards: [
+				{
+					count: 3
+					id: "726D3F0AFC299157"
+					item: {
+						count: 1
+						id: "silentgear:crimson_steel_ingot"
+					}
+					type: "item"
+				}
+				{
+					id: "4FE0EE97B26B065E"
+					type: "xp"
+					xp: 100
+				}
+			]
+			shape: "circle"
+			tasks: [{
+				id: "29FFC1A3BFF17BBC"
+				item: { count: 4, id: "silentgear:crimson_steel_block" }
+				type: "item"
+			}]
+			x: 18.5d
+			y: -2.0d
+		}
+		{
+			dependencies: ["7C3D763CF22D167A"]
+			id: "29131C3532610ADF"
+			rewards: [
+				{
+					count: 3
+					id: "26F88065FA41600C"
+					item: {
+						count: 1
+						id: "silentgear:azure_electrum_ingot"
+					}
+					type: "item"
+				}
+				{
+					id: "0962E384BB408452"
+					type: "xp"
+					xp: 100
+				}
+			]
+			shape: "circle"
+			tasks: [{
+				id: "5EB5C4ECB49D1A4B"
+				item: { count: 1, id: "silentgear:azure_electrum_block" }
+				type: "item"
+			}]
+			x: 20.5d
+			y: -2.5d
+		}
+		{
+			dependencies: ["7C3D763CF22D167A"]
+			id: "3B560B2ECE331CAF"
+			rewards: [
+				{
+					count: 3
+					id: "5B4F394C75229DA8"
+					item: {
+						count: 1
+						id: "silentgear:tyrian_steel_ingot"
+					}
+					type: "item"
+				}
+				{
+					id: "2D2BAC3F5A4E447F"
+					type: "xp"
+					xp: 100
+				}
+			]
+			shape: "circle"
+			tasks: [{
+				id: "68EF78DC95598D3B"
+				item: { count: 1, id: "silentgear:tyrian_steel_block" }
+				type: "item"
+			}]
+			x: 22.5d
+			y: -2.0d
+		}
+		{
+			dependencies: ["7C3D763CF22D167A"]
+			id: "48D358470A019E7A"
+			rewards: [
+				{
+					count: 3
+					id: "11895ED684B965A5"
+					item: {
+						count: 1
+						id: "silentgear:blaze_gold_dust"
+					}
+					type: "item"
+				}
+				{
+					id: "76EEEF6924214EEA"
+					type: "xp"
+					xp: 50
+				}
+			]
+			shape: "circle"
+			tasks: [{
+				id: "2276AE38B913787C"
+				item: { count: 1, id: "silentgear:blaze_gold_dust" }
+				type: "item"
+			}]
+			x: 19.5d
+			y: -1.0d
+		}
+		{
+			dependencies: ["7C3D763CF22D167A"]
+			id: "2BF119DD5D977409"
+			rewards: [
+				{
+					count: 3
+					id: "628BD6D6D899D5E2"
+					item: {
+						count: 1
+						id: "silentgear:azure_silver_dust"
+					}
+					type: "item"
+				}
+				{
+					id: "01A07D4EC1D447D5"
+					type: "xp"
+					xp: 50
+				}
+			]
+			shape: "circle"
+			tasks: [{
+				id: "0948B07BD000E2A2"
+				item: { count: 1, id: "silentgear:azure_silver_dust" }
+				type: "item"
+			}]
+			x: 20.5d
+			y: -1.5d
+		}
+		{
+			dependencies: ["7C3D763CF22D167A"]
+			id: "0FEAD3CA2CC4A8B1"
+			rewards: [
+				{
+					count: 3
+					id: "149C0884AF0F9C96"
+					item: {
+						count: 1
+						id: "silentgear:starmetal_dust"
+					}
+					type: "item"
+				}
+				{
+					id: "3645936047468429"
+					type: "xp"
+					xp: 50
+				}
+			]
+			shape: "circle"
+			tasks: [{
+				id: "4B244AC889982750"
+				item: { count: 1, id: "silentgear:starmetal_dust" }
+				type: "item"
+			}]
+			x: 21.5d
+			y: -1.0d
+		}
+		{
+			dependencies: ["15DE3BF0CBD8E0B4"]
+			hide_dependency_lines: true
+			id: "11B0B93D725ABE43"
+			rewards: [{
+				id: "5B2A96E10ADDA704"
+				type: "xp"
+				xp: 50
+			}]
+			shape: "rsquare"
+			size: 1.5d
+			tasks: [{
+				id: "2FEC915DC58F30C4"
+				item: { components: { "ftbfiltersystem:filter": "ftbfiltersystem:item_tag(silentgear:repair_kits)" }, count: 1, id: "ftbfiltersystem:smart_filter" }
+				type: "item"
+			}]
+			x: 15.0d
+			y: 4.5d
+		}
+		{
+			dependencies: ["7B690431CF1B87D0"]
+			id: "15DE3BF0CBD8E0B4"
+			rewards: [{
+				id: "55AD7084DF68E820"
+				type: "xp"
+				xp: 10
+			}]
+			tasks: [{
+				id: "2ADE9DBE9448AC7F"
+				item: { count: 1, id: "silentgear:pickaxe" }
+				type: "item"
+			}]
+			x: 4.5d
+			y: 0.0d
+		}
+		{
+			dependencies: ["52EB902E76829EBB"]
+			icon: {
+				id: "silentgear:pickaxe_head"
+			}
+			id: "7B690431CF1B87D0"
+			rewards: [
+				{
+					count: 8
+					id: "02F9EAB98F91686F"
+					item: {
+						count: 1
+						id: "silentgear:template_board"
+					}
+					type: "item"
+				}
+				{
+					id: "70451634EBBAFA04"
+					type: "xp"
+					xp: 10
+				}
+			]
+			tasks: [
+				{
+					count: 4L
+					id: "1ABEFFE6204BD2AD"
+					item: { count: 1, id: "silentgear:template_board" }
+					type: "item"
+				}
+				{
+					id: "64F6638FCD946102"
+					item: { count: 1, id: "silentgear:pickaxe_template" }
+					type: "item"
+				}
+				{
+					id: "489419C982E77CD2"
+					item: { count: 1, id: "silentgear:pickaxe_head" }
+					type: "item"
+				}
+			]
+			x: 2.5d
+			y: 0.0d
+		}
+		{
+			dependencies: ["0DF4B01CC5B49E4E"]
+			id: "694D7CD9EC663355"
+			optional: true
+			rewards: [
+				{
+					id: "1326AF6FE557A430"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "24810FCDB4DF5F96"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "diamond"
+			tasks: [{
+				id: "282C4C82D8606426"
+				item: { count: 1, id: "silentgear:mace_blueprint" }
+				type: "item"
+			}]
+			x: 6.5d
+			y: -3.0d
+		}
+		{
+			id: "769D5DE66D13B256"
+			invisible: true
+			optional: true
+			shape: "circle"
+			tasks: [
+				{
+					id: "6D9DBD885FE4C94C"
+					type: "checkmark"
+				}
+				{
+					id: "55E0635973A828B0"
+					type: "checkmark"
+				}
+			]
+			x: -1.5d
+			y: 0.0d
+		}
+		{
+			dependencies: ["52EB902E76829EBB"]
+			id: "7043CDA7EBFAF560"
+			rewards: [
+				{
+					id: "0A94A82D98D5F223"
+					item: {
+						count: 1
+						id: "silentgear:coating_smithing_template"
+					}
+					type: "item"
+				}
+				{
+					id: "6FA6CE79EB12EF2D"
+					type: "xp"
+					xp: 50
+				}
+			]
+			tasks: [{
+				id: "7E448E8BE375C457"
+				item: { count: 1, id: "silentgear:coating_smithing_template" }
+				type: "item"
+			}]
+			x: 1.5d
+			y: -1.5d
+		}
+		{
+			dependencies: ["64AB1E133E218173"]
+			hide_dependency_lines: true
+			id: "7098F24BC8FAC749"
+			optional: true
+			rewards: [
+				{
+					id: "1928B8CF56CF3C3D"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "4CAA3A56D4CE21E2"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "hexagon"
+			tasks: [{
+				id: "4CAF4931EB7B2C4A"
+				item: { count: 1, id: "silentgear:necklace_blueprint" }
+				type: "item"
+			}]
+			x: 14.0d
+			y: -4.0d
+		}
+		{
+			dependencies: ["0DF4B01CC5B49E4E"]
+			id: "222D08F43B995FED"
+			optional: true
+			rewards: [
+				{
+					id: "2B3E13D6871A834F"
+					item: {
+						count: 1
+						id: "silentgear:blueprint_paper"
+					}
+					type: "item"
+				}
+				{
+					id: "2A15109D5679690E"
+					type: "xp"
+					xp: 10
+				}
+			]
+			shape: "diamond"
+			tasks: [{
+				id: "28ACA9420900F422"
+				item: { count: 1, id: "silentgear:trident_blueprint" }
+				type: "item"
+			}]
+			x: 7.5d
+			y: -3.0d
+		}
+		{
+			dependencies: ["2EB96FF06627FD9A"]
+			id: "3AC03D1FA5C341A7"
+			rewards: [
+				{
+					count: 3
+					id: "0FE25ED785E73A0E"
+					item: {
+						count: 1
+						id: "silentgear:azure_electrum_ingot"
+					}
+					type: "item"
+				}
+				{
+					id: "626F1042179E253B"
+					type: "xp"
+					xp: 50
+				}
+			]
+			size: 1.25d
+			tasks: [{
+				id: "09B42553C6DF48E5"
+				item: { count: 1, id: "silentgear:recrystallizer" }
+				type: "item"
+			}]
+			x: 11.0d
+			y: 2.5d
+		}
+	]
+}

--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -11,6 +11,7 @@
 	chapter.18A429E7F56AF5A9.title: "Bounty Board"
 	chapter.193F91842D2ED7D9.title: "Industrial Foregoing"
 	chapter.1BE666F01EFFC00D.title: "Tips and Tricks"
+	chapter.1D42B373285DEF81.title: "Silent Gear"
 	chapter.1DB294A8F8686321.title: "Basic Storage"
 	chapter.1FAAEF0B9FD05CB9.title: "Productive Trees"
 	chapter.23983F4DC524B14B.title: "Mekanism"
@@ -27,7 +28,7 @@
 	chapter.4B9D26E0087CD163.title: "Basic Tools"
 	chapter.4C507C004144BFEE.title: "Occultism"
 	chapter.4EAAE0CEB26378A6.title: "Just Dire Things"
-	chapter.5103E2D95685ADFF.title: "&aChapter 2&r: &6The ATM Star&r"
+	chapter.5103E2D95685ADFF.title: "&aChapter 2&r: &6The ATM Star"
 	chapter.5712300EF4E5E846.title: "Pylons"
 	chapter.59395B6806F2A98A.title: "Cataclysm"
 	chapter.5B00676D79306EA2.title: "Welcome"
@@ -426,7 +427,7 @@
 	quest.046C417B2ADF3AA7.quest_desc: ["Cards have their limits. Item Extration can only extract 8 items per Operation. Fluid Extract at only 5 Buckets. God knows with Chemical and Energy. \\n\\nThis is Modded &2&lMinecraft&r these limits won't suffice we need to Overclock them. \\n\\nThrow some Overclockers in the top right of the Card and it'll upgrade the cap they can transfer!"]
 	quest.046C417B2ADF3AA7.quest_subtitle: "Max: 4"
 	quest.0480DF316ACF12DA.quest_subtitle: "Western Hemlock + Jungle"
-	quest.0484051446480B54.quest_desc: ["Crap ton of damage, and chops down trees! What more do you need!"]
+	quest.0484051446480B54.quest_desc: ["Does a ton of damage, and chops down trees! What more do you need?"]
 	quest.0484051446480B54.title: "&6Allthemodium &5Alloy &3Axe&r"
 	quest.048BD38532A1DDCF.quest_subtitle: "Holds a max of 1M LP"
 	quest.048F2942436D3C46.title: "&6Master of The Sky&r"
@@ -474,6 +475,9 @@
 		"Now you can pump in air from your Air Compressors to increase the pressure. We need it to hit 4.9 to craft the Black Hole!"
 	]
 	quest.04C7B49076E48841.title: "&aThe Pressure Chamber&r"
+	quest.04D0543FE2820F64.quest_desc: ["Flax String can be used in replace of normal String."]
+	quest.04D0543FE2820F64.quest_subtitle: "Who needs Spiders anyway?"
+	quest.04D0543FE2820F64.title: "Flax String"
 	quest.04D9F6587EF8D9B7.quest_desc: ["The &9Potion Jar&r stores up to 100 potions. You can remove them by using an empty bottle or a potion flask on the jar. \\n\\nWixies will use these jars during Potion Autocrafting."]
 	quest.04D9F6587EF8D9B7.quest_subtitle: "Storing Potions"
 	quest.04DEC6E210F06D65.quest_subtitle: "Balsa + Cocobolo"
@@ -522,9 +526,8 @@
 	quest.0573B6F1BE5110FD.quest_desc: ["Minecraft Bees are adorable but the limited things Honey gives us isn't enough to justify the work to get it. \\n\\nWell unless you can get just about anything from the Bees, then that'd be different!"]
 	quest.0573B6F1BE5110FD.title: "Productive Bees"
 	quest.0583862ED0114442.quest_subtitle: "&f4 &cAttack Damage"
-	quest.05850541675B2493.quest_desc: ["It does. \\n\\nYou've gone and done the hardest of the Mods we have here and you have showed they are no sweat. You have created the ATM Star, that means you have beat the Modpack! \\n\\nBut what's next?"]
-	quest.05850541675B2493.quest_subtitle: "I think this means you won"
-	quest.0583862ED0114442.quest_subtitle: "&f4 &cAttack Damage"
+	quest.05850541675B2493.quest_desc: ["It does. \\n\\nYou have created the ATM Star, that means you have beat the modpack!\\n\\nSo what's next?"]
+	quest.05850541675B2493.quest_subtitle: "Does this mean you win?"
 	quest.0589911EB4D30FAD.quest_desc: ["&l&cRegions Unexplored&r also adds the ability for you to paint Planks as if they were Wool or Glass! "]
 	quest.0589911EB4D30FAD.title: "Painted Planks"
 	quest.0591CAFD665CE151.quest_subtitle: "Tier: &b4"
@@ -743,8 +746,7 @@
 	quest.0830195863384CF0.title: "&bStrata Salt"
 	quest.0837E35C9C6881B4.quest_subtitle: "Increases RF Capacity and Transfer Rate"
 	quest.0837E35C9C6881B4.title: "Expanded RF Coil"
-	quest.083ABBA1C45FF960.quest_subtitle: "It's a Lawn Mower."
-	quest.083ABBA1C45FF960.title: "Sickle Blueprint"
+	quest.083ABBA1C45FF960.quest_subtitle: "Just a Lawn Mower"
 	quest.083D458032F0325C.quest_desc: ["The &bME Export Bus&f periodically spits items in its whitelist filter out to whatever external storage the bus is facing. Unlike the Import Bus, the Export Bus cannot work without being filtered."]
 	quest.083D458032F0325C.quest_subtitle: "The O"
 	quest.08457BEED799E600.quest_desc: ["These new &7Carts&r are mostly for laying down &6Tracks&r.\\n\\nThe &7Track Layer&r places down &6Tracks&r while the &7Track Remover&r removes &6Tracks&r.\\n\\nThe &7Track Relayer&r replaces the &6Tracks&r with different ones and the &7Track UnderCutter&r replaces the blocks beneath the &6Tracks&r."]
@@ -825,13 +827,8 @@
 	quest.092A23FDA5D50812.quest_subtitle: "Tier: &a2"
 	quest.09408C6DCAC90318.quest_desc: ["This block stores power, and can also be used to charge items."]
 	quest.09408C6DCAC90318.quest_subtitle: "Storing Power"
-	quest.0947B4ED95B0267E.quest_desc: [
-		"Coats an item or tool. "
-		""
-		"Netherite makes a great coating material."
-	]
-	quest.0947B4ED95B0267E.quest_subtitle: "Totally not just for Netherite."
-	quest.0947B4ED95B0267E.title: "Coating Blueprint"
+	quest.0947B4ED95B0267E.quest_desc: ["Coats an items and tools.\\n\\nNetherite makes a great coating material."]
+	quest.0947B4ED95B0267E.quest_subtitle: "Totally not just for Netherite"
 	quest.09485B63483B7A15.quest_desc: [
 		"&lAbility Type:&r Active"
 		""
@@ -920,7 +917,7 @@
 		"Yes, we are not direclty utilizing this immediately. But setting it up now to craft and collect will be very beneficial, and save you a ton of time!"
 	]
 	quest.0A1BACA070EB5264.quest_subtitle: "Star Matter"
-	quest.0A1C2A7A8617D3E4.quest_subtitle: "Speedrunners Love This Stuff"
+	quest.0A1C2A7A8617D3E4.quest_subtitle: "Speedrunners Love this Stuff"
 	quest.0A1C2A7A8617D3E4.title: "Wheat"
 	quest.0A1D4228271DECA3.quest_desc: ["Where'd you go?\\n\\nOh you're just half your previous size. Small enough to fit beneath a 1 Block gap."]
 	quest.0A1D4228271DECA3.quest_subtitle: "Necklace"
@@ -969,7 +966,7 @@
 	quest.0AD2B11565B484E7.title: "&cR&6a&ei&2n&3b&9o&5w &cP&6l&ea&2t&3i&9n&5g"
 	quest.0ADBE90B33ACC9FB.quest_desc: ["The &cR&6a&ei&2n&3b&9o&5w&r &cG&6e&en&2e&3r&9a&5t&ce&6r&r is a boost to the &cR&6a&ei&2n&3b&9o&5w&r &cF&6u&er&2n&3a&9c&5e&r while using &3Augment&r: Generator. If all other 8 Furnaces (not counting &5Netherite Furnace&r) are around the &cR&6a&ei&2n&3b&9o&5w&r &cF&6u&er&2n&3a&9c&5e&r, have &3Augment&r: Generator, and are actively making Energy (fueled up and not full) they will give a boost to a &cR&6a&ei&2n&3b&9o&5w&r &cF&6u&er&2n&3a&9c&5e&r that has &3Augment&r: Generator and is working. It will make 50kFE a tick more!"]
 	quest.0ADBE90B33ACC9FB.title: "&cR&6a&ei&2n&3b&9o&5w &cG&6e&en&2e&3r&9a&5t&ce&6r"
-	quest.0AE28C998A3BF136.quest_subtitle: "531,441 Blocks of Netherrack"
+	quest.0AE28C998A3BF136.quest_subtitle: "531,441 Netherrack"
 	quest.0AEAEA976ED0C470.quest_desc: ["The &3Charging Station&r is used to charge various tools and gadgets in &aPneumaticCraft&r using pressure."]
 	quest.0AEAEA976ED0C470.quest_subtitle: "Where's the cord?"
 	quest.0AEC181F5E21A299.quest_desc: [
@@ -1139,9 +1136,8 @@
 	quest.0D20644407244A60.title: "Nether Layer Ores"
 	quest.0D259B9B93B39FAE.quest_desc: ["This is an expensive component to build out. But you will be needing a few of these as we continue to progress. There are a few different multiblocks that rely on the ZPM Field Generator."]
 	quest.0D259B9B93B39FAE.quest_subtitle: "Espensive, but worth it"
-	quest.0D26E5EF6CFCFDBF.quest_desc: ["Higher Durability than a dagger, but lower damage and speed."]
-	quest.0D26E5EF6CFCFDBF.quest_subtitle: "Stabby."
-	quest.0D26E5EF6CFCFDBF.title: "Knife Blueprint"
+	quest.0D26E5EF6CFCFDBF.quest_desc: ["Higher Durability than a Dagger, but lower damage and speed."]
+	quest.0D26E5EF6CFCFDBF.quest_subtitle: "Stabby"
 	quest.0D2C935F99D1A1FE.quest_desc: [
 		"Navigating through our &aEngineer's Manual&r, you can find the &aSqueezer&r in the &eHeavy Machinery&r category. "
 		""
@@ -1226,13 +1222,8 @@
 	quest.0DC8B68CDF945348.quest_desc: ["The Router giveth and the Router taketh. \\n\\nThis Module is helpful for Builders or even Miners! It can be set to send items from its Buffer to your Inventory or take items from your Inventory into its Buffer. \\n\\nPerfect for Strip-Mining, have it take all the Cobble and Deepslate from your Inventory and put it in a Trash Can."]
 	quest.0DD389A24F5F8CDD.quest_desc: ["&l&6Aqua Regia&r&r is a mixture of Concentrated Nitric Acid and Hydrochloric Acid, usually one part to three parts, respectively. The Mixture was given its name (literally \\\"Royal Water\\\") by alchemists because of its ability to dissovle &l&eGold&r&r."]
 	quest.0DD389A24F5F8CDD.quest_subtitle: "Im a Barbie Girl, In a Barbie world... If you know, you know."
-	quest.0DF4B01CC5B49E4E.quest_desc: [
-		"Everyone loves the sword. "
-		""
-		"With this blueprint, you can make the basic sword! Reliable damage, reliable speed."
-	]
-	quest.0DF4B01CC5B49E4E.quest_subtitle: "Ol' Reliable"
-	quest.0DF4B01CC5B49E4E.title: "Sword Blueprint"
+	quest.0DF4B01CC5B49E4E.quest_desc: ["With this Blueprint, you can make the basic sword! Reliable damage and reliable speed."]
+	quest.0DF4B01CC5B49E4E.quest_subtitle: "Good ol' Reliable"
 	quest.0DF9014435C8F4D2.quest_desc: [
 		"You might be wondering why I forced Nickel Zinc Ferrite ingots on you, and this recipe is exactly why! "
 		""
@@ -1245,9 +1236,9 @@
 	quest.0E03F5EAE4963ECB.quest_subtitle: "8 Dry Green Blocks"
 	quest.0E057B7F76401421.quest_subtitle: "The First Upgrade"
 	quest.0E057B7F76401421.title: "Iron Backpack"
+	quest.0E0CAA31480EC0A1.quest_desc: ["Allows the Backpack to pick up items."]
 	quest.0E0CAA31480EC0A1.quest_subtitle: "Allows the backpack to pick up items."
 	quest.0E0CAA31480EC0A1.title: "Pickup Upgrade"
-	quest.0E0CAA31480EC0A1.quest_desc: ["Allows the Backpack to pick up items."]
 	quest.0E20A9B79D1C6637.title: "Kill The Warden"
 	quest.0E25CDB09FE88A63.title: "Saltpeter Seeds"
 	quest.0E2AD156E5EF263A.quest_desc: ["Used to inscribe spells on with the Scribe's Table."]
@@ -1371,7 +1362,7 @@
 	quest.0F03E75CF79BADD7.quest_subtitle: "Bulk and cut"
 	quest.0F03E75CF79BADD7.title: "Bulk Item Storage"
 	quest.0F16498769DFB3B0.quest_desc: ["This will be the main ingredient for most of this mod's items and blocks."]
-	quest.0F1CA44520BDEFEA.quest_subtitle: "Only 6,561 Diamond Blocks, that's not bad!"
+	quest.0F1CA44520BDEFEA.quest_subtitle: "6,561 Diamond Blocks"
 	quest.0F326EEEC2EBE4E5.quest_desc: [
 		"Using the Enrichment Chamber, you can enrich items to convert them into Enriched variants."
 		""
@@ -1531,15 +1522,8 @@
 	]
 	quest.1194FF35ADAA9957.quest_subtitle: "Sharks with Laser beams?"
 	quest.11AAA1DCB452DFFC.quest_subtitle: "For"
-	quest.11B0B93D725ABE43.quest_desc: [
-		"Silent Gear items can be repaired using a &9Repair Kit&r. "
-		""
-		"To repair an item, place the Repair Kit into a crafting table, then place the materials needed to repair the tool inside the table with it. This will 'fill' the Repair Kit. "
-		""
-		"To repair the tool, combine the filled Repair Kit with the tool you'd like to repair in a crafting grid."
-	]
-	quest.11B0B93D725ABE43.quest_subtitle: "Your First Repair Kit"
-	quest.11B0B93D725ABE43.title: "Repairing Items"
+	quest.11B0B93D725ABE43.quest_desc: ["Silent Gear gear can be repaired using a &9Repair Kit&r.\\n\\nTo repair an item, place the Repair Kit into a crafting grid, then place the materials needed to repair the tool in with it. This will \"fill\" the Repair Kit.\\n\\nTo repair the tool, combine the filled Repair Kit with the tool you'd like to repair in a crafting grid."]
+	quest.11B0B93D725ABE43.quest_subtitle: "No Anvils required"
 	quest.11B1FB0AB2677902.quest_subtitle: "Balsa + Silver Lime"
 	quest.11B8C5F88DCB3BF5.title: "What Happens Next?"
 	quest.11C0233861D3DD0C.quest_desc: [
@@ -1580,7 +1564,7 @@
 	quest.11D4EEAC61C7E530.quest_desc: ["The Collector Upgrade will make the Drawer vacuum items in from one of the sides."]
 	quest.11D57C768032E3F7.quest_subtitle: "More Filtering Options"
 	quest.11D57C768032E3F7.title: "&eAdvanced Magnet Upgrade"
-	quest.11E957CDEFA0CAAB.quest_desc: ["Everyone missed the Void Worlds added from some Mods so ATM made their own! \\nWelcome to &5&lThe Beyond&r! \\n\\nThere's nothing here! \\n\\nYou might want an Angel Block."]
+	quest.11E957CDEFA0CAAB.quest_desc: ["Welcome to &5&lThe Beyond&r! \\n\\nThere's nothing here! \\n\\nYou might want an Angel Block."]
 	quest.11E957CDEFA0CAAB.title: "&5&lThe Beyond"
 	quest.11F7D3DDF5683EB3.quest_desc: [
 		"Uses a laser and specific lenses to engrave different patterns on the wafers"
@@ -1923,13 +1907,8 @@
 	]
 	quest.1569CD190336F5F6.quest_subtitle: "Assembler but with Circuits!"
 	quest.156FF8B7B724DC38.quest_desc: ["Adds a filter for items being pumped in or out of the Backpack."]
-	quest.158B24939A269D83.quest_desc: [
-		"The tip upgrade is used to increase the mining level of the tool. "
-		""
-		"For example: If you have an iron pickaxe with 1 diamond, you can make a Diamond Tip Upgrade, and place it on your pickaxe. This will allow it to mine obsidian, as well as give it a stat boost."
-	]
-	quest.158B24939A269D83.quest_subtitle: "For when you didn't find 3 diamonds."
-	quest.158B24939A269D83.title: "Tip Upgrade Blueprint"
+	quest.158B24939A269D83.quest_desc: ["The Tip Upgrade is used to increase the mining level of a tool.\\n\\nFor example: If you have an Iron Pickaxe, with 1 Diamond, you can make a Diamond Tip Upgrade, and place it on your pickaxe. This will allow it to mine Obsidian, as well as give it a stat boost."]
+	quest.158B24939A269D83.quest_subtitle: "For when you don't find 3 Diamonds"
 	quest.158F13367C2E0C6D.quest_desc: [
 		"To start our first ritual, you'll need Soul Shards."
 		"Craft a Brazier, this will burn the \\\"important\\\" item to start a ritual."
@@ -1958,15 +1937,7 @@
 		"The Dissolution Chamber is a Machine added by &l&7Industrial Foregoing&r. It's also how we'll combine &3Vibranium&r and &5Unobtainium&r. \\n\\nYou'll need &dPink Slime&r which you get from the Mob Slaughter Factory which is another Machine added by IF. \\n\\nYou'll also need Soul Lava which is found in &b&lThe Other&r, common in the Piglin Village. \\n\\nAfter those you'll need to put your Ingots and Piglich Hearts in the exact order, power it, and it'll be done!\\n"
 		"{ \"text\": \"INDUSTRIAL FOREGOING QUESTLINE\", \"color\": \"#55FF55\", \"underlined\": true, \"clickEvent\": { \"action\": \"change_page\", \"value\": \"193F91842D2ED7D9\" } }"
 	]
-	quest.15DE3BF0CBD8E0B4.quest_desc: [
-		"To make your first tool, take your Pickaxe Head part and put it into the crafting table. "
-		""
-		"To create a full pickaxe, you can either add a stick to the crafting table, or create your own custom handle using a &9Tool Rod Template&r instead of using a stick. "
-		""
-		"*Note: You can always search up the templates and then press U on it, then navigate to the 'Gear Crafting' tab. This will show you how to make gear parts."
-	]
-	quest.15DE3BF0CBD8E0B4.quest_subtitle: "Or At Least How To Make It"
-	quest.15DE3BF0CBD8E0B4.title: "Your First Tool!"
+	quest.15DE3BF0CBD8E0B4.quest_desc: ["To make your first tool, take your Pickaxe Head part and put it in a crafting grid.\\n\\nTo create a full pickaxe, you can either add a Stick to the crafting grid, or create your own custom handle using a &9Tool Rod Template&r instead.\\n\\nNote: You can always search up the templates and then press check it's uses in JEI, then navigate to the \"Gear Crafting\" tab. This will show you how to make gear parts."]
 	quest.15ECBC8E174FA39B.quest_desc: ["Allows you to access your storage wirelessly."]
 	quest.15ECBC8E174FA39B.title: "Wireless Grid"
 	quest.15FEA03A2CDBA33B.quest_desc: ["&b&lThe Other&r has seen dozens of changes over the years but always it has been a realm for adventures! \\n\\nThere's dozens of new biomes, blocks, and of course structures! \\n\\nThe Structures are: Piglin Village, Ancient Pyramid, and Dungeon. All containing amazing loot with some things being unique to their structure! \\n\\nYou can also mine for &3Vibranium&r (and other ores!) or find it and better in the structures! \\n\\nYou can't set up Quarries or many blocks in &b&lThe Other&r though, no cheesing anything here."]
@@ -2033,6 +2004,7 @@
 		"See, that wasn't so bad was it?"
 	]
 	quest.16A6C47E35F3B9D0.title: "&3Fissile Fuel"
+	quest.16AAC61729C44881.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks.\\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission.\\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
 	quest.16B44F78707E148E.quest_desc: ["While not necessary, the IV Macerator will give you a speed boost on processing Sheldonite, as this processing line can be quite &n&l&2TimeConsuming.&r&r&r"]
 	quest.16B44F78707E148E.quest_subtitle: "Hey, Macerator, Yaaah!"
 	quest.16B88F46021E956D.quest_desc: ["&l&6Theurgy&r has Machines so of course it needs Logistics!\\n\\n(Check out the Basic Logistics Page to learn more about logistics).\\n\\nWith &cMercury&r you can move Items and Fluids from place to place using &cMercury Wires&r and other Items! Wires are what will actually move the Items."]
@@ -2081,10 +2053,9 @@
 	quest.1744E700CF742CE2.quest_desc: ["&5The Coralssus&r works as a Guard and Steed for the &5Sunken City&r. They're used with the &5Deeplings&r but he's different so he gets his own quest! They have only 110 Hearts and basic attacks but the &5Deeplings&r with them make it much more dangerous. Its attacks are just smacking and throwing you. When killed it'll drop Crystalized Coral which is needed to make the Abyssal Sacrifice."]
 	quest.1744E700CF742CE2.title: "&5Coralssus&r"
 	quest.174D18D9D732EC10.quest_subtitle: "8 Wet Green Blocks"
-	quest.17542D7633FBF098.quest_desc: ["Something had to give it its Star shape!"]
+	quest.17542D7633FBF098.quest_desc: ["Too bad SpongeBob isn't a Star."]
 	quest.1756F81ACFC56C58.quest_subtitle: "&eTier 5"
 	quest.17598C171E610752.quest_desc: ["I don't even know what to say for this. I'm getting lost looking through the recipes. I'd rather list out all the Family Trees for Productive Trees. \\n\\nGet Advanced Motors and combine them with Titanium Rods and a Processing Unit to make the Large Advacnced Motor."]
-	quest.1756F81ACFC56C58.quest_subtitle: "&eTier 5"
 	quest.175D943160C10646.quest_desc: [
 		"&l&7RailCraft&r uses many machines for different things but mostly resource creation."
 		""
@@ -2239,6 +2210,8 @@
 	]
 	quest.18E0F5A78F696FA3.quest_desc: ["Echo shards give a special effect to the spawner. Any mobs spawned will have the loot that they drop multiplied."]
 	quest.18E0F5A78F696FA3.title: "Echoing"
+	quest.18EADBAFC932F864.quest_desc: ["To shear Sheep you need Shears, you wouldn't get Wool any other way...right?"]
+	quest.18EADBAFC932F864.quest_subtitle: "Pacifist Run"
 	quest.18EADBAFC932F864.title: "It's Clippin' Time"
 	quest.18EB86F91CBBCCC6.quest_desc: ["Not all Cataclysm Dungeons are as easy to find as the Pyramids are, so a special Eye might help you find them. Each of the different Eyes will lead you to its set structure, and don't worry them breaking is very rare."]
 	quest.18EB86F91CBBCCC6.title: "Eye see you!"
@@ -2283,7 +2256,7 @@
 		""
 		"Let's combine ethylene with chlorine in the &echemical reactor&r and get some Vinyl Chloride"
 	]
-	quest.1972B36F72808D55.quest_desc: ["No the Stones aren't chipped! Well actually some might be... you know what I mean!"]
+	quest.1972B36F72808D55.quest_desc: ["Only some of theses stones are chipped though."]
 	quest.1972B36F72808D55.title: "&l&bChipped&r Stones"
 	quest.1985CFD1F0425E88.quest_subtitle: "More Filtering Options"
 	quest.1985CFD1F0425E88.title: "&eAdvanced Pickup Upgrade"
@@ -2521,12 +2494,8 @@
 	quest.1D1ABA9BD978E8A1.quest_subtitle: "Citron + Wild Cherry"
 	quest.1D2700821045CCF2.quest_desc: ["The 65536k Storage Disk can store 65536000 items."]
 	quest.1D2700821045CCF2.title: "&565536k Storage Part&r"
-	quest.1D2EF12FD7FDD217.quest_desc: [
-		"Chickens will lay these naturally. I guess it's not really considered naturally... "
-		""
-		"I guess the chickens are just getting... &oEggs-ercise!!!&r."
-	]
-	quest.1D2EF12FD7FDD217.quest_subtitle: "or am I?"
+	quest.1D2EF12FD7FDD217.quest_desc: ["Chickens will lay these naturally. I guess it's not really considered naturally...\\n\\nI guess the chickens are just getting... &oEggs-ercise!!!&r."]
+	quest.1D2EF12FD7FDD217.quest_subtitle: "...or am I?"
 	quest.1D2EF12FD7FDD217.title: "I'm not gonna make an Egg pun"
 	quest.1D31C515533DAD36.quest_subtitle: "Cave Dweller + Soul Tree"
 	quest.1D3F11194EA3BB73.quest_subtitle: "&bTier 3"
@@ -2656,7 +2625,7 @@
 	quest.1E9BD4B74DAEA9FC.quest_desc: ["To attract Bees to this nest, you'll need Popped Chorus Fruit instead of Honey Treats."]
 	quest.1E9BD4B74DAEA9FC.quest_subtitle: "Lures in Ender Bees when placed in the End"
 	quest.1EA02BA24AF02256.quest_desc: ["Eclipse Alloy Templetes are used to upgrade Celestigem armor and tools to Eclipse Alloy while retaining enchantments and installed upgrades."]
-	quest.1EB04FE105ACA4BE.quest_desc: ["On (and if) death of a Warden they might drop the Heart of the Deep. \\n\\nThis can be used for the ATM Star, or to activate the Portal in the Ancient City! \\n\\nThere can't be anything in the Portal to activate it, that includes Sculk!"]
+	quest.1EB04FE105ACA4BE.quest_desc: ["When a Warden dies it has a chance to drop a Heart of the Deep. \\n\\nThis can be used for the ATM Star, or to activate the Portal in the Ancient City! \\n\\nThere can't be anything in the Portal to activate it, that includes Sculk!"]
 	quest.1EBD5E4410A6DF34.quest_subtitle: "Feed a Ghostly Bee a Soulium Dagger"
 	quest.1EBD5E4410A6DF34.title: "Soulium Bee"
 	quest.1ECFA72CF2BA4B45.quest_desc: ["A simple dropper and you can configure the amount dropped at once."]
@@ -2664,12 +2633,8 @@
 	quest.1F09F091F5CF4711.quest_subtitle: "Reach out and Touch Faith. With your personal... Jesus."
 	quest.1F0A68DFAA19D5C7.quest_desc: ["A few of the Large Multiblock Structures do &nnot&r dont rely on the Alloy Blast Smelter to create resources for their blocks. The blocks for the Large Multiblock structures above are a couple of those machines that do not rely on the Alloy Blast Smelter. "]
 	quest.1F0A68DFAA19D5C7.quest_subtitle: "Skidding without ABS"
-	quest.1F114EB0AAB86DB4.quest_desc: [
-		"Markets provide you with a villager than can sell you anything if you have the right amount of emeralds. "
-		""
-		"Spoiler: It's usually just 1 Emerald per item, luckily, they have EVERYTHING."
-	]
-	quest.1F114EB0AAB86DB4.quest_subtitle: "The villager has more than one way to spawn"
+	quest.1F114EB0AAB86DB4.quest_desc: ["Markets provide you with a villager than can sell you anything if you have the right amount of emeralds.\\n\\nSpoiler: It's usually just 1 Emerald per item, luckily, they have EVERYTHING."]
+	quest.1F114EB0AAB86DB4.quest_subtitle: "The Villager has more than one way to Spawn"
 	quest.1F114EB0AAB86DB4.title: "Purchasing Farm Supplies"
 	quest.1F146FE1002643B2.quest_subtitle: "Brazilwood + Rose Gum"
 	quest.1F18B64C84C8809D.title: "&l&9Overworld Bounty:&r&e Spiders"
@@ -2836,7 +2801,6 @@
 	quest.2077D64428E9C067.quest_subtitle: "This has a use outside of crafting cables."
 	quest.2077D64428E9C067.title: "Forgot to Mention"
 	quest.2094D1CE4BA66091.quest_desc: ["Light is a very important part of any Base. \\n\\nIt keeps Monsters from Spawning, helps to see, and even adds more Color and life to your Builds! \\n\\nOr you can just use Night Vision but where's the fun in that!"]
-	quest.2098D8BFADB55D2A.title: "Lining Blueprint"
 	quest.209DC1E9AD4C5A84.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks.\\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission.\\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
 	quest.20A01B6A6B1177CB.quest_desc: [
 		"Another tier up, another boost to processing time. But again, theres no time to get comfortable. The new resources we will be processing will need further advancements to bring those processing times down. So keep at it!"
@@ -2902,7 +2866,6 @@
 		"Now it's no longer a secret."
 	]
 	quest.2114BABF547A0E2A.title: "Toast"
-	quest.21234BB40DB05C78.title: "Bracelet Blueprint"
 	quest.212EC1F41227184D.quest_desc: [
 		"Do you want to be able to shoot Ender blasts like the Lich? This is the scepter for it."
 		""
@@ -2937,7 +2900,7 @@
 	quest.21693C4DE6531D73.title: "Crusher"
 	quest.216DA9782EBDFF34.quest_desc: ["I think this Mod is unrealistic. I don't care what Books or Items you have, I don't think the Demonic will follow your every command and work as a slave for you. \\n\\nRegardless you can follow the Quests to do so."]
 	quest.216DA9782EBDFF34.title: "Occultism"
-	quest.2171DC0B13C4BD43.quest_desc: ["Roots may look small in JEI but I can promise you there's so much to it! \\n\\nRoots is all about using Natures gifts to make rituals. \\n\\nTrust me you'll find these Items everywhere!"]
+	quest.2171DC0B13C4BD43.quest_desc: ["Roots Classic may look small in JEI but I can promise you there's so much to it! \\n\\nRoots is all about using nature's gifts to make rituals.\\n\\nTrust me you'll find these items everywhere!"]
 	quest.2171DC0B13C4BD43.title: "Roots Classic"
 	quest.21770049843DD275.quest_subtitle: "Part 2 of 2"
 	quest.217DB12EA32E1724.quest_desc: ["The &bInfusion Crystal&r is need in order to \"tier up\" seeds. For example if you combine the crystal with 4 Inferium Essence you will get 1 Prudentium Essence.\\n\\nLater on you will be able to craft an Infusion Crystal that doesn't break."]
@@ -2989,6 +2952,7 @@
 	quest.221C9EDA651144BA.title: "&3Charm of Sinking&r"
 	quest.2226555D9552236E.quest_subtitle: "Spawns from most Wood Nests"
 	quest.222739E77C745519.quest_subtitle: "Tier: &b4"
+	quest.222D08F43B995FED.quest_subtitle: "Try and dent this"
 	quest.2230244B2CE5851D.quest_desc: [
 		"Has an ability to clear away Cobblestone, Dirt, Netherrack, and other common materials, leaving behind only ores and fine resources."
 		""
@@ -3025,8 +2989,7 @@
 	]
 	quest.229455730219F7B1.quest_subtitle: "Red Iron"
 	quest.229455730219F7B1.title: "&cVentium"
-	quest.22A0A9C81A5C85A1.quest_subtitle: "It holds everything together."
-	quest.22A0A9C81A5C85A1.title: "Binding Blueprint"
+	quest.22A0A9C81A5C85A1.quest_subtitle: "Holding everything together"
 	quest.22A1C68078EFB38B.quest_subtitle: "Amplifies Potion Effect"
 	quest.22AC248B6BB88486.quest_desc: [
 		"Distills compounds into other substances - note the programmed circuit setting for the available recipes"
@@ -3050,7 +3013,6 @@
 	]
 	quest.22C4318523A43B49.quest_subtitle: "[Linux user joke goes here]"
 	quest.22C4318523A43B49.title: "Terminals"
-	quest.22C51025DC42CDE2.title: "Leggings Blueprint"
 	quest.22D0C3F454F5E8F1.quest_subtitle: "Tier: &b4"
 	quest.22D2CFDDB06C720C.quest_desc: ["Tools are very important in &2&lMinecraft&r but so is inventory space. So why not clear some space up by making a Paxel! \\n\\nPaxels are a combination of Pickaxes (P), Axes (axe), and Shovels (els). \\n\\nThey can strip wood, make paths, and mine any blocks that same pickaxe/axe/shovel tier can!"]
 	quest.22D2CFDDB06C720C.title: "Paxel"
@@ -3160,6 +3122,7 @@
 	quest.23ADD20D9B1AE0F3.quest_desc: ["Use a &bPure Daisy&r to convert Stone into Livingrock!"]
 	quest.23ADD20D9B1AE0F3.title: "&7Livingrock"
 	quest.23AE395433AED3C0.quest_desc: ["The ATM Star needs a few Blocks to hold together the different Items, and make its star shape! \\n\\nThe first Blocks are Unobtainium-AllTheModium Alloy Blocks. You need to use an Enchanting Apparatus from Ars Nouveau to make them! To make 28 to be exact. \\n\\nFor 17 X3 Netherstar Blocks you'll need 111,537 Netherstars. (Please I am begging you use HNN just don't spawn and kill 111,537, please!)"]
+	quest.23AE395433AED3C0.title: "The Star's Casing"
 	quest.23B55A8C7D6482FF.quest_desc: [
 		"Grab your tools and open up the maintenance hatch, there are problems to fix!"
 		""
@@ -3259,7 +3222,7 @@
 	]
 	quest.24E3CB198F73524A.quest_subtitle: "Arcing electricity!"
 	quest.24E658BA47367A44.quest_desc: ["The &n&5Rope Pulley&r can move blocks up or down, they can be glued together."]
-	quest.24F3E90C14BFD1B4.quest_desc: ["Modern Industrialization is a Mod as big as its name! It has multiple tiers of Machines and thankfully we don't need to go to the last one for the Star."]
+	quest.24F3E90C14BFD1B4.quest_desc: ["Modern Industrialization is a mod as big as its name! It has multiple tiers of machines and thankfully we don't need to go to the last one for the Star."]
 	quest.24F3E90C14BFD1B4.title: "Modern Industrialization"
 	quest.25213DBA6E6CEDD2.quest_desc: [
 		"Shadowpulse Goo is the fourth and final tier of goo added by JDT and requires Ancient City and Warden materials to craft."
@@ -3365,7 +3328,6 @@
 	quest.2607F3DC07049785.title: "&6Plastic Drinking Hat"
 	quest.260F9C98DC2E485B.quest_subtitle: "Tier: &b4"
 	quest.262036FE8E87F50A.quest_subtitle: "3x3 Mining"
-	quest.262036FE8E87F50A.title: "Hammer Blueprint"
 	quest.262AE37765B139BE.quest_desc: [
 		"Remember: Overclocking runs a recipe twice as fast but at four times power consumption"
 		""
@@ -3591,7 +3553,7 @@
 	quest.28FEB4C11AD1AE7C.quest_desc: ["&bDiamonds&r are usually expensive... for Vanilla, but this is modded you'll have enough for atleast 1 &bDiamond Generator&r. Still uses normal Furnace Fuel."]
 	quest.28FEB4C11AD1AE7C.title: "&bDiamond Generator"
 	quest.290FAB3DE8FD04E7.quest_desc: ["{atm9.quest.evilcraft.desc.maceExplosion}"]
-	quest.29131C3532610ADF.quest_desc: ["This is a Tier 2 Pillar Cap for the Starlight Charger structure."]
+	quest.29131C3532610ADF.quest_desc: ["This is a Tier 2 Pillar Cap for the Starlight Charger."]
 	quest.29131C3532610ADF.title: "Tier 2 Starlight Charger Pillar Cap"
 	quest.29164630E1BD76B5.quest_desc: ["This is the main resource in the mod. Go out and mine some!"]
 	quest.29164630E1BD76B5.title: "Arcane Crystals"
@@ -3635,7 +3597,7 @@
 		"This is what we are going to achieve. 4 Amps of &dLuV&r Energy Will give us &4ZPM&r tier energy!"
 	]
 	quest.29CD5C0A253425D5.quest_subtitle: "How about &dLuV&r Energy Hatch, But 4x?"
-	quest.29D28983E0200A3C.quest_desc: ["Ars Nouveau is all about using Glyphs into Spellbooks to be able to cast them as Spells! \\n\\nWe'll only need the former. \\n\\nThe Quest should help you get them."]
+	quest.29D28983E0200A3C.quest_desc: ["Ars Nouveau is all about using Glyphs in Spellbooks to be able to cast them as Spells!"]
 	quest.29D28983E0200A3C.title: "Ars Nouveau"
 	quest.29DF2E7D0402284F.title: "Radiance"
 	quest.29E2033EA65E706E.quest_desc: [
@@ -3725,7 +3687,7 @@
 		"{image:atm:textures/questpics/bumblezone/bumble_sugar.png width:200 height:100 align:center}"
 	]
 	quest.2A6FC21142E75DD5.title: "Lakes of Sugar! (&bWater&r)"
-	quest.2A72B262AF4F11C9.quest_desc: ["To get the Socotra Dragon Sapling you'll need to Breed Wenge with Cocobolo. \\n\\nTo get Wenge you'll need to Breed Cocobolo with Balsa. \\n\\nTo get Cocobolo you'll need to Breed Balsa with Dark Oak. \\n\\nTo get Balsa you'll need to Breed Acacia with Teak. \\n\\nTo get Teak you can Breed Jungle and Dark Oak. \\n\\nYou might notice Interbreeding, it's okay with Trees just not people."]
+	quest.2A72B262AF4F11C9.quest_desc: ["To get the Socotra Dragon Sapling you'll need to Breed Wenge with Cocobolo. \\n\\nTo get Wenge you'll need to Breed Cocobolo with Balsa. \\n\\nTo get Cocobolo you'll need to Breed Balsa with Dark Oak. \\n\\nTo get Balsa you'll need to Breed Acacia with Teak. \\n\\nTo get Teak you can Breed Jungle and Dark Oak."]
 	quest.2A787B99A8B0C767.quest_desc: [
 		"A very important block and a very common one! Can be crafted or found in most &lIron Spells&r Structures. \\n\\nThese are used for adding and removing &3Scrolls&r from &eSpell Books&r! Throw the &eSpell Book&r in the Book Slot then the &3Scroll&r below it. If you want to remove a &3Scroll&r, click it then take it from the right and into your Inventory."
 		"{image:atm:textures/questpics/iron_spells/spells_table_gui.png width:150 height:100 align:center}"
@@ -3818,7 +3780,7 @@
 	quest.2B4801CD3E90BD40.title: "&l&3Handcrafted&r"
 	quest.2B539F4F290DC4CF.title: "Nitro Player Transmitter"
 	quest.2B5733BDAF83B2D4.title: "Quartzite Vein"
-	quest.2B57C8D2F98A9279.quest_desc: ["Pocket Storage is a new Mod to AllTheMods. It's a simple handheld storage. \\n\\nRight Click to open it and you can put Items in. They will have a max count that it can hold, and anymore Items put in past it will be voided. It will also vacuum up Items on the ground that are the same as in it. \\n\\nThere's also ways you can dump it into Chests or take out of Chests quickly. \\n\\nThe different Tiers the higher the Slots and Max Items will be."]
+	quest.2B57C8D2F98A9279.quest_desc: ["Pocket Storage is a mod that adds simple handheld storage. \\n\\nRight Click to open it and you can put Items in. They will have a max count that it can hold, and anymore Items put in past it will be voided. It will also vacuum up Items on the ground that are the same as in it. \\n\\nThere's also ways you can dump it into Chests or take out of Chests quickly. \\n\\nThe different Tiers the higher the Slots and Max Items will be."]
 	quest.2B57C8D2F98A9279.title: "Pocket Storage"
 	quest.2B60D123123A5E8E.quest_desc: ["Why set a location to where the Energy can go? Why not let it go free! \\n\\nLike freeing a bunch of Bees, the Energy will go everywhere almost instantly (with less buzzing). Any blocks needing Energy nearby will be charged wirelessly."]
 	quest.2B6AE772B72E6DD3.quest_desc: ["You may want to avoid falling into the Bacteria Solution. You'll probably survive, assuming you don't have any open cuts..."]
@@ -3844,7 +3806,6 @@
 	]
 	quest.2B8E66760514BE77.quest_subtitle: "UV Superconductor"
 	quest.2B901ECF97FFA181.quest_desc: ["When you finally combine the Ancient Knowledge Fragments you'll get the... &9Eldritch Manuscript&r! That's what the last class is! \\n\\n&9Eldritch&r is the last class, the most powerful of all &3Spells&r. They are crafted with &9Echo Shards&r and need to be learned from the &9Manuscript&r to use them. Each &9Manuscript&r is only one use."]
-	quest.2B901ECF97FFA181.title: "&9&lEldritch&r"
 	quest.2B901ECF97FFA181.title: "&9&lEldritch"
 	quest.2B9AF0D6ED8BA628.quest_subtitle: "&f6 &cAttack Damage"
 	quest.2B9BA85662BF637C.quest_desc: ["Engraved wafers need to be cut into the appropriate size, so back to the Cutter we go!"]
@@ -4000,7 +3961,7 @@
 	]
 	quest.2D65DC315CCC60C8.quest_subtitle: "By Products"
 	quest.2D6FDCC948DB927D.quest_subtitle: "Mahogany + Teak"
-	quest.2D8026E10FBA7A72.quest_desc: ["I think it should be able to break Bedrock but Minecraft disagrees!"]
+	quest.2D8026E10FBA7A72.quest_desc: ["A very fast pickaxe."]
 	quest.2D8026E10FBA7A72.title: "&6Allthemodium &5Alloy &3Pick"
 	quest.2D84DA544D7A24FA.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks. \\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission. \\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
 	quest.2D86D4403E0F4EB9.quest_desc: [
@@ -4079,12 +4040,8 @@
 	]
 	quest.2E8F851A4E98F741.quest_subtitle: "Compressed Iron Man"
 	quest.2E8F851A4E98F741.title: "Pneumatic Armor"
-	quest.2E9C035EEE7E5C34.quest_desc: [
-		"The classic Lead. Use this to get animals into your farm area. "
-		""
-		"This isn't the same thing as the ore."
-	]
-	quest.2E9C035EEE7E5C34.quest_subtitle: "Get along little doggy"
+	quest.2E9C035EEE7E5C34.quest_desc: ["The classic Lead. Use this to get animals into your farm area.\\n\\nThis isn't the same thing as the ore."]
+	quest.2E9C035EEE7E5C34.quest_subtitle: "Get along little Doggy"
 	quest.2E9C035EEE7E5C34.title: "We're doing this the Old Fashioned way"
 	quest.2E9FC7DC2AC6FD8E.quest_desc: [
 		"&8Nuclear Waste&r can be sent into an Isotopic Centrifuge to create &9Plutonium&r."
@@ -4115,8 +4072,8 @@
 		"{image:atm:textures/questpics/flux/flux_ui.png width:125 height:150 align:1}"
 	]
 	quest.2EB7784D5296F410.title: "The Flux Networks UI"
-	quest.2EB96FF06627FD9A.quest_subtitle: "Breaks down items into their components."
-	quest.2EB96FF06627FD9A.title: "Salvager"
+	quest.2EB96FF06627FD9A.quest_desc: ["The Salvager allows you to break down gear into the items they from.\\n\\nFor example: If you put in some Diamond Boots you will get 4 Diamonds back."]
+	quest.2EB96FF06627FD9A.quest_subtitle: "Braking down (some) items!"
 	quest.2EC9668ED4EA47CB.quest_desc: ["This quest only requires you to make one Diamond tool or armor piece, but it's probably good to get a full set!\\n\\nDiamond tools boast high durability, and the armor offers great protection overall.\\n\\nTo make the better tools and armor in the game, you'll need Diamond stuff as a base!"]
 	quest.2EC9668ED4EA47CB.title: "&9Gearing Up"
 	quest.2ED7878B7919AF6D.quest_subtitle: "&f6&r &4Damage&r"
@@ -4394,7 +4351,7 @@
 	quest.31BCE63F5E016323.quest_subtitle: "In the palm of my hand..."
 	quest.31BCE63F5E016323.title: "Pressure from the Sun"
 	quest.31EC6244E4A3CBD6.quest_subtitle: "Tier: &b4"
-	quest.31EEE2875595F315.quest_desc: ["You should have already made &2Sulfuric Acid&r for your Tier 4 Ore Processing facility, but here is a reminder on how to get it.\\n\\nStart by getting &eSulfur Dust&r either by crushing Sulfur from Thermal, or by mixing &bHydrogen Chloride&r with &3Gunpowder&r in a Chemical Dissolution Chamber.\\n\\nTake the Sulfur Dust and run it through a &9Chemical Oxidizer&r to get &eSulfur Dioxide&r. Combine that with &bOxygen&r in a Chemical Infuser to get &eSulfur Trioxide&r.\\n\\nNext, we'll combine &bWater Vapor&r with the Sulfur Trioxide to make &2Sulfuric Acid&r."]
+	quest.31EEE2875595F315.quest_desc: ["You should have already made &2Sulfuric Acid&r for your Tier 4 Ore Processing facility, but here is a reminder on how to get it.\\n\\nStart by getting &eSulfur&r by finding it underground, or by mixing &bHydrogen Chloride&r with &3Gunpowder&r in a Chemical Injection Chamber.\\n\\nTake the Sulfur Dust and run it through a &9Chemical Oxidizer&r to get &eSulfur Dioxide&r. Combine that with &bOxygen&r in a Chemical Infuser to get &eSulfur Trioxide&r.\\n\\nNext, we'll combine &bWater Vapor&r with the Sulfur Trioxide to make &2Sulfuric Acid&r."]
 	quest.31EEE2875595F315.quest_subtitle: "A Quick Recap"
 	quest.31EEE2875595F315.title: "&2Sulfuric Acid"
 	quest.31FD9EA513E0D010.quest_desc: [
@@ -4700,7 +4657,6 @@
 	]
 	quest.35CC898E0E49FE58.quest_subtitle: "The Ultimate Wireless Power Solution"
 	quest.35CC898E0E49FE58.title: "Flux Networks"
-	quest.35E8C65CCA676E76.title: "Chestplate Blueprint"
 	quest.35E8F1CC0080E45E.quest_subtitle: "Feed a Diamond Bee a Ruby"
 	quest.35E8F1CC0080E45E.title: "RuBee"
 	quest.35EAB77C195E594E.quest_subtitle: "Feed a Diamond Bee Amethyst"
@@ -4767,7 +4723,6 @@
 	quest.36B1995B495AA674.quest_subtitle: "Orange = Radiation Protection"
 	quest.36B1995B495AA674.title: "Suiting Up for Reactors"
 	quest.36B9D5A99E1AA85C.quest_subtitle: "&f8 &cAttack Damage"
-	quest.36BCE35215B2B6E9.title: "&eAuto-Smoking Upgrade&r"
 	quest.36BCE35215B2B6E9.quest_desc: ["Auto-smelt items in the Backpack."]
 	quest.36BCE35215B2B6E9.quest_subtitle: "Automatic"
 	quest.36BCE35215B2B6E9.title: "&eAuto-Smoking Upgrade"
@@ -4802,9 +4757,8 @@
 	quest.371E09ED2A3F6BDC.quest_subtitle: "Spawns in empty Advanced Beehives in Dark Places"
 	quest.371E09ED2A3F6BDC.title: "ZomBee"
 	quest.371E5E1E435E41AA.quest_desc: ["You can make yourself some &aFloral Fertilizer&r which works like bone meal but for Botania Flowers!"]
-	quest.3722B43822F80470.quest_desc: ["Slightly faster than a sword, but lower damage."]
+	quest.3722B43822F80470.quest_desc: ["Slightly faster than a Sword, but lower damage."]
 	quest.3722B43822F80470.quest_subtitle: "Release Your Inner Samurai"
-	quest.3722B43822F80470.title: "Katana Blueprint"
 	quest.3722E5A8BE99C5B1.quest_desc: ["Allows Mana Bursts to break through blocks by using its own mana."]
 	quest.372B5BF416CA83A4.quest_desc: ["Mekanism is one of the most popular Machine and Technology Mods. Quite frankly I have a hard time summarizing it as it has so much in it! \\n\\nIt has so much we even had to make 2 Quest Pages for it! \\n\\nThe stuff we need for the ATM Star is in the Reactors page but you'll need to get through the Mekanism page to get there."]
 	quest.372B5BF416CA83A4.title: "Mekanism"
@@ -4873,7 +4827,6 @@
 	quest.37EBB8E0D6E5F821.title: "Welcome to &9Hostile Neural Networks&r!"
 	quest.37F2BE3C2BAF7C2D.quest_desc: ["Tags are an essential part of Minecraft. \\n\\nFor all who don't know they work as an organization tool to help choose similar items for the same task. Like Crafting Table being made with any Planks or Trees being Chopped down fastest with any Axe. \\n\\nTo filter by Tag put an item in, then select the tag from the groups. Like Iron Ore for Ores."]
 	quest.38135FFD9ED64395.title: "Vibranium-AllTheModium Alloy"
-	quest.3844877F6C1AFE77.title: "Arrow Blueprint"
 	quest.38451B61E3FC075B.quest_desc: [
 		"Wait we have Steel again does that also mean we get our (Coal) Coke back? Yes! \\nTo get (Coal) Coke you'll need a Coke Oven. To make one you'll need 26 Coke Oven Bricks and place them 3x3x3 with 1 block hollow in the center. You'll know it's done when you can access the GUI and it's all one texture. \\n\\nPlace Coal or Coal Blocks to get (Coal) Coke and Liquid Creosote! You can always put any log in to get Charcoal and Creasote."
 		"{image:atm:textures/questpics/railcraft/rail_coke.png width:100 height:100 align:center}"
@@ -4925,13 +4878,8 @@
 	quest.392EAE8BE71510C1.title: "&5End&r: Land of 1 lonely boss"
 	quest.392F34FD4FCC794A.quest_desc: ["While they can be expensive they're also plenty stylish!"]
 	quest.392F34FD4FCC794A.title: "&2&lMystical Agriculture&r Blocks"
-	quest.3930404D5C8B44EB.quest_desc: [
-		"This is used to create custom alloys. "
-		""
-		"It is also the only way to get Tyrian Steel!"
-	]
+	quest.3930404D5C8B44EB.quest_desc: ["This is used to create custom alloys.\\n\\nIt is also the only way to get Tyrian Steel!"]
 	quest.3930404D5C8B44EB.quest_subtitle: "Combines Materials"
-	quest.3930404D5C8B44EB.title: "Metal Alloyer"
 	quest.393DA9C9D808A851.quest_desc: ["&l&6Theurgy's&r Wrench is the &cMercurial&r Wand. You can Shift and Scroll to change its Modes. \\n\\nYou can Enable/Disable to basically stop Wires from transferring. \\n\\nYou can change the side of where Items will Extract or Insert to. \\n\\nAnd you can change the Frequency Channel!"]
 	quest.393DA9C9D808A851.quest_subtitle: "I thought this was a magic mod..."
 	quest.393DA9C9D808A851.title: "Of course there's a Wrench"
@@ -4973,9 +4921,8 @@
 	]
 	quest.39B6D9FD21419776.quest_desc: ["{image:atm:textures/questpics/allthemodium/all_armor_vibmage.png width:100 height:175 align:center}"]
 	quest.39B6D9FD21419776.title: "&3Vibranium Mage Armor"
-	quest.39B85DB54B1037FE.quest_desc: ["More damage than a sword, but slower."]
+	quest.39B85DB54B1037FE.quest_desc: ["More damage than a Sword, but slower."]
 	quest.39B85DB54B1037FE.quest_subtitle: "Thicc Sword"
-	quest.39B85DB54B1037FE.title: "Machete Blueprint"
 	quest.39C8E1705EF1CD31.quest_desc: ["The 64k Fluid Storage Part is used to craft the 64k Fluid Storage Disk."]
 	quest.39C8E1705EF1CD31.title: "&e256k Fluid Part&r"
 	quest.39CD35C91F07258C.quest_desc: [
@@ -4994,8 +4941,6 @@
 	quest.39F142224D5210A9.quest_subtitle: "Bio/Diesel"
 	quest.39F142224D5210A9.title: "Biodeisel"
 	quest.39F9C825B03DA317.quest_desc: ["Aerial Interface works as a link between it's own internal storage and your Inventory. Basically whatever goes in it, goes to you. \\n\\nYou'll need a whole assembly line to craft it, the Quests should help you!"]
-	quest.3A1D07AED2A841E4.quest_subtitle: "Auto-smelt items in the backpack."
-	quest.3A1D07AED2A841E4.title: "&eAuto-Smelting Upgrade&r"
 	quest.3A1D07AED2A841E4.quest_desc: ["Auto-smelt items in the Backpack."]
 	quest.3A1D07AED2A841E4.quest_subtitle: "Automatic"
 	quest.3A1D07AED2A841E4.title: "&eAuto-Smelting Upgrade"
@@ -5050,6 +4995,7 @@
 		""
 		"If you don't have enough LP, that's cool too. It'll just take 5 hearts from you. No biggie."
 	]
+	quest.3AC03D1FA5C341A7.quest_desc: ["The Recrystallizer allows you to combine together different crystals to make new crystals to use to make weapons, tools and armor."]
 	quest.3AD4367855B3E595.quest_subtitle: "Tier: &b4"
 	quest.3ADC0CBB059FF927.quest_desc: ["To use this 1. Have it in your Offhand 2. Have it being Daytime 3. Be exposed to the sky. \\n\\nThen you will get Regeneration, Saturation, Speed, Haste, and Resistance. It will also repair your Armor Durability. \\n\\nOnce used up it will have a 10 Minute cooldown."]
 	quest.3ADC0CBB059FF927.title: "&eEssence of Radiance"
@@ -5109,7 +5055,7 @@
 		"You probably want to make another &aDistillation Tower&r to distill this"
 	]
 	quest.3B542DC05240242C.quest_subtitle: "&f6 &cAttack Damage"
-	quest.3B560B2ECE331CAF.quest_desc: ["This is a Tier 3 Pillar Cap for the Starlight Charger structure."]
+	quest.3B560B2ECE331CAF.quest_desc: ["This is a Tier 3 Pillar Cap for the Starlight Charger."]
 	quest.3B560B2ECE331CAF.title: "Tier 3 Starlight Charger Pillar Cap"
 	quest.3B570B3DB5F6D2CB.quest_subtitle: "x16 Storage Upgrade"
 	quest.3B570B3DB5F6D2CB.title: "&eGold Upgrade&r"
@@ -5162,7 +5108,7 @@
 	]
 	quest.3BDB94F17765EE77.quest_subtitle: "More Power Than You'll Need"
 	quest.3BDB94F17765EE77.title: "End Game Power Options"
-	quest.3BE5CD0C7CC4BCC6.quest_desc: ["Soul Lava is a part of the AllTheModium Mod. It can be found in The Other very rarely underground, or common in Piglin Village structures! \\n\\nWe'll need to feed a Bucket of it to a Ghostly Bee to make a Soul Lava Bee. \\n\\nThen, you'll need to squish them or poke them for its DNA to make a Spawn Egg!  "]
+	quest.3BE5CD0C7CC4BCC6.quest_desc: ["Soul Lava is a part of &6Allthemodium&r. It can be found in The Other very rarely underground, or common in Piglich Villages!\\n\\nWe'll need to feed a Bucket of Soul Lava to a Ghostly Bee to make a Soul Lava Bee.\\n\\nThen, you'll need to squish them or poke them for it's DNA to make a Spawn Egg!  "]
 	quest.3BEDF19CD79D53D5.quest_desc: [
 		"The &aDistillation Tower&r serves as the foundation for &dOil Processing&r which can turn oil into many more useful forms"
 		""
@@ -5269,8 +5215,8 @@
 	quest.3CE3D9245F8EC005.quest_desc: ["The fourth MEGA tier of storage component, providing &e67108864&f (65536k) bytes of storage."]
 	quest.3CE3D9245F8EC005.quest_subtitle: "x4^3"
 	quest.3CE3D9245F8EC005.title: "64M Storage Component"
-	quest.3CFD27F273B97FDD.quest_desc: ["Apotheosis has multiple Cores now each changing different parts of Minecraft. \\n\\nThe Attributes and Enchanting Cores are what you'll need to follow to get the ATM Star! \\n\\nThere'll be Quest chapters for both!"]
-	quest.3CFD27F273B97FDD.title: "Apotheosis"
+	quest.3CFD27F273B97FDD.quest_desc: ["The Apothic mods have multiple cores, each changing different parts of Minecraft.\\n\\nThe Attributes and Enchanting mods are what you'll need to follow to get the ATM Star!"]
+	quest.3CFD27F273B97FDD.title: "Apothic Mods"
 	quest.3CFE522A4B7CC2EC.quest_desc: [
 		"The &3Reinforced Chest&r is a blast-proof Chest with 36 slots. Not Double Chest-able. Also works like a Shulker Box."
 		"{image:atm:textures/questpics/pneumaticcraft/reinforced_chest_ui.png width:200 height:100 align:center}"
@@ -5284,9 +5230,8 @@
 		"When an enemy is hit from this bow, you will swap places with them. Be careful shooting things out of the sky!"
 	]
 	quest.3D2A03EB2B91E9C1.quest_desc: ["The &n&5Chute&r is used to insert/extract from inventories, or to place/take items from a belt."]
-	quest.3D2C6FF462B17205.quest_desc: [" Low damage, very high attack speed. Reduces the invincibility time of the target."]
-	quest.3D2C6FF462B17205.quest_subtitle: "Stabby Stabby"
-	quest.3D2C6FF462B17205.title: "Dagger Blueprint"
+	quest.3D2C6FF462B17205.quest_desc: ["Low damage, very high attack speed. Reduces the invincibility time of the target."]
+	quest.3D2C6FF462B17205.quest_subtitle: "Stabby Stab"
 	quest.3D40D91D7D948714.quest_desc: ["There is going to be a high demand for these plates. Figuring out how to supply yourself with a bunch of these plates may be a challenge, but well worth it."]
 	quest.3D40D91D7D948714.quest_subtitle: "The dishes Plating matters"
 	quest.3D41D0092D94636B.quest_desc: [
@@ -5461,8 +5406,8 @@
 	quest.3E8C7D92F99496BE.title: "&5Eye of Abyss&r"
 	quest.3E99F4CD379DE9D7.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks.\\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission.\\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
 	quest.3EA2578C3A56FAE8.quest_desc: ["The Soul Extractor allows you to fill up Soul Jars by inserting a jar and using mob items to fill them. For example, adding Rotten Flesh will give a portion of a Zombie Soul."]
-	quest.3EA883C0BB7BD38F.quest_desc: ["Let's gather some pieces of wool!"]
-	quest.3EA883C0BB7BD38F.quest_subtitle: "Whose fleece was....rainbow?"
+	quest.3EA883C0BB7BD38F.quest_desc: ["Let's gather some pieces of Wool!"]
+	quest.3EA883C0BB7BD38F.quest_subtitle: "Whose Fleece was....Rainbow?"
 	quest.3EA883C0BB7BD38F.title: "Mary had a Little Lamb"
 	quest.3EB63AF53E70C931.quest_desc: [
 		"Reformation takes Mercury Flux to work! You'll need to Shift Right Click all 3 Pedestals with the Sulfuric Flux Emitter to set them. Then place down the Emitter and feed it power.\\n\\nAfter that it should be ready to Reform!"
@@ -5488,7 +5433,7 @@
 		"This allows your RS system to be accessed wirelessly from any dimension."
 	]
 	quest.3EE9958D84A1252C.title: "Dimension Card"
-	quest.3EEF17C57375CC39.quest_desc: ["&lSimply Lights&r are my favorite Light Sources. Very simple to make and easy to use. \\n\\nWhen Inverted they will work without Redstone and will turn pff when Redstone Signal goes to it. \\n\\nPlenty of different colors and shapes of it!"]
+	quest.3EEF17C57375CC39.quest_desc: ["&lSimply Lights&r adds very simple to make and easy to use lights.\\n\\nWhen inverted they will work without Redstone and will turn off when the Redstone signal goes activates it.\\n\\nThere are plenty of different colors and shapes of it!"]
 	quest.3EEF17C57375CC39.title: "&lSimply Light&r"
 	quest.3F064B466CC4914B.title: "Saltpeter Vein"
 	quest.3F0C949C8F243AFD.quest_desc: ["Make any IV Tier and up Fluid Heater so that we can process that Raw Growth Medium we made."]
@@ -5503,7 +5448,6 @@
 		"To deselect a block, L-Click it with the Arm in your hand."
 	]
 	quest.3F39BEB788175CEF.quest_subtitle: "3x3 Digging!"
-	quest.3F39BEB788175CEF.title: "Excavator Blueprint"
 	quest.3F3F70FEEE8AFEEA.quest_desc: ["Just preparing a backstock of HASOC's, so that once we unlock the proper machines, we can start crafting a bunch of processors!"]
 	quest.3F3F70FEEE8AFEEA.quest_subtitle: "Prepping for whats to come"
 	quest.3F5010269469EBE0.quest_desc: [
@@ -5511,7 +5455,6 @@
 		"{image:atm:textures/questpics/mek/rod_example.png width:250 height:200 align:1}"
 	]
 	quest.3F5010269469EBE0.title: "Inside the Reactor: Fuel Control"
-	quest.3F56A5253D477B97.title: "Fletching Blueprint"
 	quest.3F5B5D6B788E0A73.quest_desc: ["Blood, flesh, rituals, if it's evil you can bet it's from EvilCraft! "]
 	quest.3F5B5D6B788E0A73.title: "EvilCraft"
 	quest.3F657CF4EBDDC3C4.quest_desc: ["Making Plastic can take a while, if you wish to automate this process you can use &eProductive Bees&r. I guess you could also just automate it using these previous quests."]
@@ -5638,9 +5581,8 @@
 	quest.405369118613F935.quest_desc: ["A little expensive but the &9Echoing Deep Shelf&r is like a much better &bSeashelf&r. (BTW you'll need to kill quite a few wardens to advance more in Enchanting... shoulda warned you earlier). Also increases Max &aEterna&r to &a37.5&r."]
 	quest.405369118613F935.title: "&9Echoing Deepshelf&r"
 	quest.4059373B88845C6F.quest_desc: ["The &eChemical Bath&r is used in &aOre Processing&r lines to get certain &dbyproducts&r by washing crushed ores in mercury or sodium persulfate"]
-	quest.405DCD3E36232EEA.quest_desc: ["Less damage than a sword, but longer reach."]
+	quest.405DCD3E36232EEA.quest_desc: ["Less damage than a Sword, but longer reach."]
 	quest.405DCD3E36232EEA.quest_subtitle: "Release Your Inner Spartan"
-	quest.405DCD3E36232EEA.title: "Spear Blueprint"
 	quest.406C924820DE5473.quest_desc: [
 		"This Wetware Printed Circuit board has completed the line of Circuit boards we will be making for our processors. "
 		""
@@ -5848,7 +5790,6 @@
 	quest.427014BDE06DE631.quest_subtitle: "Hands"
 	quest.427014BDE06DE631.title: "&cFire Gauntlet&r"
 	quest.427516AA3E8C9442.quest_subtitle: "Versatile Hoe"
-	quest.427516AA3E8C9442.title: "Mattock Blueprint"
 	quest.427B9C6D95885DE2.quest_subtitle: "Red Delicious Apple + Flowering Azalea"
 	quest.427C3AFC0FF131CD.title: "Fluids"
 	quest.427E7112ED0978FB.quest_desc: [
@@ -5913,7 +5854,8 @@
 		"Lubricant is very useful with a cutter because recipes using it are much faster compared to water for example"
 	]
 	quest.4300938A4E8AF937.title: "Scheelite Vein"
-	quest.43021923E220CF68.quest_subtitle: "Wait until you get machines for this..."
+	quest.43021923E220CF68.quest_desc: ["To till Dirt into Farmland you'll need a Hoe."]
+	quest.43021923E220CF68.quest_subtitle: "Wait until you get Machines for this..."
 	quest.43021923E220CF68.title: "The Planter"
 	quest.431A8FDF15701BA4.quest_desc: ["The &2Hunter's Belt&r works like the Leather Belt as in it holds Talismans. That's its first ability which can be upgraded to hold more! \\n \\nThe Second Ability increases the damage your pets do. Pets are tamed Mobs that can do damage to other Mobs, like wolves!"]
 	quest.431A8FDF15701BA4.quest_subtitle: "Found in Butcher's Huts of any Village"
@@ -6052,7 +5994,6 @@
 	quest.450EDE68EC992A5A.quest_desc: ["Interfaces &cread&r whatever they're looking at. You can think of this like an &bAE2&r Storage Bus.\\n\\nYou don't know what that is? Well here's an example: A chest with 100 Cobblestone in it has an interface on it, this means your ID network has 100 Cobblestone in it's system, pretty simple, right?"]
 	quest.450EDE68EC992A5A.quest_subtitle: "Interfaces Have GUIs!"
 	quest.4510FD92BACF00FF.quest_subtitle: "Plum + Sweet Chestnut"
-	quest.45268A619787288F.title: "&bDiamond Backpack&r"
 	quest.45268A619787288F.title: "&eGold Backpack"
 	quest.4526E151BAE88310.quest_subtitle: "Tier: &e1"
 	quest.452B3207B6C3A5D7.quest_desc: ["Liquid Uranium 235. Lets use this liquid to bind together the other components and craft the Absolute Reaction Plate"]
@@ -6164,7 +6105,7 @@
 		"{image:pneumaticcraft:textures/patchouli/small_tanks.png width:250 height:250 align:center fit:true}"
 	]
 	quest.461C8F1E88AA58D9.quest_subtitle: "32,000mb"
-	quest.462C1F75A2FB9F02.title: "Fishing Rod Blueprint"
+	quest.462C1F75A2FB9F02.quest_subtitle: "Where's Willy?"
 	quest.4632DA3CE9D95064.quest_desc: ["Platinum Group Sludge will process down into a bunch of great resources that will help you moving forward."]
 	quest.4632DA3CE9D95064.quest_subtitle: "Money! *Mister Krabs*"
 	quest.464110726B823072.quest_desc: [
@@ -7137,7 +7078,7 @@
 	quest.500BEAD94C97DF96.quest_desc: ["Can be placed in a hive or centrifuge.\\n\\nWhen in a hive, it decreases the amount of time bees spend in the hive by 20%.\\n\\nWhen placed in a Centrifuge, it increases the processing speed.\\n\\nThese do stack."]
 	quest.500BEAD94C97DF96.quest_subtitle: "Sonic Bees"
 	quest.50150380043F97F9.title: "Flight of the Bumblebee"
-	quest.501A0AEEC73C0790.quest_desc: ["Piglich is a Boss added by AllTheModium Mod which lives in the Ancient Pyramid in The Other. \\n\\nOn death he'll drop 1 of his Hearts! You'll need 9 of them dead to make a Block of it... \\n\\nThankfully there's way to farm them!"]
+	quest.501A0AEEC73C0790.quest_desc: ["Piglich is a Boss added by &6Allthemodium&r which lives in the Ancient Pyramid in The Other. \\n\\nOn death he'll drop 1 of his Hearts! You'll need 9 of them dead to make a Block of it... \\n\\nThankfully there are ways to farm them!"]
 	quest.501C6B7580453410.quest_desc: ["The &aFluidizer&r is a customizable multiblock that has a minimum size of 3x3x3. Just like the other multiblocks, the frame will need to be made out of Casings, while the faces can be made out of Glass."]
 	quest.501C6B7580453410.title: "Fluidizer Construction"
 	quest.502FF1A93E06073C.quest_subtitle: "Precursor"
@@ -7388,19 +7329,13 @@
 	quest.52BB58D470560219.quest_subtitle: "Range: &c54&r Blocks"
 	quest.52C7FAA044E07628.quest_desc: ["Think of the Totem of Undying, now think of how it can be super over powered. That's the &fEssence of Continuity&r. \\n\\nWhen you're about to take a fatal hit you will be teleported to your Respawn Point with full Health, Hunger, and bad Effects taken away. Saving your life obviously. \\n\\nIt will also give you a journal describing how and where you would have died. \\n\\nAfter it saved your life it will get a 40 Minute cooldown and will give cooldowns to every other Essence you might have. "]
 	quest.52C7FAA044E07628.title: "&fEssence of Continuity"
-	quest.52CDB46F6CBF007B.title: "Shovel Blueprint"
+	quest.52CDB46F6CBF007B.quest_subtitle: "Are you digging this?"
 	quest.52D3697F1F5625C7.quest_desc: ["&3Etching Acid&r is made in the Pressure Chamber with Molten Plastic...and some other stuff. Used in the Etching Tank."]
 	quest.52D3697F1F5625C7.quest_subtitle: "Don't Ask..."
 	quest.52E59FCB39D66BCF.quest_desc: ["One of the best options for \"Passive Power\", the &9Thermal Generator&r will produce FE when placed over a &cHeat Source&r and given a steady supply of water.\\n\\nThere are currently 3 blocks you can place this over: a Magma block which produces the lowest, a lava source block which is a little better, or a &cBlock of Blazing Crystal&r, which provides the most heat. "]
-	quest.52EB902E76829EBB.quest_desc: [
-		"Silent Gear is a tool and armor mod that makes crafting gear easy. "
-		""
-		"Each gear piece is customizable, allowing you to upgrade it with special traits or repair it on the go! "
-		""
-		"You can also convert vanilla tools like an iron pickaxe to a Silent Gear pickaxe by putting it into a crafting table!"
-	]
-	quest.52EB902E76829EBB.quest_subtitle: "Simple Tool Crafting"
-	quest.52EB902E76829EBB.title: "Silent Gear Weapons, Tools, and Armor"
+	quest.52EB902E76829EBB.quest_desc: ["Silent Gear is a gear mod that makes crafting gear easy.\\n\\nEach piece of gear is customizable, allowing you to upgrade it with special traits or repair it on the go!\\n\\nYou can also convert vanilla tools like an Iron Pickaxe to a Silent Gear Iron Pickaxe by putting it in a crafting grid!"]
+	quest.52EB902E76829EBB.quest_subtitle: "Weapons, Tools and Armor"
+	quest.52EB902E76829EBB.title: "Silent Gear"
 	quest.52EC86E03EB50525.quest_desc: [
 		"Intrinsic Ability:"
 		"- Lava Repair"
@@ -7439,7 +7374,7 @@
 	]
 	quest.53518D4ED99A242F.quest_desc: ["The &3Camouflage Applicator&r can be used to hide PneumaticCraft machinery inside of other blocks."]
 	quest.53518D4ED99A242F.quest_subtitle: "Want to make your setup look cool?"
-	quest.535525EA4DF4AB59.quest_desc: ["The Player Transmitter will supply Energy to anyone with the Binded Card. That includes Energy to all Armor, Tools, and Items in their Inventory. \\n\\nWe need the Nitro Tier of it, which is of course the last and hardest one to get."]
+	quest.535525EA4DF4AB59.quest_desc: ["The Player Transmitter will supply energy to anyone with the Binded Card. That includes energy to all armor, tools, and items in their inventory. \\n\\nThe Nitro tier is needed for the Star, which is of course the last and hardest one to get."]
 	quest.5357A140DD05654A.quest_desc: ["16x Uranium Triplatinum Wire - Qty 8"]
 	quest.5357A140DD05654A.quest_subtitle: "EV Superconductor"
 	quest.53594EBA9F7BA840.quest_desc: ["The Advanced Item Unloader is just like the normal part but can be used from any direction. Nothing different besides direction."]
@@ -7686,8 +7621,7 @@
 	]
 	quest.55B9B9C3AA01D323.title: "&5Overgrown Flower"
 	quest.55C47B868C5ECF54.quest_desc: ["Need help finding ores? Make yourself one of these and charge it up by placing it in any machine's energy slot"]
-	quest.55C4824DAD905512.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks. \\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission. \\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
-	quest.55C4824DAD905512.title: "AllRightsReserved"
+	quest.55C4824DAD905512.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks.\\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission.\\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
 	quest.55C8DD9A754545BD.quest_desc: ["The Pulverizer breaks raw ores into dusts, and also has a 25% chance to create an extra dust."]
 	quest.55C8DD9A754545BD.quest_subtitle: "Breaks Ores into Dusts"
 	quest.55D7CD0FA8F1AE48.quest_desc: ["The reason we're all here, &5Trains&r. The mod is called &l&7RailCraft&r don't act surprised. \\n\\nThere's 2 different main &5Trains&r and 1 special mining &5Train&r. \\n\\nThese &5Trains&r all by themselves can get a little boring, so why not attach &7Carts&r to them! Connecting &7Carts&r with &7Carts&r and with &5Trains&r is called Coupling, and to unconnect them is to Decouple. To Couple &5Trains&r and &7Carts&r use a &4Crowbar&r or a &6Track&r with the Coupling &cTrack Kit&r."]
@@ -7714,6 +7648,8 @@
 	quest.562BD37539EE318E.title: "Tier: &cBlazing"
 	quest.565376084F05ED6E.quest_desc: ["The Dimension known for housing the piglins and blazes and wither skeletons, now houses 2 more bosses to fight!"]
 	quest.565376084F05ED6E.title: "&4Nether&r: Land of 2 bosses"
+	quest.56550CD12C681B0F.quest_desc: ["&2Flax Seeds&r can be found growing in fields of grass. Flax is great if you need a lot of String in the eraly game."]
+	quest.56550CD12C681B0F.quest_subtitle: "Flax on, Flax off"
 	quest.565EBD340595EAC4.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks. \\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission. \\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
 	quest.568A1121F820345F.quest_subtitle: "&fTier 2&r"
 	quest.56970D44D4C9015A.quest_subtitle: "&f7 &cAttack Damage"
@@ -8039,9 +7975,8 @@
 		"The &c&lPyromancer&r (different from the Pie Romancer) is another Neutral Mob added by &lIron's Spells&r. He will maybe set Mobs that are close to him on &cfire&r though... \\n\\nYou can trade him all things &cFire&r, Ink, and even &cFire Scrolls&r. \\n\\nIf you want to risk all the hair on your body by fighting him be prepared, he has 60 Hearts. He will set you on &cFire&r with &cFire Spells&r, not even a question. \\n\\nOn death he will drop Arcane Essence, Inks, &cFire Runes&r, and &cFire Spells&r!"
 		"{image:atm:textures/questpics/iron_spells/spells_pyromancer.png width:100 height:200 align:center}"
 	]
-	quest.59E68086A8B99EA7.title: "&c&lPyromancer&r"
-	quest.59EC02C1FBCF14EA.quest_desc: ["You can upgrade your Obsidian Generator into an Ender Generator. \\n\\nThen, it can use Ender Pearls or Eyes of Ender to make Energy! \\n\\nOr make the Star, your choice."]
 	quest.59E68086A8B99EA7.title: "&c&lPyromancer"
+	quest.59EC02C1FBCF14EA.quest_desc: ["You can upgrade your Obsidian Generator into an Ender Generator. \\n\\nThen, it can use Ender Pearls or Eyes of Ender to make Energy! \\n\\nOr make the Star, your choice."]
 	quest.59F5ED931FD70C55.quest_desc: ["&9Patterns&r are the bread and butter of autocrafting. These store recipes to let your RS network know how to craft items."]
 	quest.59F5ED931FD70C55.title: "Autocrafting!"
 	quest.5A0305BB1F8EA932.quest_desc: ["If you want good gear you're gonna need Apotheosis Affixes, and that all starts with a Gem. "]
@@ -8097,14 +8032,8 @@
 	quest.5A8F4CA0F09F4842.title: "{atm9.quest.evilcraft.removingEnchantments}"
 	quest.5A912903E09F664F.quest_desc: ["Tip: Use the Ritual Tablet on the brazier first, then right click with one of each of the Wilden mob drops, then activate the ritual to summon the Wilden Chimera."]
 	quest.5A912903E09F664F.title: "Summoning Wilden Chimera"
-	quest.5A94A2664BFDD7B9.quest_desc: [
-		"Welcome to the Basic Storage Chapter! "
-		""
-		"You'll find all of the basic ways to store items without power, as well as useful items for your storage needs!"
-	]
-	quest.5A94A2664BFDD7B9.title: "Basic Storage"
-	quest.5A955C0F53AED3ED.quest_desc: ["The Chain of Souls works similar to a Grappling Hook. You can Right Click for it to send a Chain which will drag you toward the Block you shot it at. You can Right Click again to release it. Plus it has a Range of 90 Blocks give or take a few. \\n\\nTo make it you'll need a Trapped Soul, 2 Tenacious Vines, and a Tenacious Petal. \\n\\nThe first two you can get as drops from a Tangled Hatred while the last you'll need to kill a Lunar Monstrocity. "]
 	quest.5A94A2664BFDD7B9.quest_desc: ["Welcome to the Basic Storage Chapter!\\n\\nYou'll find all of the basic ways to store items without needing power, as well as useful items for your storage needs!"]
+	quest.5A955C0F53AED3ED.quest_desc: ["The Chain of Souls works similar to a Grappling Hook. You can Right Click for it to send a Chain which will drag you toward the Block you shot it at. You can Right Click again to release it. Plus it has a Range of 90 Blocks give or take a few. \\n\\nTo make it you'll need a Trapped Soul, 2 Tenacious Vines, and a Tenacious Petal. \\n\\nThe first two you can get as drops from a Tangled Hatred while the last you'll need to kill a Lunar Monstrocity. "]
 	quest.5A9D6672385D3D82.quest_desc: ["Only use 1 Lapis for an Upgrade instead of 4."]
 	quest.5A9D6672385D3D82.quest_subtitle: "Saving Lapis"
 	quest.5A9E8222AEA6EF6F.title: "Charoite Armor"
@@ -8116,7 +8045,6 @@
 	quest.5AAD0E516762BA53.quest_desc: ["Do you feel like you are levitating yet? Might be all that shulker from that Soul Vial."]
 	quest.5AAD0E516762BA53.quest_subtitle: "Prescient Crystal"
 	quest.5AAF6CA41209B365.title: "&3Vibranium Tools"
-	quest.5AB8651FCB1E2F72.title: "Elytra Blueprint"
 	quest.5AC1BE754210429E.quest_desc: ["If you want to create a team for you and your friends, use the command &a/ftbteams party create (name of team)&r to create the team!"]
 	quest.5AC497F76A086A5C.title: "&l&9Overworld Bounty:&r&e Witches"
 	quest.5AD09CCEEDC0B50F.quest_desc: ["Now these are super helpful, you should definitely check them out! \\n\\nThe actual Light Source is the Feral Flare Lantern. It will place invisible Light Sources around 20 Blocks or more around it. \\n\\nThe Mega Torch is different: it doesn't emit Light but it does Block all Hostile Mob spawns with 64 Blocks of it! Useful for those using Night Vision. \\n\\nThe Dread Lamp does the opposite, it blocks Passive Mob spawns in the same area."]
@@ -8624,7 +8552,7 @@
 	quest.6013C6B2E0B81D73.title: "&6Daycares"
 	quest.60175A8E3A67F51C.quest_desc: ["The Emitters and Sensors for each tier always seem to be the hardest components to make. But they always end up helping us in the end with the machines they construct. So its worth it in the end."]
 	quest.60175A8E3A67F51C.quest_subtitle: "Im sensing that you are emitting."
-	quest.601C719C8FD513F0.quest_desc: ["3 Netherite Ingots, 3 Wireless Boosters, and a bunch of fancy Gears we can get an Infinity Range Booster! \\n\\nThe most confusing parts are the Gears. We can't make the Ingots directly we need to mix Dusts together then Smelt the result to get the Ingots. \\n(Doesn't work across Dimensions sorry!)"]
+	quest.601C719C8FD513F0.quest_desc: ["3 Netherite Ingots, 3 Wireless Boosters, and a bunch of fancy Gears we can get an Infinity Range Booster! \\n\\nThe most confusing parts are the Gears. We can't make the Ingots directly we need to mix Dusts together then Smelt the result to get the Ingots.\\n\\nThis doesn't work across Dimensions sorry!"]
 	quest.601DA80C08C3F9AC.quest_desc: ["For all your rod production needs!"]
 	quest.601DA80C08C3F9AC.quest_subtitle: "Good ol' rod"
 	quest.60244F26B9ABED49.quest_desc: ["The 1024k Fluid Storage Part is used to craft the 1024k Fluid Storage Disk."]
@@ -8860,8 +8788,8 @@
 	quest.62A262A706CFCAF0.title: "{atm9.quest.evilcraft.bloodInfuser}"
 	quest.62B2C1A24AE245EA.quest_desc: ["The &9Deepshelf&r (not dormant) is your next step to Enchanting. Like everything else it needs Infusion. The &9Deepshelf&r needs 30 &aEterna&r, &c40%% Quanta&r, and &540%% Arcana&r. You can get that with &45 Blazing Hellshelves&r and &b4 Heart-Forged Seashelves&r."]
 	quest.62B2C1A24AE245EA.title: "&9Deepshelf&r"
-	quest.62B5A84753ADFC35.quest_subtitle: "8 Dry Dark Pink Blocks"
 	quest.62B4A37CFDECA679.quest_desc: ["The Menril Resin will go to 2 sides of the Squeezer. Placing a Drying Basin next to the Squeezer will make the Drying Basin pick up the Menril Resin.\\n\\nAfter 7.5 seconds the Menril Resin will turn into a Block of Crystallized Menril."]
+	quest.62B5A84753ADFC35.quest_subtitle: "8 Dry Dark Pink Blocks"
 	quest.62BBF61C9849CA26.quest_desc: [
 		"The minimum size is 5x5x5 and the maximum size is 15x15x15, and anywhere in between is valid!"
 		""
@@ -8963,8 +8891,7 @@
 	quest.63AEFB3C1395BBBA.quest_subtitle: "I swear, I am not a hoarder! I just like collecting things!"
 	quest.63BFEE8B17688712.quest_desc: ["The &6Large Chemical Bath&r can make large batch processing of resources a breeze! Im certain you will have a few of these setup in your base for the resources to come."]
 	quest.63BFEE8B17688712.quest_subtitle: "You down with LCB? Yeah you know me!"
-	quest.63CAD77A4488F2CE.quest_subtitle: "The All In One Tool"
-	quest.63CAD77A4488F2CE.title: "Paxel Blueprint"
+	quest.63CAD77A4488F2CE.quest_subtitle: "Pickaxe + Axe + Shovel"
 	quest.63DD7F5A4441ACE7.quest_desc: ["Tier 2 Glyphs require 5 levels of experience to be made. \\n\\nThey also require a &9Mage's Spell Book&r to create."]
 	quest.63E4149FF75592C8.quest_desc: [
 		"Finally, at &6HV&r you get access to the &dByproducts&r from the &eMacerator&r"
@@ -9032,13 +8959,9 @@
 	quest.649167FC31EB916E.title: "Vegetable Oil"
 	quest.6497A255E427A5EB.quest_subtitle: "Balsam Fir + Bull Pine"
 	quest.64A09E2E3EF16C31.quest_subtitle: "Banana + Teak"
-	quest.64AB1E133E218173.quest_desc: [
-		"You can't use template boards forever!!! "
-		""
-		"Blueprint paper is used to make blueprints, which are reusable, unlike template boards."
-	]
+	quest.64AB1E133E218173.quest_desc: ["You can't use Template Boards forever!\\n\\nBlueprint Paper is used to make Blueprints, which are reusable, unlike Template Boards."]
 	quest.64AB1E133E218173.quest_subtitle: "The Schematic Maker"
-	quest.64AB1E133E218173.title: "Blueprint Paper"
+	quest.64AB1E133E218173.title: "&9Blueprint Paper"
 	quest.64B04D1CBC923789.quest_subtitle: "Tier: &b4"
 	quest.64C105E1E2F97900.quest_desc: ["The Spike Mauls are used on normal &6Tracks&r to switch their modes. Very helpful for trying to make intersections!"]
 	quest.64C105E1E2F97900.title: "'Switch em up'"
@@ -9099,8 +9022,7 @@
 	quest.652DBDD284873140.title: "Deorum Block"
 	quest.653260450BEDB6AB.quest_desc: ["Why have 2 Energy Hatches when just one will do? This energy hatch accepts 4 Amps of IV all on its own!"]
 	quest.653487501398DECA.title: "Creative Jetpack"
-	quest.657B3116A6419420.quest_subtitle: "Create your own Handle!"
-	quest.657B3116A6419420.title: "Tool Rod Blueprint"
+	quest.657B3116A6419420.quest_subtitle: "Your own Handle!"
 	quest.657DB994B029F61C.quest_desc: [
 		"When the &3Heat Frame&r is placed on a container containing certain fluids and made cold enough, it will turn said fluids into items."
 		""
@@ -9238,7 +9160,7 @@
 		""
 		"Note: You only have to make one of the items to complete the quest."
 	]
-	quest.67216EC5274F08B9.title: "Shears Blueprint"
+	quest.67216EC5274F08B9.quest_subtitle: "Used by Shear-perds"
 	quest.672B308FD1DC0F45.quest_desc: [
 		"Give the &eBoiler&r some &bwater&r, input a &6fuel source&r, watch it heat up, and it will start creating &7steam&r!"
 		""
@@ -9493,12 +9415,12 @@
 	quest.6904EC449FBEE387.quest_subtitle: "Connecting The System"
 	quest.6904EC449FBEE387.title: "Cables"
 	quest.690CFF61CE787D43.quest_desc: ["Plastic is the main resource of &bIndustrial Foregoing&r, you now have access to some very useful machines!"]
-	quest.6912C0E3D092DD27.title: "Boots Blueprint"
 	quest.69201157ECFBB426.quest_desc: ["I always hate when I have an &5Endermen&r Farm for either XP or Apotheosis Gems but end up with all these &3Ender Pearls&r (hehe end up, &3ender pearls&r). Now you can use those &3Ender Pearls&r for Energy with the &3Ender Generator&r. You can even make &aEyes of Ender&r for even more Energy!"]
 	quest.69201157ECFBB426.title: "&3Ender Generator"
 	quest.692C9BA71EA0F0A7.quest_desc: ["You need this tier of Mixer to make &3Tungstensteel Dust&r as well as &dVanadium Gallium Dust&r"]
 	quest.692C9BA71EA0F0A7.quest_subtitle: "Where's the dough hook?"
-	quest.69383DA579901E7E.title: "Axe Blueprint"
+	quest.69383DA579901E7E.quest_subtitle: "Let me Axe you this"
+	quest.694D7CD9EC663355.quest_subtitle: "Mace I interest you in this?"
 	quest.6950FC974624C6AA.quest_subtitle: "Tier: &63"
 	quest.695A0DC585FB6E97.quest_desc: [
 		"Making the &6ATM Star&r requires a massive recipe using 55 &aCreate&r &eMechanical Crafters&r. "
@@ -9578,7 +9500,8 @@
 	quest.6A0D1E9D534958B8.title: "Chalcopyrite Vein"
 	quest.6A1145678E80FB8E.quest_desc: ["There's so many useless &5Enchantments&r out there, why not get some Energy out of them! The &bEnchantment Generator&r uses &5Enchanted Books&r to make Energy. The Level and Rarity of &5Enchanted Books&r changes the amount of Energy you get from them."]
 	quest.6A1145678E80FB8E.title: "&bEnchantment Generator"
-	quest.6A12188E50EAEB78.quest_desc: ["The Rainbow Furnace will smelt a stack of Items at a time! \\n\\nTo craft it you will need a Rainbow Core which needs 2 Netherite Furnaces and all the colors of the rainbow in Glass! \\n\\nThen, you'll need Rainbow Plating which you get from combining literally every other Furnace in the Mod (technically not literal it is missing some)."]
+	quest.6A12188E50EAEB78.quest_desc: ["The Rainbow Furnace will smelt a stack of Items at a time! \\n\\nTo craft it you will need a Rainbow Core which needs 2 Netherite Furnaces and all the colors of the rainbow in Glass! \\n\\nThen, you'll need Rainbow Plating which you get from combining almost every other Furnace in the mod. You'll need 2 of them to craft the Improbable Probablility Device."]
+	quest.6A12188E50EAEB78.title: "2 &cR&6a&ei&2n&3b&9o&5w &cF&6u&er&2n&3a&9c&5e&cs"
 	quest.6A18B971C3DB83AE.quest_subtitle: "Tier: &63"
 	quest.6A1C0B17B22CE50F.quest_desc: ["The &9Amulet of Mana Boost&r gives a boost to max mana. \\n\\nThe &6Amulet of Mana Regen&r gives a boost to your mana regen."]
 	quest.6A1C0B17B22CE50F.title: "The Amulets"
@@ -9598,15 +9521,8 @@
 		""
 		"Alternatively, a &emixer&r with salt dust and water will also produce salt water, but at that point you might as well &eelectrolyze&r the salt dust"
 	]
-	quest.6A393C7A24899E3E.quest_desc: [
-		"Placing an ingot in this with a Grader Catalyst will give the material a grade. "
-		""
-		"The better the grade, the better the stats are on the material. "
-		""
-		"The best grade is MAX. "
-	]
+	quest.6A393C7A24899E3E.quest_desc: ["Placing an ingot in the Grader with a Grader Catalyst will give the material a grade.\\n\\nThe better the grade, the better the stats are on the material.\\n\\nThe best grade is \"MAX\"."]
 	quest.6A393C7A24899E3E.quest_subtitle: "The Material Tester"
-	quest.6A393C7A24899E3E.title: "Material Grader"
 	quest.6A452BFC8A967C39.quest_desc: ["Wearing these &aClaws&r just makes you feel a certain way. Adrenaline pumping, thoughts ceasing, strength rising like no other! \\n\\nWith &aFeral Claws&r you will Attack much faster with your Weapons or Fists."]
 	quest.6A452BFC8A967C39.quest_subtitle: "Hands"
 	quest.6A452BFC8A967C39.title: "&aFeral Claws&r"
@@ -9732,8 +9648,7 @@
 	quest.6BEE3578BD2C713C.quest_subtitle: "Spawns from a Dirt Nest"
 	quest.6BF6B00BC21CA547.quest_subtitle: "RF-Powered Handsaw!"
 	quest.6BF6C7C04F26D8BA.quest_subtitle: "Black Ember + Soul Tree"
-	quest.6BFD7854F078BF16.quest_subtitle: "Get a Grip."
-	quest.6BFD7854F078BF16.title: "Grip Blueprint"
+	quest.6BFD7854F078BF16.quest_subtitle: "Get a Grip on this"
 	quest.6C001E18093FC037.title: "Plants"
 	quest.6C0D4CBC089988ED.quest_desc: ["This rune increases the capacity of the Altar by a multiplicative amount of 7.5% per rune. These apply after regular Capacity Runes."]
 	quest.6C14D1B60124C2B2.quest_desc: [
@@ -9788,9 +9703,8 @@
 		"Now we finally get to the Meat of the Mod, &eAlchemical Sulfurs&r! \\n\\nTo make them we'll need a Liquefaction Cauldron, an Item, &dSal Ammoniac&r, and a Heater. \\n\\nHeat is explained in another Quest but you'll need either the Pyromantic Brazier or the Caloric Flux Emitter beneath the Cauldron to Heat it. \\n\\nThen the Liquid &dSal Ammoniac&r in it. \\n\\nAnd finally the Item you want to be turned into an &eAlchemical Sulfur&r. \\n\\nYou'll know it's working when it's bubbling."
 		"{image:atm:textures/questpics/theurgy/theurgy_lique.png width:100 height:100 align:center}"
 	]
-	quest.6CAD27627A3F8FD7.title: "Making &eAlchemical Sulfur&r"
-	quest.6CAD67D21E1EA861.quest_desc: ["Universal remote access."]
 	quest.6CAD27627A3F8FD7.title: "Making &eAlchemical Sulfur"
+	quest.6CAD67D21E1EA861.quest_desc: ["Universal remote access."]
 	quest.6CB1BFBA10DF24E4.quest_desc: [
 		"Using this Scepter, you can drain the life of your enemies!"
 		""
@@ -9883,7 +9797,6 @@
 	quest.6D81DF90E9C2C049.title: "Elite Destructor"
 	quest.6D88C19F47D0D469.title: "Tier: &7Tiny"
 	quest.6D95CB7906C0DC84.quest_subtitle: "Beech + Cacao"
-	quest.6D9CDB4D81DC164D.title: "Bow Blueprint"
 	quest.6D9CFCD81A23BB3B.quest_desc: [
 		"&lAbility Type:&r Passive"
 		""
@@ -9959,7 +9872,6 @@
 		"Make at least 1 Mk.III Reactor. It will serve you well."
 	]
 	quest.6E18951E41103391.quest_subtitle: "Mk. III"
-	quest.6E2806D8DC61C46F.title: "Helmet Blueprint"
 	quest.6E29BA2E8642AF53.title: "ME Quantum Ring"
 	quest.6E2F24117ACF3694.quest_desc: [
 		"Gather the listed materials and then check JEI's Multiblock Info page to see how to build it"
@@ -10121,7 +10033,7 @@
 	quest.6FBF112811FB707C.quest_subtitle: "Ash + Birch"
 	quest.6FC4146E534C51DA.quest_desc: ["By combining a Netherite Upgrade Template, a Netherite Helmet, and a Monstrous Horn to make the Monstrous Helm. It has better stats and when you're at half health it'll do knockback everything close to you and increase defense stats."]
 	quest.6FC4146E534C51DA.title: "Monstrous Helm"
-	quest.6FC55CF56BE22866.quest_subtitle: "531,441 Blocks of Dirt"
+	quest.6FC55CF56BE22866.quest_subtitle: "531,441 Dirt"
 	quest.6FC7DC1F856A748D.quest_desc: ["Okay this is a long one just stick with me. First Ability allows two modes,  &6Sancity&r and &7Unholiness&r. &6Sancity&r takes some of your Healing and uses it as Damage against enemies. &7Unholiness&r does the opposite, it takes the enemies Healing to help you deal more damage. Mobs like &dEnder Dragon&r and &5Wither&r both regenerate Health. \\n \\nThe Second Ability is Repentance, while active it will Burn Undead Mobs (Zombie, Skeleton, and their cousins). \\n \\nThe Third Ability grants a small time period of Invincibility."]
 	quest.6FC7DC1F856A748D.quest_subtitle: "Found in all Villages"
 	quest.6FC7DC1F856A748D.title: "&6Holy&r &7Locket&r"
@@ -10190,6 +10102,7 @@
 		"If you have a way to drop items precisely into the crucible, it helps to avoid anything missing in that 4 second time."
 	]
 	quest.704184F62CA78E1E.quest_subtitle: "It's complicated."
+	quest.7043CDA7EBFAF560.quest_desc: ["Coating Smithing Templates are used to coat gear. They can be duplicated by crafting like other Smithing Templates."]
 	quest.7044EAB5EDF32BBC.quest_desc: [
 		"When attached to your system, the &9Crafting Monitor&r allows you to see what items are currently in your crafting queue. "
 		""
@@ -10245,7 +10158,7 @@
 		"First things first, let's work towards making stainless steel so we can make HV machines"
 	]
 	quest.70C952B8FF3418F6.quest_subtitle: "Buckle up for &6HV&r"
-	quest.70CCE558E03227AB.quest_desc: ["Pressure Chamber is how we currently cook up the ATM Star and the Patrick Star. \\n\\nPressure Chamber is a hollow cube made mostly of Pressure Chamber Walls or Glass (the frame must be only Walls). It will need atleast 1 Valve to move Pressure to it! The Interfaces are the most important; these are how Items go in, get crafted, and come out. Blue side is input and Orange side is output. \\n\\nOnce the Items are in and the Pressure is set perfectly, it'll craft your Items!"]
+	quest.70CCE558E03227AB.quest_desc: ["The Pressure Chamber is how we craft the ATM Star and the Patrick Star.\\n\\nThe Pressure Chamber is a hollow cube made mostly of Pressure Chamber Walls or Glass (the frame must be only Walls). It will need at least 1 Valve to move Pressure to it! The Interfaces are the most important; these are how Items go in, get crafted, and come out. Blue side is input and the orange side is output.\\n\\nOnce the items are in and the pressure is set perfectly, it'll craft your items!"]
 	quest.70CDA5F1593DB4B2.quest_desc: ["&eThe Cursed Pyramid&r spawns in deserts and it's very hard to miss. A massive pyramid with huge pillars by the entrance. In it you'll find a lot of traps, husks, and loot! Once you get to the bottom you'll find many &eKoboletons&r and a sleeping giant. To wake it up you'll need a..."]
 	quest.70CDA5F1593DB4B2.title: "&eCursed Pyramid&r: Home of &eAncient Remnant&r"
 	quest.70D60687AAB145FE.quest_subtitle: "Common"
@@ -10269,8 +10182,8 @@
 		"- Stupefy"
 		"- Night Vision"
 	]
-	quest.7154D73516548149.quest_desc: ["AllTheModium Mod is one added specifically by the AllTheMods team to add more content after Netherite! \\n\\nYou'll need to adventure through it to get some Items needed for the ATM Star. \\n\\nThere is a Quest page now that you can follow for it!"]
-	quest.7154D73516548149.title: "AllTheModium"
+	quest.7154D73516548149.quest_desc: ["&6Allthemodium&r is a mod added specifically by the AllTheMods team to add more content after Netherite! \\n\\nYou'll need to adventure through it to get some Items needed for the ATM Star. \\n\\nThere is a Quest page now that you can follow for it!"]
+	quest.7154D73516548149.title: "Allthemodium"
 	quest.71581992E8E4C43E.quest_desc: ["Throw a few Wither Skeleton Skulls and an Abjuration Essence to make a Wither Glyph! \\n\\nIf it didn't work you might need more EXP."]
 	quest.715B86DC82EA636B.quest_desc: [
 		"The &3Liquid Compressor&r creates pressure using certain liquids. You can put the fuel in by right-clicking the bucket onto the machine, pumping in the fluid, or by putting a bucket in the top slot in the GUI."
@@ -10517,7 +10430,7 @@
 	quest.7353DB3A9820C92F.quest_desc: ["Titanium Carbide dust for Titanium Carbide plates are the second item needed for the Alloy Blast Furnace walls. "]
 	quest.7353DB3A9820C92F.quest_subtitle: "High Strength Titanium"
 	quest.7361BD20A6B95D14.quest_subtitle: "Tier: &63"
-	quest.7377C657CED885AC.quest_desc: ["Mystical Agriculture is a Mod about Agriculture clearly, but what are we farming for? \\n\\nPretty much anything, from Honey to Steel to Wither Skeletons. \\n\\nYou'll need a lot of farming with this Mod to get the ATM Star!"]
+	quest.7377C657CED885AC.quest_desc: ["Mystical Agriculture is a mod about agriculture, but what are you farming for?\\n\\nPretty much anything, from Honey to Steel to Wither Skeletons.\\n\\nYou'll need to do a lot of farming with this mod to make the ATM Star!"]
 	quest.7377C657CED885AC.title: "Mystical Agriculture"
 	quest.7382C366A1ABAAE3.quest_desc: ["Quantum CPU's processing all the Qubits!"]
 	quest.7382C366A1ABAAE3.quest_subtitle: "How many Qubits in a Ghz?"
@@ -10536,11 +10449,7 @@
 	quest.73B73870B29DFAD9.quest_desc: ["One of us! One of us! \\n\\nThe &eVillager Hat&r makes the Villagers believe you're from the same Town so they get rid of the Out-of-Towners Tax. Villager Trades are cheaper."]
 	quest.73B73870B29DFAD9.quest_subtitle: "Head"
 	quest.73B73870B29DFAD9.title: "&eVillager Hat"
-	quest.73B8A70240E6070E.quest_desc: [
-		"Find a cow and Right Click it with a bucket. "
-		""
-		"Seriously, why no bulls?"
-	]
+	quest.73B8A70240E6070E.quest_desc: ["Find a Cow and Right Click it with a Bucket.\\n\\nSeriously, why no Bulls?"]
 	quest.73B8A70240E6070E.quest_subtitle: "Why aren't there Bulls in the game?"
 	quest.73B8A70240E6070E.title: "Milk a Cow - Profit"
 	quest.73BE1EB3E69814E9.quest_desc: ["First and easiest part of this recipe is Evil Sticks. Just need Dark Gems which you Mine for, and Undead Planks which you get from Undead Trees. \\n\\nNext, is the Empowered Inverted Potentia. It's not that hard to make simply craft an Inverted Potentia then keep it in an Enviromental Accumulator and have it get struck with Lightning! \\n\\nLast part has a huge line of Empty Promises; you'll be infusing a whole lot. \\n\\nHope you got plenty of Blood! Speak of the devil you'll also need to fill the Mace with Blood."]
@@ -10558,9 +10467,8 @@
 	quest.73CD6CE2B10830B9.title: "&6Master of The Universe&r"
 	quest.73D60868024FF907.quest_desc: ["The Fluid MK2! \\n\\nAny Liquid Source nearby can be used with this one, not just adjacent."]
 	quest.73D6B980D35082A0.quest_desc: ["This one takes awhile to explain so have patience. \\n\\nFirst, find an &aEvoker Fort&r. \\nNext, find a Research Book hidden in it. Then, have a Trader who's hostage in the &aFort&r translate it. (Like our hostage Quest Translators!) \\nOnce, it's translated bring it to a &6&lPriest&r in a &6Village&r to trade it for the &eSpell Book&r! \\n\\nIt gives a boost to &6Holy Spells&r and don't worry the hostage Traders are very very rare, keep looking!"]
-	quest.73D6B980D35082A0.title: "&6Villager Bible&r"
-	quest.73E2A53A088AD29A.quest_subtitle: "11 Wet Pink Blocks"
 	quest.73D6B980D35082A0.title: "&6Villager Bible"
+	quest.73E2A53A088AD29A.quest_subtitle: "11 Wet Pink Blocks"
 	quest.73EA326304C01C3B.quest_desc: [
 		"Put an Importer onto the inventory you want stuff pulled from. Next, put the Interface on the second inventory and connect them with Logic Cables. Then, put in the Variable Card into the Importer and change it as you please.\\n\\nIt can be changed to import things at the Integer Limit (Over 2 billion)."
 		"{image:atm:textures/questpics/logistics/id_item.png width:200 height:50 align:center}"
@@ -10650,7 +10558,6 @@
 		"This also produces Cobalt Oxide and some Sulfur Dioxide which can be further processed to get some of that oxygen back"
 	]
 	quest.74F524F4F0231A78.quest_desc: ["Can be used to charge items, augment machines, or fill up items with liquid."]
-	quest.74FA25B2E087BEC4.title: "Ring Blueprint"
 	quest.74FC0DDDB91DB172.quest_desc: [
 		"To make life that much easier, AE2 provides a whole suite of devices for the manipulation of ME data, i.e. moving stored items around the world. "
 		""
@@ -10668,7 +10575,7 @@
 	quest.751189465F91B353.quest_desc: ["The &bCrystalline Seashelf&r is an upgrade to the &bInfused Seashelf&r. It's very good for normal Enchantments but doesn't give us enough &5Arcana&r for the next Infusion we'll need. Still good stats for normal Enchanting though!"]
 	quest.751189465F91B353.title: "&bCrystalline Seashelf&r"
 	quest.75238B267CBFFAFE.quest_subtitle: "&f4.5&r &4Damage&r"
-	quest.752DD0BF36B70D88.quest_desc: ["Furnaces just aren't fast enough in Normal Minecraft so how do you think they're going to fair in Modded! \\n\\nThankfully Iron Furnaces helps speed them up, like by a lot! \\n\\nIt also has a Quest page it is just rooming together with Generator Galore."]
+	quest.752DD0BF36B70D88.quest_desc: ["Furnaces just aren't fast enough in normal Minecraft, so how do you think they're going to fair in Modded!?\\n\\nThankfully Iron Furnaces helps speed them up by a lot! \\n\\nIt also has a Quest page it is just rooming together with Generator Galore."]
 	quest.752DD0BF36B70D88.title: "Iron Furnaces"
 	quest.753B3EF7CC94A6DD.quest_desc: [
 		"{atm9.quest.evilcraft.desc.uniqueDrop.1}"
@@ -10765,7 +10672,7 @@
 	quest.762C54C261ED5D29.quest_subtitle: "Teak + Mahogany"
 	quest.76406EFFF8CBA6B4.quest_desc: ["Diamonds are one of the best materials to use for tool crafting, but also allows you to visit new dimensions like the Nether!"]
 	quest.76406EFFF8CBA6B4.title: "We've Struck &bDiamonds&r!"
-	quest.764609E41957DA69.quest_subtitle: "Hope you like Trading!"
+	quest.764609E41957DA69.quest_subtitle: "6,561 Emerald Blocks"
 	quest.7649D648A3688D4A.quest_desc: ["The Puller Upgrade allows Drawers to pull in items from any side."]
 	quest.76558D23A70AFF78.title: "&bIce&r Upgrade Orb"
 	quest.7655E1C6C5E5469F.quest_subtitle: "Range: &a18&r Blocks"
@@ -10777,7 +10684,7 @@
 	]
 	quest.7666D2DA3D0C3F00.quest_desc: ["The ZPM Mixer is needed to craft the Uranium Rhodium Dinaquadide that we need for our Fusion Reactor Mk.II."]
 	quest.7666D2DA3D0C3F00.quest_subtitle: "Mixin' it up!"
-	quest.766C80E5D7B7A916.title: "Pickaxe Blueprint"
+	quest.766C80E5D7B7A916.quest_subtitle: "Pick one!"
 	quest.766EEB89C6DF3575.quest_desc: ["Eternal Stella can be used to either make an Item Unbreakable by combining it with the Item in a Smithing Table. Or you can use it to craft Alloy Tools! \\n\\nFirst, you'll need a Tier 3 Forge with plenty Materials in it. \\n\\nThen, you'll need 3 Xpetrified Orbs. Which you need to feed a Black Hole Items to get. \\n\\nPlus, a Stellarite Piece which you need to Mine for! And &6AllTheModium Ingot&r which is the same."]
 	quest.7678B5DD1339833E.quest_desc: ["The Solar Panel generates FE when given direct access to the sun. However, you can use a &7Lens of Ender&r to ignore blocks in its way."]
 	quest.768951FBE8A5C934.quest_desc: [
@@ -10789,6 +10696,7 @@
 	quest.768B5E3633A76ED0.quest_subtitle: "&eTier 5&r"
 	quest.768C07D1B5EB1FEB.quest_desc: ["These can be found in Suspicious Sand and Gravel inside Cold Ocean Ruins."]
 	quest.768C07D1B5EB1FEB.quest_subtitle: "Cold Ocean Ruin Sus Blocks"
+	quest.769D5DE66D13B256.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks.\\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission.\\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
 	quest.76A0592F4C294545.quest_desc: ["The Sawmill cuts Logs into Sawdust and more Planks than you would get from crafting. Sawdust can be used to make Paper.\\n\\n - Fustic Logs will also give you Fustic.\\n - Brazilwood Logs and Logwood Logs will also give you Haematoxylin."]
 	quest.76A0592F4C294545.quest_subtitle: "I Wood too"
 	quest.76A0592F4C294545.title: "Sawing"
@@ -10884,10 +10792,8 @@
 	]
 	quest.77D3546953550E39.quest_subtitle: "Bull Pine + Spruce"
 	quest.77F2271C45DB49BA.quest_desc: ["This Module, when put into the Mekasuit Chestplate, will give you Creative Flight. \\nYou only need some of the most expensive Items in the game to craft it!"]
-	quest.77F241BEE9902751.quest_desc: ["Even MORE slots for storage and upgrades."]
-	quest.77F241BEE9902751.quest_subtitle: "So much room for activities!"
-	quest.77F241BEE9902751.title: "&5Netherite Chest&r"
 	quest.77F241BEE9902751.quest_desc: ["The biggest of the chests from Sophisticated Storage"]
+	quest.77F241BEE9902751.quest_subtitle: "So much room for activities!"
 	quest.77F241BEE9902751.title: "&dNetherite Chest"
 	quest.77FC692AC94D2EEF.title: "&l&9Overworld Bounty:&r&e Creepers"
 	quest.780DE5A24ED53F60.quest_desc: [
@@ -10912,8 +10818,6 @@
 		"Networks without an &bME Controller&f are known as 'ad-hoc' networks and only support a maximum of 8 channels."
 	]
 	quest.7834734E79E41A3A.quest_desc: ["Please reconsider playing with the &l&6Bumblezone&r Mod if you suffer from any of these phobias: \\n\\nMelissophobia, Apiphobia, Entomophobia, Arachnophobia, Homophobia, Trypophobia, Acrophobia, Claustrophobia, and Crystallophobia. \\n\\nIf you suffer from Trypophobia you can use the resource pack added by &l&6Bumblezone&r to help! If it's anything else you're screwed."]
-	quest.784D6D11C4F41215.quest_subtitle: "&f6.5 &cAttack Damage"
-	quest.785951190FFDAA21.title: "&eStack Upgrade Tier 2&r"
 	quest.7834734E79E41A3A.quest_subtitle: "Bee careful!"
 	quest.784D6D11C4F41215.quest_subtitle: "&f6.5 &cAttack Damage"
 	quest.785951190FFDAA21.quest_desc: ["Increases stack size in the Backpack by 4."]
@@ -10921,8 +10825,7 @@
 	quest.785CB375F25F0715.quest_desc: ["Were almost there, to a completed Circuit Board strong enough for our Quantum Processors!"]
 	quest.785CB375F25F0715.quest_subtitle: "Annealed Copper makes a Come back!"
 	quest.786073B57C901DB7.title: "Pluses Banner Pattern"
-	quest.7860FD3D3273351F.quest_subtitle: "Stores all of your blueprints!"
-	quest.7860FD3D3273351F.title: "Blueprint Book"
+	quest.7860FD3D3273351F.quest_subtitle: "Storing Blueprints!"
 	quest.78656C89EEE80DB5.quest_desc: ["The &n&5Tunnels&r can be placed on belts and they will filter items that pass through them. You can link multiple tunnels by placing them next to each other."]
 	quest.787415570026FFAA.quest_desc: [
 		"These upgrades add enchantments to your Destructor. "
@@ -10970,7 +10873,6 @@
 	quest.78AA7BFABBFB9973.quest_desc: ["&2&lNature's&r &eSpell Book&r. \\n\\nIt has 10 &3Spells&r and gives a boost to &2Nature Spells&r! \\n\\nYou need a Rotten Spell Book to craft it though..."]
 	quest.78AA7BFABBFB9973.title: "&2Druidic Tome"
 	quest.78B7FC6A868F5C4D.quest_desc: ["You have to either find these in structures in the &6&lBumblezone&r or you can trade with the &5Bee Queen&r to get one! \\n\\nWhile wearing it you can hold Space Bar to fly for a little. \\n\\nExcept like a &6B&8e&6e&r the Wings are too small to keep your fat little body off the ground."]
-	quest.78C112170E17FBF4.title: "Shield Blueprint"
 	quest.78C51E9B7B8315F6.quest_desc: ["This machine also uses Casting Molds to form the fluids into different shapes"]
 	quest.78C51E9B7B8315F6.quest_subtitle: "Need that fluid to be solid?"
 	quest.78CDA5B4A52FF5D8.quest_desc: ["As is the theme with these multiblocks, Having a machine that can process all of the programmed circuits all in one machine?! These machines really are a true advancement in helping to progress to the end!"]
@@ -11273,6 +11175,8 @@
 	]
 	quest.7B5A0BFD47D96BDE.quest_desc: ["Used to catch bees that are flying around it.\\n\\nYou can use a Filter Upgrade to filter out which bees you want to catch, as well as a BaBee Upgrade to only catch baby bees."]
 	quest.7B5A0BFD47D96BDE.quest_subtitle: "Catches Bees"
+	quest.7B690431CF1B87D0.quest_desc: ["To get started with gear crafting in the early game, we'll need to make some &9Template Boards&r to create our first Template.\\n\\nTemplates are single-use \"blueprints\" for creating tool parts. Using basic Template Boards, craft yourself a &aPickaxe Template&r.\\n\\nIf you combine the Pickaxe Template with 3 of most materials, you can create a Pickaxe Head.\\n\\nNote: The material must have a Silent Gear material tooltip with the main type."]
+	quest.7B690431CF1B87D0.title: "Pickaxe Heads"
 	quest.7B7504F386DABBDD.quest_desc: ["Place this under the soil to allow Dragon Egg Seeds to grow."]
 	quest.7B7D1F0CB326B28F.quest_desc: [
 		"The &bME IO Port&f allows for the contents of an ME network's storage to be quickly rearranged between different storage media such as ME cells and external containers connected to storage buses. "
@@ -11314,17 +11218,9 @@
 	quest.7C26D0295ABBF5BD.title: "Elite Disk Manipulator"
 	quest.7C2ED69E07988DF4.quest_desc: ["The original &2&lMinecraft&r Chair, the stairs. \\n\\nWelcome to Modded &2&lMinecraft&r, we have much more than just stairs for decoration. \\n\\nThere are dozens of mods that add decoration and even more that add items that can be used for decoration!"]
 	quest.7C2ED69E07988DF4.title: "Decoration!"
-	quest.7C3D763CF22D167A.quest_desc: [
-		"The Starlight Charger can 'enchant' materials with the 'Star Charged' enchantment. "
-		""
-		"A structure must be built with the Starlight Charger in the middle in view of the night sky. It only gains Starlight Power during the night. "
-		""
-		"The Charger must be placed in the middle of a 7x7 structure, with a Pillar in each corner. Each pillar must have a 'Starlight Charger Cap'. "
-		""
-		"It also requires a charger catalyst per material."
-	]
-	quest.7C3D763CF22D167A.quest_subtitle: "'Enchanting' Materials"
-	quest.7C3D763CF22D167A.title: "&5Starlight Charger"
+	quest.7C3D763CF22D167A.quest_desc: ["The Starlight Charger can \"enchant\" materials with the \"Star Charged\" enchantment.\\n\\nA structure must be built with the Starlight Charger in the middle in view of the night sky. It only gains Starlight Power during the night.\\n\\nThe Charger must be placed in the middle of a 7x7 structure, with a Pillar in each corner. Each pillar must have a \"Starlight Charger Cap\".\\n\\nIt also requires a charger catalyst per material."]
+	quest.7C3D763CF22D167A.quest_subtitle: "\"Enchanting\" Materials"
+	quest.7C3D763CF22D167A.title: "&dStarlight Charger"
 	quest.7C3F65B5DAC7E57B.quest_desc: ["&dShadow Glaives&r are more Weapons than &6Relic&r. First Ability is just throwing 1 &dGlaive&r. After it hits a mob, it'll bounce back to other mobs, and maybe return back to you. You can upgrade it for more damage, bounces, and quicker recharge. \\n \\nThe Second Ability uses all its charges to release a giant &dsaw&r! It's very cool I recommend trying it out!"]
 	quest.7C3F65B5DAC7E57B.quest_subtitle: "Found in End Cities and End Ships"
 	quest.7C3F65B5DAC7E57B.title: "&dShadow Glaive"
@@ -11400,7 +11296,7 @@
 		"You can set specific channels, named by you, to transfer whatever you want from it."
 	]
 	quest.7CC49360D07086B8.quest_subtitle: "Wireless Power, Gases, Fluids, Everything."
-	quest.7CC96CE9901F25BB.quest_desc: ["&l&5Forbidden Arcanus&r is another Magic Mod this one revolving around the Multiblock structure called, the Hephaestus Forge. \\n\\nTo make it follow the instructions in the Forges description! Once made you can feed it the 4 Materials to power Rituals: Aureal, Souls, Blood, and Experience. \\n\\nYou'll also need to upgrade the Forge via Rituals (all these you can find in EMI)."]
+	quest.7CC96CE9901F25BB.quest_desc: ["&l&5Forbidden and Arcanus&r is another magic mod, this one revolving around the Multiblock structure called, the Hephaestus Forge.\\n\\nTo make it follow the instructions in the forge's tooltip! Once made you can feed it the 4 Materials to power Rituals: Aureal, Souls, Blood, and Experience.\\n\\nYou'll also need to upgrade the Forge via Rituals (all these you can find in JEI)."]
 	quest.7CE86300AF8E9BCA.quest_desc: ["Crafting 8 of the same Generators together with an Echo Shard combines them into 1 massive Generator! Works the same as 8 regular generators but only takes up the space of 1."]
 	quest.7CE86300AF8E9BCA.title: "8x What a deal!"
 	quest.7CF13A4941F608E5.quest_desc: ["From normal Glass, to Glass with Panes, to even Mosiacs!"]
@@ -11471,7 +11367,8 @@
 		"We want to use the Fusion Anvil we made to upgrade our &dInfernal Forge&r to a &dVoid Forge&r... but we're missing one crucial piece: a &5Void Core&r. To get this, head to the End and locate the &eRuined Citadel&r. Defeat the &dEnder Golem&r inside and make your &dVoid Forge&r!"
 	]
 	quest.7D8ECACF214324D6.title: "&5Void Forge&r"
-	quest.7D972A3C4211EB26.quest_desc: ["You'll need 2 more for the Improbable Probability Device."]
+	quest.7D972A3C4211EB26.quest_desc: ["Rainbow Coal is obtained by blowing up a Rainbow Furnace."]
+	quest.7D972A3C4211EB26.title: "&cR&6a&ei&2n&3b&9o&5w &cC&eo&3a&5l"
 	quest.7D972F334DCE5626.quest_desc: [
 		"Naquadah is going to be an extremely vital component of this Tier as well as future tiers."
 		""
@@ -11517,14 +11414,14 @@
 	]
 	quest.7E07C5A6FA6B6B1F.title: "Blutonium"
 	quest.7E124E6EFC7E8ADD.quest_desc: ["Increases movement speed."]
-	quest.7E13007340A818C5.quest_desc: ["This is a Tier 1 Pillar Cap for the Starlight Charger structure."]
+	quest.7E13007340A818C5.quest_desc: ["This is a Tier 1 Pillar Cap for the Starlight Charger."]
 	quest.7E13007340A818C5.title: "Tier 1 Starlight Charger Pillar Cap"
 	quest.7E17AB5A4492929E.quest_desc: ["Every Reactor uses Uranium somewhere for fuel, right?\\n\\nFor starters, let's gather some &aUranium Ingots&r. We'll need to process these in an &9Enrichment Chamber&r to turn it into &eYellow Cake Uranium&r."]
 	quest.7E17AB5A4492929E.quest_subtitle: "Of Course It Uses Uranium"
 	quest.7E17AB5A4492929E.title: "&aUranium"
 	quest.7E39FB9F3E973009.title: "Ether Gas"
 	quest.7E407CDBFD85E65F.quest_desc: ["Oxygen + Ethylene on &aProgram 2&r in your &eChemical Reactor&r is one way to make Acetic Acid"]
-	quest.7E4367252A39BE6C.quest_desc: ["Powah is about Ponies. No I'm kidding it's about Power! Generating Power like FE to use Machines from other Mods like Mekanism or Industrial Foregoing! \\n\\nThere's different Tiers you'll have to craft up to and of course we'll need the last one for the Star!"]
+	quest.7E4367252A39BE6C.quest_desc: ["Powah is about power! Generating Power like FE to use Machines from other Mods like Mekanism or Industrial Foregoing! \\n\\nThere's different Tiers you'll have to craft up to and of course we'll need the last one for the Star!"]
 	quest.7E4367252A39BE6C.title: "Powah"
 	quest.7E49C985A0433B20.quest_desc: ["&d&lArs Nouveau&r is a very fun magic Mod and with it brings its own set of Wood! \\n\\nArchwood comes in 5 different colors of trees that spawn in most Biomes but mostly in their Archwood Biome!"]
 	quest.7E49C985A0433B20.title: "&d&lArs Nouveau&r Logs"
@@ -11756,6 +11653,7 @@
 	task.0A77407CE9055F04.title: "Sweat Bee"
 	task.0AD65BDFBE16460E.title: "Observe Complete Large Extraction Machine"
 	task.0AFA64F1025569A2.title: "Netherite Gear"
+	task.0B10BF3641629974.title: "Tools"
 	task.0B31B1E6089BB33E.title: "Observe a completed Fusion Reactor"
 	task.0B54EDC9E21F2E77.title: "Logistics Frames"
 	task.0BAEC53DD32C9870.title: "Productive Trees"
@@ -11863,9 +11761,9 @@
 	task.208145EA6533CDDB.title: "Enderium Comb"
 	task.212BB84583FE4B8B.title: "Farmer Bee"
 	task.2153473228DA4678.title: "Breeding and Converting Bees"
+	task.21AD4382C0068CDB.title: "Quests By AllTheMods"
 	task.21FBC4E0F668347C.title: "NBT and YOU!"
 	task.225F53F8A0E9E822.title: "Cooking for Blockheads"
-	task.2363F64BEC430933.title: "Quartz Swords"
 	task.22CCBBC66D509404.title: "Networks!"
 	task.2363F64BEC430933.title: "Quartz Swords"
 	task.238B5BA2FAE9785B.title: "AllRightsReserved"
@@ -11898,6 +11796,7 @@
 	task.2A2D77813F3127A6.title: "Rails"
 	task.2A6E713A062510B6.title: "Fueling the Reactor"
 	task.2A7CD3F14D3DC7C5.title: "Unobtainium Armor"
+	task.2ADE9DBE9448AC7F.title: "Silent Gear Pickaxes"
 	task.2BA7FC10243AA011.title: "Pressurized Tubes"
 	task.2BC0F5A88E2F03C3.title: "Archwood Logs"
 	task.2BECEC3EFA8F6DA3.title: "Chipped Stones"
@@ -11921,6 +11820,7 @@
 	task.2F28B803C75DA3B2.title: "Kill 1 Elder Guardian"
 	task.2F608F433D9A3363.title: "Expanded RF Coil"
 	task.2F94B8FED9BF6698.title: "Macaw's Holidays"
+	task.2FEC915DC58F30C4.title: "Repair Kits"
 	task.3007461CFCC0A013.title: "AllRightsReserved"
 	task.301665A6315B569C.title: "Storage Controllers"
 	task.30443BA4C089AA8B.title: "Any GT Hammer"
@@ -12039,12 +11939,14 @@
 	task.4851C74261B5FA25.title: "AllRightsReserved"
 	task.485E17B9E80D5DFF.title: "Occultism Pickaxes"
 	task.4892144C32DCEB55.title: "Painted Planks"
+	task.489419C982E77CD2.title: "Pickaxe Heads"
 	task.48A30B08A090BD75.title: "Wrenches"
 	task.48C19477CB216AD4.title: "Sulfur Dust"
 	task.48CF7A7622423DEA.title: "Pipe Upgrades"
 	task.490EAAA3703A576F.title: "Black Lotus"
 	task.491DC7AF3356B0AE.title: "GT Wrenches"
 	task.497485048E0AD20D.title: "Auxiliary Process Sieve"
+	task.498AA33867046334.title: "Armor"
 	task.49A8320F9EA7F4BD.title: "Automating Compressed Iron"
 	task.49C77D4CDAE03481.title: "The Silence of the Forest"
 	task.49F387C7EAD579A2.title: "Completed Macaw"
@@ -12094,6 +11996,7 @@
 	task.54A7E248C8A40239.title: "Tier 2 Sigils"
 	task.558649C69096D2D7.title: "Starter Generating Flowers"
 	task.559F3BFEC15996F8.title: "Turbine Power"
+	task.55E0635973A828B0.title: "AllRightsReserved"
 	task.55F718D796CEB1B1.title: "Bronze Comb"
 	task.56A486D09B8B90EC.title: "Observe Alloy Blast Smelter"
 	task.570BF38EA2870300.title: "Quests By AllTheMods"
@@ -12158,6 +12061,7 @@
 	task.64248C6FBC867D56.title: "Nomad Bee"
 	task.646B54EB48AFB6A4.title: "Kill 10 Bee Variants"
 	task.647F2A845A62F6B6.title: "Observe a Rotary Hearth Furnace"
+	task.6487378AF8DF4EBD.title: "Quests By AllTheMods"
 	task.64A8B8EDC7F58D0D.title: "Palladium Dust"
 	task.64EAD3DE84E94F02.title: "ME Covered Cables"
 	task.64FADC78A8AD3FE4.title: "Seeds"
@@ -12170,6 +12074,7 @@
 	task.6609E5E7EDE6F92B.title: "Saplings"
 	task.665A5DFA6270ADA6.title: "Simple Machines"
 	task.669DEA201002793D.title: "Fridges"
+	task.66ACCF967C939342.title: "AllRightsReserved"
 	task.66C97246C3EEFB7C.title: "Observe Sulfuric Acid in a Machine"
 	task.6754D9E162472CA1.title: "Allthemodium Progression"
 	task.67B21CF59C3D02E5.title: "Advanced Machines"
@@ -12199,6 +12104,7 @@
 	task.6D7DD99A02A8F451.title: "Visit The Deep Dark"
 	task.6D9221A533926A7B.title: "AllRightsReserved"
 	task.6D9C084B63F0AE29.title: "Forge Hammers"
+	task.6D9DBD885FE4C94C.title: "AllRightsReserved"
 	task.6DE94C2C7F4B9AC7.title: "Observe completed Distillation Tower"
 	task.6E0961A56194F0A8.title: "Digger Bee"
 	task.6E75525A5D88EF23.title: "Heaters"

--- a/config/ftbquests/quests/reward_tables/3602F483568B92BA.snbt
+++ b/config/ftbquests/quests/reward_tables/3602F483568B92BA.snbt
@@ -6,7 +6,6 @@
 	loot_size: 1
 	order_index: 18
 	rewards: [
-		{ item: { count: 1, id: "minecraft:mangrove_chest_boat" } }
 		{ count: 4, item: { count: 1, id: "minecraft:raw_iron" } }
 		{ count: 8, item: { count: 1, id: "minecraft:iron_bars" } }
 		{ count: 10, item: { count: 1, id: "minecraft:bone_meal" } }
@@ -19,7 +18,6 @@
 		{ item: { components: { "minecraft:stored_enchantments": { levels: { "minecraft:blast_protection": 2 } } }, count: 1, id: "minecraft:enchanted_book" } }
 		{ item: { count: 1, id: "chipped:chisel" } }
 		{ item: { count: 1, id: "ironfurnaces:upgrade_copper" } }
-		{ item: { count: 1, id: "productivetrees:avocado" } }
 		{ count: 64, item: { count: 1, id: "minecraft:glass" } }
 		{ item: { count: 1, id: "minecraft:diamond_sword" } }
 		{ item: { count: 1, id: "minecraft:iron_axe" } }

--- a/config/ftbquests/quests/reward_tables/uncommon.snbt
+++ b/config/ftbquests/quests/reward_tables/uncommon.snbt
@@ -128,16 +128,14 @@
 			weight: 10.0f
 		}
 		{
-			count: 2
+			count: 4
 			item: {
 				count: 1
 				id: "ae2:silicon"
 			}
-			random_bonus: 4
+			random_bonus: 8
 			weight: 15.0f
 		}
-		{ item: { count: 1, id: "aquaculture:neptunium_sword" } }
-		{ }
 		{
 			count: 4
 			item: {


### PR DESCRIPTION
Added Silent Gear quests ported from ATM9 with some quests added and a lot of descriptions added/changed. Redid rewards the quests in the chapter.
Added some Stars above quests that have items needed for the Star.
Added ARR quest to the Basic Tools chapter.
Fixed some reward orders (a lot in the Chapter 2 and Food & Farming chapters).
Lots of work to the quests in Chapter 2.
Added 2 rewards to the MA chapter.
Added 2 quests to the Food & Farming chapter.
Fixed 2 HNN Prediction quests.
Moved a PNC quest image slightly.
Adds rewards to some Relics quests.
Removes dependencies from Artifacts quests.
Fixes/Changes 2 reward tables.
Lots of space saves.
A few typo fixes.
Lots of various other fixes, changes and additions.

Resolves: https://github.com/AllTheMods/ATM-10/issues/730
Resolves: https://github.com/AllTheMods/ATM-10/issues/713
Resolves: https://github.com/AllTheMods/ATM-10/issues/711
Resolves: https://github.com/AllTheMods/ATM-10/issues/704