### PR TITLE
Added Nature's Aura to Basic Tools Quests

### DIFF
--- a/config/ftbquests/quests/chapters/applied_energistics_2.snbt
+++ b/config/ftbquests/quests/chapters/applied_energistics_2.snbt
@@ -10,23 +10,14 @@
 		id: "ftbquests:custom_icon"
 	}
 	id: "07210DDF872160BA"
-	images: [
-		{
-			height: 0.3d
-			image: "allthetweaks:item/atm_star"
-			rotation: 0.0d
-			width: 0.3d
-			x: 6.0d
-		}
-		{
-			height: 3.0d
-			image: "atm:textures/questpics/ae2.png"
-			rotation: 0.0d
-			width: 9.27d
-			x: 7.0d
-			y: -3.5d
-		}
-	]
+	images: [{
+		height: 3.0d
+		image: "atm:textures/questpics/ae2.png"
+		rotation: 0.0d
+		width: 9.27d
+		x: 7.0d
+		y: -3.5d
+	}]
 	order_index: 1
 	progression_mode: "flexible"
 	quest_links: [ ]
@@ -420,7 +411,8 @@
 			y: 1.5d
 		}
 		{
-			dependencies: ["40A7CC56DACC2623"]
+			dependencies: ["5C22E3103544B120"]
+			hide_dependency_lines: true
 			id: "74FC0DDDB91DB172"
 			rewards: [
 				{
@@ -446,7 +438,8 @@
 			y: 1.5d
 		}
 		{
-			dependencies: ["40A7CC56DACC2623"]
+			dependencies: ["5C22E3103544B120"]
+			hide_dependency_lines: true
 			id: "51DE3157DE3E57B8"
 			rewards: [
 				{
@@ -1689,7 +1682,7 @@
 			y: 4.5d
 		}
 		{
-			dependencies: ["2F16B6A173525277"]
+			dependencies: ["2FB231069D2E4E77"]
 			hide_dependency_lines: true
 			id: "5BB887411B8B38FA"
 			rewards: [

--- a/config/ftbquests/quests/chapters/basic_tools.snbt
+++ b/config/ftbquests/quests/chapters/basic_tools.snbt
@@ -1019,7 +1019,7 @@
 			}]
 			tasks: [{
 				id: "224A2A7012749DFC"
-				item: { count: 1, id: "rootsclassic:living_pickaxe" }
+				item: { components: { "ftbfiltersystem:filter": "or(item(rootsclassic:living_pickaxe)item(naturesaura:infused_iron_pickaxe))" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 				type: "item"
 			}]
 			x: 2.5d
@@ -1035,7 +1035,7 @@
 			}]
 			tasks: [{
 				id: "56B07E580BF13848"
-				item: { count: 1, id: "forbidden_arcanus:draco_arcanus_pickaxe" }
+				item: { components: { "ftbfiltersystem:filter": "or(item(forbidden_arcanus:draco_arcanus_pickaxe)item(naturesaura:sky_pickaxe))" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 				type: "item"
 			}]
 			x: 3.0d
@@ -1335,7 +1335,7 @@
 			}]
 			tasks: [{
 				id: "236DA60F43220525"
-				item: { count: 1, id: "rootsclassic:living_sword" }
+				item: { components: { "ftbfiltersystem:filter": "or(item(rootsclassic:living_sword)item(naturesaura:infused_iron_sword))" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 				type: "item"
 			}]
 			x: 2.0d
@@ -1358,6 +1358,54 @@
 			]
 			x: 0.0d
 			y: -1.5d
+		}
+		{
+			id: "7CA60DC31447E57A"
+			optional: true
+			rewards: [{
+				id: "15113DA55CF0D536"
+				type: "xp"
+				xp: 10
+			}]
+			tasks: [{
+				id: "6A098C929647B0A6"
+				item: { count: 1, id: "naturesaura:sky_sword" }
+				type: "item"
+			}]
+			x: 2.0d
+			y: 5.0d
+		}
+		{
+			id: "5D46EEC88D662443"
+			optional: true
+			rewards: [{
+				id: "436E69F5BDCECDBA"
+				type: "xp"
+				xp: 10
+			}]
+			tasks: [{
+				id: "51AA75A2DC748648"
+				item: { count: 1, id: "naturesaura:depth_sword" }
+				type: "item"
+			}]
+			x: 0.5d
+			y: 6.5d
+		}
+		{
+			id: "7B1818D2C5C2BB18"
+			optional: true
+			rewards: [{
+				id: "39DC36E274780620"
+				type: "xp"
+				xp: 10
+			}]
+			tasks: [{
+				id: "44F471C85DF505E9"
+				item: { count: 1, id: "naturesaura:depth_pickaxe" }
+				type: "item"
+			}]
+			x: 1.5d
+			y: -4.0d
 		}
 	]
 }

--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -516,16 +516,6 @@
 	quest.0515422E36E4E9A3.quest_desc: ["Grants invisibility when sneaking."]
 	quest.0518551637F76C50.quest_desc: ["A little expensive but the &9Echoing Deep Shelf&r is like a much better &bSeashelf&r. (BTW you'll need to kill quite a few wardens to advance more in Enchanting... should a warned you earlier). Also increases Max &aEterna&r to &a75&r."]
 	quest.0518551637F76C50.title: "&9Echoing Deepshelf"
-	quest.051E0C85E7B71CE0.quest_desc: [
-		"I'm going to assume you've been out mining, right? It is MINEcraft after all. "
-		""
-		"You'll find a ton of new ores that might confuse you, but you can stick to the vanilla materials to get you started! "
-		""
-		"Copper is abundant and has plenty of uses for things like &aOre Hammers&r or &eDrawer Upgrades&r, so make sure to grab plenty of it! "
-		""
-		"Iron is probably one of the most important ores you'll want to get every time you run into it. The world of modded MC pretty much runs on Iron."
-		""
-	]
 	quest.051E0C85E7B71CE0.quest_desc: ["I'm going to assume you've been out mining, right? It is MINEcraft after all.\\n\\nYou'll find a ton of new ores that might confuse you, but you can stick to the vanilla materials to get you started!\\n\\nCopper is abundant and has plenty of uses for things like &aOre Hammers&r or &eDrawer Upgrades&r, so make sure to grab plenty of it!\\n\\nIron is probably one of the most important ores you'll want to get every time you run into it. The world of modded MC pretty much runs on Iron."]
 	quest.051E0C85E7B71CE0.title: "The &9Metal&r Age"
 	quest.052BE1D845794702.quest_subtitle: "Teak + Acacia"
@@ -1292,7 +1282,6 @@
 	quest.0E02CE4469FCA4C9.title: "Redstone Active"
 	quest.0E03F5EAE4963ECB.quest_subtitle: "8 Dry Green Blocks"
 	quest.0E057B7F76401421.quest_subtitle: "The First Upgrade"
-	quest.0E057B7F76401421.title: "Iron Backpack"
 	quest.0E057B7F76401421.title: "&6Copper Backpack"
 	quest.0E0CAA31480EC0A1.quest_desc: ["Allows the Backpack to pick up items."]
 	quest.0E0CAA31480EC0A1.quest_subtitle: "Allows the backpack to pick up items."
@@ -1381,10 +1370,6 @@
 		"{image:atm:textures/questpics/theurgy/theurgy_brazier.png width:100 height:100 align:center}"
 	]
 	quest.0EADCEA9AB001FC7.title: "Furnace like Heat"
-	quest.0EAF01037BB20BCB.quest_subtitle: "{atm9.quest.evilcraft.subt.summonsZombies}"
-	quest.0EB5B926E1FBAF0E.quest_desc: ["{atm9.quest.enchant.desc.enchant}"]
-	quest.0EB5B926E1FBAF0E.title: "{atm9.quest.enchant.enchant}"
-	quest.0EB6ED88895366D0.quest_desc: ["I remember when it was just Stone and Cobblestone!"]
 	quest.0EAF01037BB20BCB.quest_subtitle: "Summons Zombies"
 	quest.0EB5B926E1FBAF0E.quest_desc: ["Enchanting gets a few changes with Apotheosis. To summarize it, 15 bookshelves won't be enough now. There's new bookshelves and actions you can do with Enchantment Tables now and hopefully these quests will help you understand."]
 	quest.0EB5B926E1FBAF0E.title: "Enchanting with Apotheosis"
@@ -1539,8 +1524,6 @@
 		"{image:atm:textures/questpics/eternal/starlight_golem.png width:150 height:100 align:center}"
 	]
 	quest.10AB188AC6FB24D3.title: "Starlight Golem"
