### PR TITLE
Industrial Foregoing QOL

### DIFF
--- a/kubejs/data/atm10/tags/worldgen/biome/allthemodium_spawnable.json
+++ b/kubejs/data/atm10/tags/worldgen/biome/allthemodium_spawnable.json
@@ -1,0 +1,5 @@
+{
+    "values":[
+        "minecraft:deep_dark"
+    ]
+}

--- a/kubejs/data/atm10/tags/worldgen/biome/unobtainium_spawnable.json
+++ b/kubejs/data/atm10/tags/worldgen/biome/unobtainium_spawnable.json
@@ -1,0 +1,5 @@
+{
+    "values":[
+        "minecraft:end_highlands"
+    ]
+}

--- a/kubejs/data/atm10/tags/worldgen/biome/vibranium_spawnable.json
+++ b/kubejs/data/atm10/tags/worldgen/biome/vibranium_spawnable.json
@@ -1,0 +1,6 @@
+{
+    "values":[
+        "minecraft:crimson_forest",
+        "minecraft:warped_forest"
+    ]
+}

--- a/kubejs/data/industrialforegoing/recipe/laser_drill_ore/raw_materials/azure_silver.json
+++ b/kubejs/data/industrialforegoing/recipe/laser_drill_ore/raw_materials/azure_silver.json
@@ -1,0 +1,33 @@
+{
+    "neoforge:conditions": [
+      {
+        "type": "neoforge:not",
+        "value": {
+          "type": "neoforge:tag_empty",
+          "tag": "c:raw_materials/azure_silver"
+        }
+      }
+    ],
+    "output": {
+      "tag": "c:raw_materials/azure_silver"
+    },
+    "rarity": [
+      {
+        "biome_filter": {
+          "blacklist": [],
+          "whitelist": ["atm10:unobtainium_spawnable"]
+        },
+        "dimension_filter": {
+          "blacklist": [],
+          "whitelist": []
+        },
+        "depth_min": 30,
+        "depth_max": 60,
+        "weight": 9
+      }
+    ],
+    "catalyst": {
+      "item": "industrialforegoing:purple_laser_lens"
+    },
+    "type": "industrialforegoing:laser_drill_ore"
+  }

--- a/kubejs/data/industrialforegoing/recipe/laser_drill_ore/raw_materials/glowstone_dust.json
+++ b/kubejs/data/industrialforegoing/recipe/laser_drill_ore/raw_materials/glowstone_dust.json
@@ -1,0 +1,33 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:tag_empty",
+        "tag": "c:dusts/glowstone"
+      }
+    }
+  ],
+  "output": {
+    "tag": "c:dusts/glowstone"
+  },
+  "rarity": [
+    {
+      "biome_filter": {
+          "blacklist": [],
+          "whitelist": ["atm10:vibranium_spawnable"]
+        },
+        "dimension_filter": {
+          "blacklist": [],
+          "whitelist": []
+        },
+      "depth_min": 100,
+      "depth_max": 123,
+      "weight": 99
+    }
+  ],
+  "catalyst": {
+    "item": "industrialforegoing:vibranium_pickaxe"
+  },
+  "type": "industrialforegoing:laser_drill_ore"
+}

--- a/kubejs/data/industrialforegoing/recipe/laser_drill_ore/raw_materials/obsidian.json
+++ b/kubejs/data/industrialforegoing/recipe/laser_drill_ore/raw_materials/obsidian.json
@@ -1,0 +1,33 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:tag_empty",
+        "tag": "c:obsidians"
+      }
+    }
+  ],
+    "output": {
+      "tag": "c:obsidians"
+    },
+    "rarity": [
+      {
+        "biome_filter": {
+          "blacklist": [],
+          "whitelist": ["atm10:unobtainium_spawnable"]
+        },
+        "dimension_filter": {
+          "blacklist": [],
+          "whitelist": []
+        },
+        "depth_min": 30,
+        "depth_max": 60,
+        "weight": 90
+      }
+    ],
+    "catalyst": {
+      "item": "industrialforegoing:purple_laser_lens"
+    },
+    "type": "industrialforegoing:laser_drill_ore"
+  }

--- a/kubejs/data/industrialforegoing/recipe/laser_drill_ore/raw_materials/raw_allthemodium.json
+++ b/kubejs/data/industrialforegoing/recipe/laser_drill_ore/raw_materials/raw_allthemodium.json
@@ -1,0 +1,34 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:tag_empty",
+        "tag": "c:raw_materials/allthemodium"
+      }
+    }
+  ],
+    "output": {
+      "tag": "c:raw_materials/allthemodium"
+    },
+    "rarity": [
+      {
+        "biome_filter": {
+          "blacklist": [],
+          "whitelist": ["atm10:allthemodium_spawnable"]
+        },
+        "dimension_filter": {
+          "blacklist": [],
+          "whitelist": []
+        },
+        "depth_min": 2,
+        "depth_max": 20,
+        "weight": 4
+      }
+    ],
+    "pointer": 0,
+    "catalyst": {
+      "item": "industrialforegoing:yellow_laser_lens"
+    },
+    "type": "industrialforegoing:laser_drill_ore"
+  }

