### PR TITLE
Unified Tiny Coals and Tiny Charcoals

### DIFF
--- a/config/almostunified/unification/materials.json
+++ b/config/almostunified/unification/materials.json
@@ -11,7 +11,9 @@
     "pneumaticcraft",
     "biggerreactors", 
     "ae2",
-    "enderio"
+    "enderio",
+    "utilitarian",
+    "actuallyadditions"
   ],
   "priority_overrides": {},
   "stone_variants": [
@@ -36,7 +38,9 @@
     "c:storage_blocks/{material}",
     "c:wires/{material}",
     "c:silicon",
-    "productivebees:flowers/plastic"
+    "productivebees:flowers/plastic",
+    "atm10:tiny_coals",
+    "atm10:tiny_charcoals"
   ],
   "ignored_tags": [],
   "ignored_items": [

--- a/kubejs/server_scripts/Tweaks/tags.js
+++ b/kubejs/server_scripts/Tweaks/tags.js
@@ -2,19 +2,27 @@
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
 
 ServerEvents.tags('block', allthemods => {
-  //Waystones
+  // Waystones
   allthemods.add('ftbchunks:interact_whitelist', ['@waystones'])
 
-  //Extreme Reactors
+  // Extreme Reactors
   allthemods.add('c:storage_blocks/yellorium', 'alltheores:uranium_block' )
-  
 })
 
 ServerEvents.tags('item', allthemods => {
-  //Extreme Reactors
+  // Extreme Reactors
   allthemods.add('c:ingots/yellorium', 'alltheores:uranium_ingot' )
   allthemods.add('c:storage_blocks/yellorium', 'alltheores:uranium_block' )
 
+  // Tiny Coal
+  allthemods.add('atm10:tiny_coals', [
+    'utilitarian:tiny_coal',
+    'actuallyadditions:tiny_coal',
+  ])
+  allthemods.add('atm10:tiny_charcoals', [
+    'utilitarian:tiny_charcoal',
+    'actuallyadditions:tiny_charcoal',
+  ])
 })
 
 ServerEvents.tags('entity_type', allthemods => {
@@ -22,10 +30,10 @@ ServerEvents.tags('entity_type', allthemods => {
   allthemods.add('justdirethings:paradox_deny', /productivebees:/);
   allthemods.add('industrialforegoing:mob_duplicator_blacklist', /productivebees:/)
 
-  //AllTheModium
+  // Allthemodium
   allthemods.add('justdirethings:paradox_deny', 'allthemodium:piglich');
   allthemods.add('industrialforegoing:mob_duplicator_blacklist', 'allthemodium:piglich')
-
 });
+
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.

--- a/kubejs/server_scripts/mods/Utilitarian/Recipes.js
+++ b/kubejs/server_scripts/mods/Utilitarian/Recipes.js
@@ -6,6 +6,9 @@ ServerEvents.recipes(allthemods => {
         R: 'minecraft:redstone',
         S: 'minecraft:chiseled_stone_bricks'
     })
+
+    allthemods.remove({ id: 'utilitarian:tiny_fuel/coal'})
+    allthemods.remove({ id: 'utilitarian:tiny_fuel/charcoal'})
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.


### PR DESCRIPTION
- Unified the Tiny Coal and Tiny Charcoal from Actually Additions with the Tiny Coal and Tiny Charcoal from Utilitarian.
- Removed duplicate Tiny Coal and Tiny Charcoal recipes.
- Added 2 item tags for Tiny Coal and Tiny Charcoal.