-	quest.10C527C66EE4E95A.quest_desc: ["Suprisingly you don't need infusion for these! You just need to kill the most powerful boss in vanilla Minecraft! The &9Skulk shelves&r increase &aEterna&r to &a40&r which will allow us to Infuse the next item."]
-	quest.10C527C66EE4E95A.title: "&9Soul-Touched Sculkshelf&r"
 	quest.10C527C66EE4E95A.quest_desc: ["{atm9.quest.enchant.desc.Soul_sculk}"]
 	quest.10C527C66EE4E95A.title: "{atm9.quest.enchant.Soul_sculk}"
 	quest.10DF2125B647379E.quest_desc: ["I promise, this is not something you want to touch or get on your skin..."]
@@ -1729,8 +1712,6 @@
 	quest.12ED1EE85E146A4B.quest_desc: ["Harvester Pylons work as a very simple Auto-Farm. Put the Pylon on or in the Water Source and it will automatically harvest and replant Crops that are fully grown in the set area around it. \\n\\nThe area can be set to 3x3, 5x5, 7x7, or 9x9 Blocks around the Pylon. \\n\\nIt will need a Hoe to use on the Plants and will need an Inventory like a chest above it to put the Crops. Do all that and if it's turned On it will start farming!\\n\\n(Careful when using a lot of modifiers with it like Lilypads or fertilizer as when it goes very fast farming it can be a TPS eater)."]
 	quest.12EF38830108D02B.quest_desc: ["Kill 32 normal Spiders."]
 	quest.12F24C9C6D2AF887.quest_desc: ["Two buckets of &boxygen&r plus the &bferrite mixture dust&r in your &eElectric Blast Furnace&r gets you the ingot - no cooling necessary!"]