--- a/kubejs/data/industrialforegoing/recipe/laser_drill_ore/raw_materials/raw_allthemodium.json
+++ b/kubejs/data/industrialforegoing/recipe/laser_drill_ore/raw_materials/raw_allthemodium.json
@@ -28,7 +28,7 @@
     ],
     "pointer": 0,
     "catalyst": {
-      "item": "industrialforegoing:yellow_laser_lens"
+      "item": "allthemodium:allthemodium_pickaxe"
     },
     "type": "industrialforegoing:laser_drill_ore"
   }

--- a/kubejs/data/industrialforegoing/recipe/laser_drill_ore/raw_materials/raw_unobtainium.json
+++ b/kubejs/data/industrialforegoing/recipe/laser_drill_ore/raw_materials/raw_unobtainium.json
@@ -1,0 +1,32 @@
+{"neoforge:conditions": [
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:tag_empty",
+        "tag": "c:raw_materials/unobtainium"
+      }
+    }
+  ],
+    "output": {
+      "tag": "c:raw_materials/unobtainium"
+    },
+    "rarity": [
+      {
+        "biome_filter": {
+          "blacklist": [],
+          "whitelist": ["atm10:unobtainium_spawnable"]
+        },
+        "dimension_filter": {
+          "blacklist": [],
+          "whitelist": []
+        },
+        "depth_min": 30,
+        "depth_max": 60,
+        "weight": 1
+      }
+    ],
+    "catalyst": {
+      "item": "industrialforegoing:purple_laser_lens"
+    },
+    "type": "industrialforegoing:laser_drill_ore"
+  }

--- a/kubejs/data/industrialforegoing/recipe/laser_drill_ore/raw_materials/raw_unobtainium.json
+++ b/kubejs/data/industrialforegoing/recipe/laser_drill_ore/raw_materials/raw_unobtainium.json
@@ -22,11 +22,11 @@
         },
         "depth_min": 30,
         "depth_max": 60,
-        "weight": 1
+        "weight": 0
       }
     ],
     "catalyst": {
-      "item": "industrialforegoing:purple_laser_lens"
+      "item": "allthemodium:unobtainium_pickaxe"
     },
     "type": "industrialforegoing:laser_drill_ore"
   }

--- a/kubejs/data/industrialforegoing/recipe/laser_drill_ore/raw_materials/raw_vibranium.json
+++ b/kubejs/data/industrialforegoing/recipe/laser_drill_ore/raw_materials/raw_vibranium.json
@@ -22,11 +22,11 @@
         },
         "depth_min": 100,
         "depth_max": 123,
-        "weight": 1
+        "weight": 0
       }
     ],
     "catalyst": {
-      "item": "industrialforegoing:green_laser_lens"
+      "item": "allthemodium:vibranium_pickaxe"
     },
     "type": "industrialforegoing:laser_drill_ore"
   }

--- a/kubejs/data/industrialforegoing/recipe/laser_drill_ore/raw_materials/raw_vibranium.json
+++ b/kubejs/data/industrialforegoing/recipe/laser_drill_ore/raw_materials/raw_vibranium.json
@@ -1,0 +1,32 @@
+{"neoforge:conditions": [
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:tag_empty",
+        "tag": "c:raw_materials/vibranium"
+      }
+    }
+  ],
+    "output": {
+      "tag": "c:raw_materials/vibranium"
+    },
+    "rarity": [
+      {
+        "biome_filter": {
+          "blacklist": [],
+          "whitelist": ["atm10:vibranium_spawnable"]
+        },
+        "dimension_filter": {
+          "blacklist": [],
+          "whitelist": []
+        },
+        "depth_min": 100,
+        "depth_max": 123,
+        "weight": 1
+      }
+    ],
+    "catalyst": {
+      "item": "industrialforegoing:green_laser_lens"
+    },
+    "type": "industrialforegoing:laser_drill_ore"
+  }

--- a/kubejs/data/industrialforegoing/recipe/stonework_generate/deepslate.json
+++ b/kubejs/data/industrialforegoing/recipe/stonework_generate/deepslate.json
@@ -1,0 +1,12 @@
+{
+  "output": {
+    "item": "minecraft:cobbled_deepslate",
+    "count": 1
+  },
+  "waterNeed": 1000,
+  "lavaNeed": 1000,
+  "waterConsume": 0,
+  "lavaConsume": 0,
+  "type": "industrialforegoing:stonework_generate"
+}
+

--- a/kubejs/data/industrialforegoing/recipe/stonework_generate/deepslate.json
+++ b/kubejs/data/industrialforegoing/recipe/stonework_generate/deepslate.json
@@ -1,6 +1,6 @@
 {
   "output": {
-    "item": "minecraft:cobbled_deepslate",
+    "id": "minecraft:cobbled_deepslate",
     "count": 1
   },
   "waterNeed": 1000,


### PR DESCRIPTION
Adds atm ores to the laser ore drill
Adds deepslate to the stonework factory. 

~~Should be accompanied by a laser ore drill base recipe change. (Not included)~~

Changes lens to pickaxes for the atm ores.  Will require the user to find the smithing templates and the ores prior to void mining for them.