### PR TITLE
Add recipe to fix honeycomb compression

### DIFF
--- a/kubejs/server_scripts/mods/Bumblezone/Recipes.js
+++ b/kubejs/server_scripts/mods/Bumblezone/Recipes.js
@@ -1,0 +1,13 @@
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
+
+ServerEvents.recipes(allthemods => {
+    allthemods.remove({ id: 'the_bumblezone:carvable_wax/from_honeycomb' })
+    allthemods.shaped('the_bumblezone:carvable_wax', ['AAA', 'A A', 'AAA'], {
+      A: 'productivebees:wax',
+    })
+  })
+  
+
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.


### PR DESCRIPTION
Changes honeycomb block incompatibility with compression by adding a new recipe for carvable wax from bumblezone and removing the old conflicting one