-	quest.12F4980CB3BFCE0D.quest_desc: ["{atm9.quest.enchant.desc.sight}"]
-	quest.12F4980CB3BFCE0D.title: "{atm9.quest.enchant.sight}"
 	quest.12F3A604329EC604.quest_subtitle: "Increase the Speed of Machines"
 	quest.12F4980CB3BFCE0D.quest_desc: ["You ever spend 3 months studying Galatic Code to finally understand Enchantment Table language just for it to be gibberish? No? Me either but &9Enchanting Clues&r are your actual translator for it. Each &9Enchanting Clue&r will tell you 1 Enchantment before you actually use it."]
 	quest.12F4980CB3BFCE0D.title: "&9Enchanting Clues&r"
@@ -2991,11 +2972,6 @@
 	quest.217DF3B66A07A8DE.quest_desc: ["Garden of Eden in just a single Seed."]
 	quest.2182492BCC1B33D8.quest_desc: ["When installed in a hive, it gives a 5% chance for a new baby bee to be spawned every time honey is delivered.\\n\\nWhen placed in a Catcher, it only allows the catcher to catch baby bees.\\n\\nYou can stack these for a greater chance."]
 	quest.2182492BCC1B33D8.quest_subtitle: "Making Babies"
-	quest.218803812A9C332B.quest_desc: [
-		"{atm9.quest.enchant.desc.infused_hellshelf}"
-		"{image:atm:textures/questpics/apotheosis/enchant_hell.png width:100 height:100 align:1}"
-	]
-	quest.218803812A9C332B.title: "{atm9.quest.enchant.infused_hellshelf}"
 	quest.218803812A9C332B.quest_desc: ["In order to get higher Max Enchantments and levels you'll need Infused Hellshelves. To get them you will need &a22.5 Eterna&r and &c30%% Quanta&r. The best way to get that would be 15 normal shelves and &45 Hellshelves&r."]
 	quest.218803812A9C332B.title: "&4Infused Hellshelf&r"
 	quest.2188C52C1F384DE4.quest_desc: ["Ever burning fuel (not really)."]
@@ -3021,13 +2997,6 @@
 	quest.21BFDE6AD1C0F62A.quest_desc: ["Obviously in real life there is much more than just &6Honey Bees&r or &6Bumble Bees&r, so the &6&lBumblezone&r adds more Bees and unique Bees! \\n\\nFrom &4&lRedtail&r Bees, to &9Blue&r Bees, to &6A&er&foa&bc&9e&r Bees, to Neopolitan Bees!"]
 	quest.21BFDE6AD1C0F62A.title: "Homophobia?"
 	quest.21EA29A8C7F950CE.quest_desc: ["&bDiamonds&r the staple of &2Minecraft&r, and of upgraded Furnaces apparently...\\n \\nThese work even faster only taking 80 Ticks or 4 Seconds to smelt items. That's even faster than a Blast Furnace! \\n \\nThese are only crafted by &eGold Furnaces&r and can be crafted into &3Crystal&r or &aEmerald Furnaces&r."]
-	quest.21EA29A8C7F950CE.title: "&bDiamond Furnace&r"
-	quest.21EE522DDBF0BF72.quest_desc: [
-		"{atm9.quest.enchant.desc.endshelf}"
-		"{image:atm:textures/questpics/apotheosis/enchant_end.png width:100 height:100 align:1}"
-	]
-	quest.21EE522DDBF0BF72.title: "{atm9.quest.enchant.endshelf}"
-	quest.21F4CFF171246537.quest_subtitle: "Tier &b4"
 	quest.21EA29A8C7F950CE.title: "&bDiamond Furnace"
 	quest.21EE522DDBF0BF72.quest_desc: ["The last sets of Shelves you'll need are &dEndshelves&r, to get them you need Infused Dragon's Breath. This one was hard to get but you need atleast &a40%% Eterna&r, &c15%%-25%% Quanta&r, and atleast &560%% Arcana&r. It has to be between &c15%%-25%% Quanta&r to get that you can try &99 Echoing Skulkshelves&r and 4 Melonshelves or &92 Echoing Skulkshelves&r and &b10 Heart-Forged Seashelves&r."]
 	quest.21EE522DDBF0BF72.title: "&dEndshelf&r"
@@ -3336,10 +3305,10 @@
 	]
 	quest.24E3CB198F73524A.quest_subtitle: "Arcing electricity!"
 	quest.24E658BA47367A44.quest_desc: ["The &n&5Rope Pulley&r can move blocks up or down, they can be glued together."]
-	quest.24FCFF18296ED907.quest_desc: ["Suprisingly you don't need infusion for these! You just need to kill the most powerful boss in vanilla Minecraft! The &9Skulk shelves&r increase &aEterna&r to &a80&r which will allow us to Infuse the next item."]
-	quest.24FCFF18296ED907.title: "&9Soul-Touched Sculkshelf"
 	quest.24F3E90C14BFD1B4.quest_desc: ["Modern Industrialization is a mod as big as its name! It has multiple tiers of machines and thankfully we don't need to go to the last one for the Star."]
 	quest.24F3E90C14BFD1B4.title: "Modern Industrialization"
