### PR TITLE
Unified Steel Tools and Armour

### DIFF
--- a/config/jei/blacklist.json
+++ b/config/jei/blacklist.json
@@ -1,0 +1,21 @@
+[
+  {"version":2},
+  {"hide_mode":"WILDCARD","ingredient":{"ingredient":{"id":"immersiveengineering:pickaxe_steel"},"type":"item_stack"}},
+  {"hide_mode":"WILDCARD","ingredient":{"ingredient":{"id":"immersiveengineering:shovel_steel"},"type":"item_stack"}},
+  {"hide_mode":"WILDCARD","ingredient":{"ingredient":{"id":"immersiveengineering:axe_steel"},"type":"item_stack"}},
+  {"hide_mode":"WILDCARD","ingredient":{"ingredient":{"id":"immersiveengineering:hoe_steel"},"type":"item_stack"}},
+  {"hide_mode":"WILDCARD","ingredient":{"ingredient":{"id":"immersiveengineering:sword_steel"},"type":"item_stack"}},
+  {"hide_mode":"WILDCARD","ingredient":{"ingredient":{"id":"railcraft:steel_sword"},"type":"item_stack"}},
+  {"hide_mode":"WILDCARD","ingredient":{"ingredient":{"id":"railcraft:steel_hoe"},"type":"item_stack"}},
+  {"hide_mode":"WILDCARD","ingredient":{"ingredient":{"id":"railcraft:steel_axe"},"type":"item_stack"}},
+  {"hide_mode":"WILDCARD","ingredient":{"ingredient":{"id":"railcraft:steel_pickaxe"},"type":"item_stack"}},
+  {"hide_mode":"WILDCARD","ingredient":{"ingredient":{"id":"railcraft:steel_shovel"},"type":"item_stack"}},
+  {"hide_mode":"WILDCARD","ingredient":{"ingredient":{"id":"railcraft:steel_boots"},"type":"item_stack"}},
+  {"hide_mode":"WILDCARD","ingredient":{"ingredient":{"id":"railcraft:steel_chestplate"},"type":"item_stack"}},
+  {"hide_mode":"WILDCARD","ingredient":{"ingredient":{"id":"railcraft:steel_helmet"},"type":"item_stack"}},
+  {"hide_mode":"WILDCARD","ingredient":{"ingredient":{"id":"railcraft:steel_leggings"},"type":"item_stack"}},
+  {"hide_mode":"WILDCARD","ingredient":{"ingredient":{"id":"immersiveengineering:armor_steel_boots"},"type":"item_stack"}},
+  {"hide_mode":"WILDCARD","ingredient":{"ingredient":{"id":"immersiveengineering:armor_steel_leggings"},"type":"item_stack"}},
+  {"hide_mode":"WILDCARD","ingredient":{"ingredient":{"id":"immersiveengineering:armor_steel_chestplate"},"type":"item_stack"}},
+  {"hide_mode":"WILDCARD","ingredient":{"ingredient":{"id":"immersiveengineering:armor_steel_helmet"},"type":"item_stack"}}
+]

--- a/kubejs/server_scripts/Unification/steel_tools.js
+++ b/kubejs/server_scripts/Unification/steel_tools.js
@@ -1,0 +1,62 @@
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
+
+ServerEvents.recipes(allthemods => {
+    // Tools
+    allthemods.remove({ id: 'mekanismtools:steel/tools/sword'})
+    allthemods.remove({ id: 'railcraft:steel_sword'})
+    allthemods.remove({ id: 'immersiveengineering:crafting/sword_steel'})
+    allthemods.remove({ id: 'mekanismtools:steel/tools/pickaxe'})
+    allthemods.remove({ id: 'railcraft:steel_pickaxe'})
+    allthemods.remove({ id: 'immersiveengineering:crafting/pickaxe_steel'})
+    allthemods.remove({ id: 'mekanismtools:steel/tools/axe'})
+    allthemods.remove({ id: 'railcraft:steel_axe'})
+    allthemods.remove({ id: 'immersiveengineering:crafting/axe_steel'})
+    allthemods.remove({ id: 'mekanismtools:steel/tools/shovel'})
+    allthemods.remove({ id: 'railcraft:steel_shovel'})
+    allthemods.remove({ id: 'immersiveengineering:crafting/shovel_steel'})
+    allthemods.remove({ id: 'mekanismtools:steel/tools/hoe'})
+    allthemods.remove({ id: 'railcraft:steel_hoe'})
+    allthemods.remove({ id: 'immersiveengineering:crafting/hoe_steel'})
+    allthemods.remove({ id: 'mekanismtools:steel/tools/paxel'})
+
+    allthemods.shaped('mekanismtools:steel_sword', [' S ', ' S ', ' R '], {
+        S: '#c:ingots/steel',
+        R: '#c:rods/wooden'
+    }).id('allthemods:mekanismtools/steel_sword')
+    allthemods.shaped('mekanismtools:steel_pickaxe', ['SSS', ' R ', ' R '], {
+        S: '#c:ingots/steel',
+        R: '#c:rods/wooden'
+    }).id('allthemods:mekanismtools/steel_pickaxe')
+    allthemods.shaped('mekanismtools:steel_axe', ['SS ', 'SR ', ' R '], {
+        S: '#c:ingots/steel',
+        R: '#c:rods/wooden'
+    }).id('allthemods:mekanismtools/steel_axe')
+    allthemods.shaped('mekanismtools:steel_shovel', [' S ', ' R ', ' R '], {
+        S: '#c:ingots/steel',
+        R: '#c:rods/wooden'
+    }).id('allthemods:mekanismtools/steel_shovel')
+    allthemods.shaped('mekanismtools:steel_hoe', ['SS ', ' R ', ' R '], {
+        S: '#c:ingots/steel',
+        R: '#c:rods/wooden'
+    }).id('allthemods:mekanismtools/steel_hoe')
+    allthemods.shaped('mekanismtools:steel_paxel', ['APS', ' R ', ' R '], {
+        A: 'mekanismtools:steel_axe',
+        P: 'mekanismtools:steel_pickaxe',
+        S: 'mekanismtools:steel_shovel',
+        R: '#c:rods/wooden'
+    }).id('allthemods:mekanismtools/steel_paxel')
+
+    // Armor
+    allthemods.remove({ id: 'immersiveengineering:crafting/armor_steel_helmet'})
+    allthemods.remove({ id: 'immersiveengineering:crafting/armor_steel_chestplate'})
+    allthemods.remove({ id: 'immersiveengineering:crafting/armor_steel_leggings'})
+    allthemods.remove({ id: 'immersiveengineering:crafting/armor_steel_boots'})
+    allthemods.remove({ id: 'railcraft:steel_helmet'})
+    allthemods.remove({ id: 'railcraft:steel_chestplate'})
+    allthemods.remove({ id: 'railcraft:steel_leggings'})
+    allthemods.remove({ id: 'railcraft:steel_boots'})
+})
+
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.


### PR DESCRIPTION
Unifies Steel tools and armour.

Removes Immersive Engineering and RailCraft Steel tools and armour recipes.
Changes Mekanism tools to use Sticks instead of Iron Ingots as handles.
Hides Steel tools and armour that don't have recipes from JEI.

First time using the new JEI hide mode, everything works in game but make sure to check.
If this works I can do the same with other tools and armour that have multiple versions.