+	quest.24FCFF18296ED907.quest_desc: ["Suprisingly you don't need infusion for these! You just need to kill the most powerful boss in vanilla Minecraft! The &9Skulk shelves&r increase &aEterna&r to &a80&r which will allow us to Infuse the next item."]
+	quest.24FCFF18296ED907.title: "&9Soul-Touched Sculkshelf"
 	quest.25080E3295B1DF01.quest_desc: ["The &5Unobtainium Furnace&r smelts items faster than any other Furnace in the pack!"]
 	quest.25080E3295B1DF01.title: "&5Unobtainium Furnace"
 	quest.25213DBA6E6CEDD2.quest_desc: [
@@ -3658,7 +3627,6 @@
 	quest.28FDB2D13D0DDE8E.title: "&l&bChipped&r"
 	quest.28FEB4C11AD1AE7C.quest_desc: ["&bDiamonds&r are usually expensive... for Vanilla, but this is modded you'll have enough for atleast 1 &bDiamond Generator&r. Still uses normal Furnace Fuel."]
 	quest.28FEB4C11AD1AE7C.title: "&bDiamond Generator"
-	quest.290FAB3DE8FD04E7.quest_desc: ["{atm9.quest.evilcraft.desc.maceExplosion}"]
 	quest.290FAB3DE8FD04E7.quest_desc: ["Holding right click will charge up the Mace to do an AoE attack using &cBlood&r. Sneak-right clicking will change the power level.\\n\\nThe higher the power level, the more damage it will do at a higher cost of Blood.\\n\\nYou will need a fully charged one to craft the &6ATM Star&r."]
 	quest.29131C3532610ADF.quest_desc: ["This is a Tier 2 Pillar Cap for the Starlight Charger."]
 	quest.29131C3532610ADF.title: "Tier 2 Starlight Charger Pillar Cap"
@@ -4194,19 +4162,11 @@
 		"{image:atm:textures/questpics/flux/flux_ui.png width:125 height:150 align:1}"
 	]
 	quest.2EB7784D5296F410.title: "The Flux Networks UI"
-	quest.2EB96FF06627FD9A.quest_subtitle: "Breaks down items into their components."
+	quest.2EB96FF06627FD9A.quest_desc: ["The Salvager allows you to break down gear into the items they from.\\n\\nFor example: If you put in some Diamond Boots you will get 4 Diamonds back."]
+	quest.2EB96FF06627FD9A.quest_subtitle: "Breaking down (some) items!"
 	quest.2EB96FF06627FD9A.title: "Salvager"
 	quest.2EC2FA680076C07D.quest_desc: ["You might need to kill a few Wardens for these but that's okay Apothic makes it easier! This shelf is mostly for &5Arcana&r but it's a good source for all quantities. It will be needed for next Infusion."]
 	quest.2EC2FA680076C07D.title: "&9Echoing Sculkshelf"
-	quest.2EC9668ED4EA47CB.quest_desc: [
-		"This quest only requires you to make one Diamond tool or armor piece, but it's probably good to get a full set! "
-		""
-		"Diamond tools boast high durability, and the armor offers great protection overall. "
-		""
-		"To make the better tools and armor in the game, you'll need Diamond stuff as a base!"
-	]
-	quest.2EB96FF06627FD9A.quest_desc: ["The Salvager allows you to break down gear into the items they from.\\n\\nFor example: If you put in some Diamond Boots you will get 4 Diamonds back."]
-	quest.2EB96FF06627FD9A.quest_subtitle: "Braking down (some) items!"
 	quest.2EC9668ED4EA47CB.quest_desc: ["This quest only requires you to make one Diamond tool or armor piece, but it's probably good to get a full set!\\n\\nDiamond tools boast high durability, and the armor offers great protection overall.\\n\\nTo make the better tools and armor in the game, you'll need Diamond stuff as a base!"]
 	quest.2EC9668ED4EA47CB.title: "&9Gearing Up"
 	quest.2ED7878B7919AF6D.quest_subtitle: "&f6&r &4Damage&r"
@@ -4425,8 +4385,6 @@
 	quest.313F5AFF459201EB.title: "&l&5Eternal Starlight&r Stones"
 	quest.3142A40E1EAEBAA3.quest_desc: ["The &6Dowsing Rod&r gives you Magic Find and Scrying when used. \\n\\nThis allows you to see nearby magic creatures as well as helping you find amethyst!"]
 	quest.3142A40E1EAEBAA3.quest_subtitle: "Magic Finder"
-	quest.314E41B84C8DD464.quest_desc: ["{atm9.quest.enchant.desc.library}"]
-	quest.314E41B84C8DD464.title: "{atm9.quest.enchant.library}"
 	quest.3145B847A15F97F2.quest_desc: ["You can combine the Essences from Mystical Agriculture to make... Coal. \\n\\nObviously it works as an amazing Fuel source but Insanium Coal seems a little too insane for me. "]
 	quest.314E41B84C8DD464.quest_desc: ["This is arguably one of the most important blocks added by Apotheosis, the Enchantment Library. You put Books in and they collect over time and can be taken out anytime. Warning 1. It has limits, high limits but limits 2. It can only take out the highest level put in regardless of how many are in."]
 	quest.314E41B84C8DD464.title: "Enchantment Library"
@@ -4487,24 +4445,8 @@
 	quest.31BCE63F5E016323.quest_desc: ["The &3Solar Compressor&r generates Pressure by using sunlight, the warmer it gets, the more Pressure it will produce.\\n\\nHowever, be careful, if it gets too hot it will malfunction and you will need to repair it."]
 	quest.31BCE63F5E016323.quest_subtitle: "In the palm of my hand..."
 	quest.31BCE63F5E016323.title: "Pressure from the Sun"
-	quest.31EC6244E4A3CBD6.quest_subtitle: "Tier: &b4"
-	quest.31EEE2875595F315.quest_desc: ["You should have already made &2Sulfuric Acid&r for your Tier 4 Ore Processing facility, but here is a reminder on how to get it.\\n\\nStart by getting &eSulfur&r by finding it underground, or by mixing &bHydrogen Chloride&r with &3Gunpowder&r in a Chemical Injection Chamber.\\n\\nTake the Sulfur Dust and run it through a &9Chemical Oxidizer&r to get &eSulfur Dioxide&r. Combine that with &bOxygen&r in a Chemical Infuser to get &eSulfur Trioxide&r.\\n\\nNext, we'll combine &bWater Vapor&r with the Sulfur Trioxide to make &2Sulfuric Acid&r."]
-	quest.31EEE2875595F315.quest_subtitle: "A Quick Recap"
-	quest.31EEE2875595F315.title: "&2Sulfuric Acid"
-	quest.31FD9EA513E0D010.quest_desc: [
-		"{atm9.quest.evilcraft.desc.modIntro.1}"]
 	quest.31E7F7464D79F881.quest_desc: ["It's not just bookshelves that can be Infused!"]
 	quest.31E7F7464D79F881.title: "Other Infusion Items"
-	quest.31EC6244E4A3CBD6.quest_subtitle: "Tier &b4"
-	quest.31EEE2875595F315.quest_desc: [
-		"You should have already made &2Sulfuric Acid&r for your Tier 4 Ore Processing facility, but here is a reminder on how to get it."
-		""
-		"Start by getting &eSulfur Dust&r either by crushing Sulfur from Thermal, or by mixing &bHydrogen Chloride&r with &3Gunpowder&r in a Chemical Dissolution Chamber."
-		""
-		"Take the Sulfur Dust and run it through a &9Chemical Oxidizer&r to get &eSulfur Dioxide&r. Combine that with &bOxygen&r in a Chemical Infuser to get &eSulfur Trioxide&r."
-		""
-		"Next, we'll combine &bWater Vapor&r with the Sulfur Trioxide to make &2Sulfuric Acid&r."
-	]
 	quest.31EC6244E4A3CBD6.quest_subtitle: "Tier: &b4"
 	quest.31EEE2875595F315.quest_desc: ["You should have already made &2Sulfuric Acid&r for your Tier 4 Ore Processing facility, but here is a reminder on how to get it.\\n\\nStart by getting &eSulfur&r by finding it underground, or by mixing &bHydrogen Chloride&r with &3Gunpowder&r in a Chemical Injection Chamber.\\n\\nTake the Sulfur Dust and run it through a &9Chemical Oxidizer&r to get &eSulfur Dioxide&r. Combine that with &bOxygen&r in a Chemical Infuser to get &eSulfur Trioxide&r.\\n\\nNext, we'll combine &bWater Vapor&r with the Sulfur Trioxide to make &2Sulfuric Acid&r."]
 	quest.31EEE2875595F315.quest_subtitle: "A Quick Recap"
@@ -6132,8 +6074,6 @@
 		"At least they arent that hard to craft."
 	]
 	quest.44BE268EC7D2689D.quest_subtitle: "MORE Coil?!"
-	quest.44D1B410550B6C28.quest_desc: ["{atm9.quest.enchant.desc.other}"]
-	quest.44D1B410550B6C28.title: "{atm9.quest.enchant.other}"
 	quest.44D1B410550B6C28.quest_desc: ["It's not just bookshelves that can be Infused!"]
 	quest.44D1B410550B6C28.title: "Other Infusion Items"
 	quest.44D5EDB8711EC7A0.quest_desc: ["&2&lVanilla&r couldn't all the fun with Maces! So of course there is an &6Allthemodium&r upgrade to them! \\n\\nUpgrade a Mace with an &6Allthemodium Block&r to get the &6Allthemodium Mace&r. \\n\\nIt does more base damage, more falling damage, and same Enchantments!"]
@@ -6160,7 +6100,6 @@
 	quest.45161821C221EF0B.title: "&4Infused Hellshelves"
 	quest.451D03BE892CDE74.quest_subtitle: "&dTier 6&r"
 	quest.451D03BE892CDE74.title: "Exploration Mod Max Pickaxes"
-	quest.45268A619787288F.title: "&bDiamond Backpack&r"
 	quest.45268A619787288F.title: "&eGold Backpack"
 	quest.4526E151BAE88310.quest_subtitle: "Tier: &e1"
 	quest.452B3207B6C3A5D7.quest_desc: ["Liquid Uranium 235. Lets use this liquid to bind together the other components and craft the Absolute Reaction Plate"]
@@ -6652,11 +6591,9 @@
 	quest.4A4C71C43519D5FE.title: "&6Summoning The &5Wither"
 	quest.4A54288FD22C903D.quest_desc: ["Velvetumoss spawns within The Abyss. \\n\\nYou can mine green ones to get Velvetumoss Balls which can either be eaten or made into a Slimeball! \\n\\nThe Red ones will spawn pretty plants!"]
 	quest.4A5937F6E5D06BE1.quest_desc: ["A simple liquid fuel generator that runs off the liquid fuels added by JDT."]
-	quest.4A59DF02128DA9F3.quest_desc: ["The &dPearlescent Endshelf&r is the best all-around shelf. It also gives a Max &aEterna&r of &a45&r, but this isn't the shelf we're looking for to get perfect set up."]
-	quest.4A59DF02128DA9F3.title: "&dPearlescent Endshelf&r"
-	quest.4A5EA948F5DCEB73.quest_desc: ["Swamp Silver can be rarely found within the Nightfall Mud. \\n\\nIt can be used to craft Armor and Tools!"]
 	quest.4A59DF02128DA9F3.quest_desc: ["{atm9.quest.enchant.desc.pearlescent}"]
 	quest.4A59DF02128DA9F3.title: "{atm9.quest.enchant.pearlescent}"
+	quest.4A5EA948F5DCEB73.quest_desc: ["Swamp Silver can be rarely found within the Nightfall Mud. \\n\\nIt can be used to craft Armor and Tools!"]
 	quest.4A5F84912C755688.quest_desc: [
 		"\"The Vengabus is coming\\nAnd everybody's jumping\\nNew York to San Francisco\\nAn intercity disco\\nThe wheels of steel are turning\\nAnd traffic lights are burning\\nSo if you like to party\\nGet on and move your body\".\\n"
 		"{image:atm:textures/questpics/bumblezone/bumble_dance.png width:200 height:100 align:center}"
@@ -7485,16 +7422,6 @@
 		"{image:atm:textures/questpics/eternal/starlight_desert.png width:200 height:100 align:center}"
 	]
 	quest.5244B2D6B5FA0487.title: "Crystallized Desert"
-	quest.525517F1625A9BCB.quest_desc: [
-		"{atm9.quest.evilcraft.desc.bloodCleanup.1}"
-		""
-		"{atm9.quest.evilcraft.desc.bloodCleanup.2}"
-		""
-		"{atm9.quest.evilcraft.desc.bloodCleanup.3}"
-		""
-		"{atm9.quest.evilcraft.desc.bloodCleanup.4}"
-	]
-	quest.525517F1625A9BCB.title: "{atm9.quest.evilcraft.collectingBloodStains}"
 	quest.525517F1625A9BCB.quest_desc: ["Did a mob hit the floor too hard and get its &cBlood&r everywhere? Oh no!\\n\\nYou can use a &cSanguinary Pedestal&r to absorb that precious &cBlood&r for later use!\\n\\nWant to automate collecting blood? Place a &9Spiked Plate&r on top of the Pedestal, then have a mob stand on it."]
 	quest.525517F1625A9BCB.title: "&aCollecting &cBlood Stains"
 	quest.5257468DC6C11851.quest_desc: ["It's more like a pickaxe that uses RF/FE."]
@@ -8442,6 +8369,7 @@
 		"The &aSaw&r is yet another crafting tool, but it can also get you 6 planks from one log!"
 	]
 	quest.5D3C8198D9756004.title: "Handy Tools"
+	quest.5D46EEC88D662443.quest_subtitle: "&f9 &cAttack Damage"
 	quest.5D4E51471F3939E0.quest_desc: [
 		"Abilites:"
 		"- Air Burst: Launches player in the direction they are facing consuming durability in the progress, higher tier wands launch the player a greater distance. Note the player won't take fall damage as long as they are holding the wand."
@@ -8954,16 +8882,6 @@
 	quest.62991D7431A48F6D.quest_subtitle: "Banana + Kapok"
 	quest.629DC8DED0F6B578.quest_desc: ["Distilling biomass results in ethanol, which is alcohol, but don't tell anyone I told you"]
 	quest.629DC8DED0F6B578.quest_subtitle: "Not for drinking"
-	quest.62A262A706CFCAF0.quest_desc: [
-		"{atm9.quest.evilcraft.desc.bloodInfuser.1}"
-		""
-		"{atm9.quest.evilcraft.desc.bloodInfuser.2}"
-		""
-		"{atm9.quest.evilcraft.desc.bloodInfuser.3}"
-	]
-	quest.62A262A706CFCAF0.title: "{atm9.quest.evilcraft.bloodInfuser}"
-	quest.62B2C1A24AE245EA.quest_desc: ["{atm9.quest.enchant.desc.deepshelf}"]
-	quest.62B2C1A24AE245EA.title: "{atm9.quest.enchant.deepshelf}"
 	quest.62A262A706CFCAF0.quest_desc: ["We won't be creating Dark Power Gems using pools of blood anymore.\\n\\nInstead, we can make the &9Blood Infuser&r to do all of the messy work for us. This allows you to directly infuse items with blood!\\n\\nThese can be upgraded using &6Promises&r as well. This is one of the main machines used for progression!"]
 	quest.62A262A706CFCAF0.title: "&aThe &cBlood Infuser"
 	quest.62B2C1A24AE245EA.quest_desc: ["The &9Deepshelf&r (not dormant) is your next step to Enchanting. Like everything else it needs Infusion. The &9Deepshelf&r needs 30 &aEterna&r, &c40%% Quanta&r, and &540%% Arcana&r. You can get that with &45 Blazing Hellshelves&r and &b4 Heart-Forged Seashelves&r."]
@@ -9507,8 +9425,8 @@
 	quest.686AEC3EF1140D15.title: "New Tools for New Ores"
 	quest.686B25F2E9D8CC97.quest_desc: ["At the time of writing this it's the end of July so I've got about 3 months until Halloween. But it's never to early to start getting Spooky! Just like Spirit Halloween we can get Spooky 3 months before it actually starts. This time by Right Clicking a Furnace with the Spook-alator! Once it's time to start getting ready for Thanksgiving Shift Right Click them to Un-Spook-Alate!"]
 	quest.686B25F2E9D8CC97.quest_subtitle: "\"This is Halloween\""
-	quest.6884E25641A1020C.quest_desc: ["This is arguably one of the most important blocks added by Apotheosis, the Enchantment Library. You put Books in and they collect over time and can be taken out anytime. Warning 1. It has limits, high limits but limits 2. It can only take out the highest level put in regardless of how many are in."]
 	quest.6877F33323910716.quest_desc: ["Tier 4 Pocket Storage has 64 Slots for Items and each hold 1,048,575 Items. That's 67,108,800 Items total. Move over Backpacks you've been replaced! \\n\\nIt only costs a few Nether Stars which in Modded honestly isn't expensive for what you get!"]
+	quest.6884E25641A1020C.quest_desc: ["This is arguably one of the most important blocks added by Apotheosis, the Enchantment Library. You put Books in and they collect over time and can be taken out anytime. Warning 1. It has limits, high limits but limits 2. It can only take out the highest level put in regardless of how many are in."]
 	quest.68879C92A044030D.quest_desc: ["Mercury and Gold are highly attracted to each other. For this reason, Mercury is widely used to leech gold out of fine sands, or other materials which are rich in fine gold that is otherwise difficult to process out."]
 	quest.68879C92A044030D.quest_subtitle: "Amalgamation"
 	quest.6889EFC6CC291463.quest_desc: [
@@ -9857,8 +9775,6 @@
 	]
 	quest.6C6F4EB5CBE2FBC2.quest_desc: ["The Iron Divination Rod is a slight bit higher, being able to find Ores that an Iron Pickaxe can mine! So Diamonds, Redstone, and Gold."]
 	quest.6C706326381CE611.title: "Creative Pressure"
-	quest.6C76AB8A6110C0C7.quest_desc: ["{atm9.quest.enchant.desc.blazing}"]
-	quest.6C76AB8A6110C0C7.title: "{atm9.quest.enchant.blazing}"
 	quest.6C76AB8A6110C0C7.quest_desc: ["The &4Blazing Hellshelf&r is an upgrade to the &4Infused Hellshelf&r. It increases max &aEterna&r to &a30&r. The negative Enchanting Clue makes it a little worse for normal Enchanting, instead we can use it for better Infusion."]
 	quest.6C76AB8A6110C0C7.title: "&4Blazing Hellshelf&r"
 	quest.6C832BFE4D07D897.quest_subtitle: "Leaves an AoE Cloud that damages living mobs"
@@ -10741,11 +10657,6 @@
 	quest.7503823ACDDB0491.quest_subtitle: "Scarf (Necklace)"
 	quest.7503823ACDDB0491.title: "&2Lucky Scarf&r"
 	quest.7509E4093010EA4C.quest_desc: ["Dropped from the Snow Queen, this bow will shoot arrows that home in on your targets. No more missing!"]
-	quest.751189465F91B353.quest_desc: [
-		"{atm9.quest.enchant.desc.crystalline}"
-		"{image:atm:textures/questpics/apotheosis/enchant_seadeep.png width:200 height:150 align:1}"
-	]
-	quest.751189465F91B353.title: "{atm9.quest.enchant.crystalline}"
 	quest.750B6316267CF574.quest_desc: ["When your Hives are vacant and in the dark you may find a little Bee visitor, the Skeletal Bee. \\n\\nYou can then feed your new visitor a Wither Rose to make them a Withered Bee. "]
 	quest.751189465F91B353.quest_desc: ["The &bCrystalline Seashelf&r is an upgrade to the &bInfused Seashelf&r. It's very good for normal Enchantments but doesn't give us enough &5Arcana&r for the next Infusion we'll need. Still good stats for normal Enchanting though!"]
 	quest.751189465F91B353.title: "&bCrystalline Seashelf&r"
@@ -11203,7 +11114,6 @@
 		"{image:atm:textures/questpics/eternal/starlight_deer.png width:200 height:100 align:center}"
 	]
 	quest.7A16D2EB63359294.title: "Aurora Deer"
-	quest.7A1C117CA8FB7C31.quest_desc: ["This one's unique! \\n\\nInstead of finding Ores it will find Budding Amethyst blocks! \\n\\nNo more struggling to find Geodes for you good sir!"]
 	quest.7A1C117CA8FB7C31.quest_desc: ["This one's unique!\\n\\nInstead of finding Ores it will find Budding Amethyst blocks!\\n\\nNo more struggling to find Geodes for you good sir!"]
 	quest.7A22E94DD83B12AE.quest_desc: [
 		"The Bacterial Sludge was added as an option. It's not necessary, as once you have Europium you don't need to use the Bacterial Sludge."
@@ -11295,6 +11205,7 @@
 	quest.7B0DFA55B4D8B16D.quest_subtitle: "Teleportation at its finest."
 	quest.7B0DFA55B4D8B16D.title: "Custom Portals!"
 	quest.7B1693793419B769.quest_subtitle: "Silver Lime + Cherry"
+	quest.7B1818D2C5C2BB18.quest_subtitle: "&eTier 5"
 	quest.7B2008977702D0C8.quest_desc: ["When making pressure in an Air Compressor, if you don't have anywhere for the pressure to go. it will just disappear. Make sure you have somewhere for the pressure to go before making some."]
 	quest.7B2008977702D0C8.quest_subtitle: "What happened to RF or FE?"
 	quest.7B27B87A520E38B0.quest_desc: ["You'll need an &6HV Chemical Reactor&r with some Chlorine, Carbon dust, and your Rutile dust to make this"]
@@ -11431,6 +11342,7 @@
 		"If we want to get to those hot planets, we need to make a &dTier 3 Rocket&r as well!"
 	]
 	quest.7CA42B3CA84A21B5.title: "&cGearing Up For The Heat&r"
+	quest.7CA60DC31447E57A.quest_subtitle: "&f7 &cAttack Damage"
 	quest.7CB3FCD789747EF5.quest_desc: ["This block enables smelting recipes in your kitchen multi-block!"]
 	quest.7CB3FCD789747EF5.title: "Honey, there's a Furnace in the Kitchen"
 	quest.7CBEBBCB9D95D11A.quest_desc: ["The Abyssal Egg is also a drop from &5The Leviathan&r, because apparently you killed a pregnant one. Place down the Egg and wait awhile and you'll have your own baby Leviathan. Like its mother it'll attack other sea creatures. Unlike its mother it won't attack you first."]
@@ -11640,12 +11552,9 @@
 		"Storage buses can be filtered and given specific priorities such that specific items will try to go to the attached storage first, however it will not retroactively move any filtered items from anywhere else in the network to its attached storage."
 	]
 	quest.7EFBAF3E281D2EBE.quest_subtitle: "The spare chest"
+	quest.7EFBFF5D0DA018E7.quest_desc: ["Adds a filter for items you want to auto-delete in the Backpack."]
 	quest.7EFBFF5D0DA018E7.quest_subtitle: "Adds a filter for items you want to auto-delete in the backpack."
 	quest.7EFBFF5D0DA018E7.title: "Void Upgrade"
-	quest.7F042DED357DEF3C.quest_desc: ["{atm9.quest.enchant.desc.book}"]
-	quest.7F042DED357DEF3C.title: "{atm9.quest.enchant.book}"
-	quest.7F076FC4F2187692.quest_subtitle: "&f8&r &4Damage&r"
-	quest.7EFBFF5D0DA018E7.quest_desc: ["Adds a filter for items you want to auto-delete in the Backpack."]
 	quest.7F042DED357DEF3C.quest_desc: ["Bookshelves are your starting point, but definitely not your end point. Atleast not normal bookshelves. With only normal bookshelves you can only get &aEterna&r up and to a max of 15. (I will explain the Enchantment Levels soon but just know you need them up)"]
 	quest.7F042DED357DEF3C.title: "Vanilla Max is just the start"
 	quest.7F076FC4F2187692.quest_subtitle: "&f8 &cAttack Damage"
@@ -11894,8 +11803,8 @@
 	task.1BA8C5F08A824C08.title: "Macaw's Lights and Lamps"
 	task.1C045BB5FAFCF4D3.title: "Interfaces"
 	task.1C193E204C8A2270.title: "Cheapest IV Processors"
-	task.1C9CC8E995547812.title: "Any #chipped:bookshelf"
 	task.1C7C0F345759111C.title: "Exporters"
+	task.1C9CC8E995547812.title: "Any #chipped:bookshelf"
 	task.1CAC89F6DFC2AB72.title: "Non-ABS Multiblocks"
 	task.1CBF0C7F2044EA9A.title: "&5The Summoner"
 	task.1CC0983CB7DBE526.title: "Gallium Ingot"
@@ -11923,9 +11832,11 @@
 	task.2153473228DA4678.title: "Breeding and Converting Bees"
 	task.21AD4382C0068CDB.title: "Quests By AllTheMods"
 	task.21FBC4E0F668347C.title: "NBT and YOU!"
+	task.224A2A7012749DFC.title: "Magic Mod Iron Pickaxes"
 	task.225F53F8A0E9E822.title: "Cooking for Blockheads"
 	task.22CCBBC66D509404.title: "Networks!"
 	task.2363F64BEC430933.title: "Quartz Swords"
+	task.236DA60F43220525.title: "Magic Mod Iron Swords"
 	task.238B5BA2FAE9785B.title: "AllRightsReserved"
 	task.238F4D40E6D9238E.title: "Dyes"
 	task.23C7F92BD9D39E14.title: "AllRightsReserved"
@@ -12166,6 +12077,7 @@
 	task.55E0635973A828B0.title: "AllRightsReserved"
 	task.55F718D796CEB1B1.title: "Bronze Comb"
 	task.56A486D09B8B90EC.title: "Observe Alloy Blast Smelter"
+	task.56B07E580BF13848.title: "Magic Mod Diamond Pickaxes"
 	task.570BF38EA2870300.title: "Quests By AllTheMods"
 	task.57DD9261905988F3.title: "Mekanism Iron Swords"
 	task.57F40CFA03BD36EF.title: "The Hard Part"


### PR DESCRIPTION
- Added the 3 pickaxes and the 3 swords from Nature's Aura to the Basic Tools quest chapter
- Fixed some AE2 dependencies and deletes a misplaced image
- Removed a bunch of unused lang (Probably caused by the Apothic Enchanting PR)
- Fixed a typo in a Silent Gear quest

Resolves: https://github.com/AllTheMods/ATM-10/issues/817