### PR TITLE
Quest Fixes and a few French quest Titles

### DIFF
--- a/config/ftbquests/quests/chapters/bounty_board.snbt
+++ b/config/ftbquests/quests/chapters/bounty_board.snbt
@@ -541,12 +541,6 @@
 					type: "item"
 				}
 				{
-					exclude_from_claim_all: true
-					id: "66C49399D8CCD721"
-					table_id: 487623848494439020L
-					type: "random"
-				}
-				{
 					id: "2052F84B9D14A141"
 					type: "xp"
 					xp: 100
@@ -1208,11 +1202,10 @@
 		{
 			icon: {
 				components: {
-					"ftbquests:icon": "ftbchunks:textures/faces/minecraft/warden.png"
+					"ftbquests:icon": "minecraft:textures/entity_icon/warden/warden.png"
 				}
 				id: "ftbquests:custom_icon"
 			}
-			icon_scale: 1.25d
 			id: "0E20A9B79D1C6637"
 			rewards: [
 				{

--- a/config/ftbquests/quests/chapters/productive_bees.snbt
+++ b/config/ftbquests/quests/chapters/productive_bees.snbt
@@ -2171,14 +2171,9 @@
 				xp: 100
 			}]
 			tasks: [{
-				icon: {
-					components: {
-						"productivebees:bee_type": "productivebees:nickel"
-					}
-					id: "productivebees:configurable_honeycomb"
-				}
-				id: "05E237133AC3F46B"
-				item: { components: { "ftbfiltersystem:filter": "component(fuzzy:{\"productivebees:bee_type\":\"productivebees:nickel\"})" }, count: 1, id: "ftbfiltersystem:smart_filter" }
+				id: "1E37FD73461EFA29"
+				item: { components: { "productivebees:bee_type": "productivebees:nickel" }, count: 1, id: "productivebees:configurable_honeycomb" }
+				match_components: "fuzzy"
 				type: "item"
 			}]
 			x: -1.0d

--- a/config/ftbquests/quests/chapters/steam_age.snbt
+++ b/config/ftbquests/quests/chapters/steam_age.snbt
@@ -342,18 +342,11 @@
 					xp: 25
 				}
 			]
-			tasks: [
-				{
-					id: "198CAAA315816D0F"
-					item: { components: { "ftbfiltersystem:filter": "ftbfiltersystem:item_tag(c:dusts/bronze)" }, count: 1, id: "ftbfiltersystem:smart_filter" }
-					type: "item"
-				}
-				{
-					id: "065FC2FF2CE5C297"
-					item: { components: { "ftbfiltersystem:filter": "ftbfiltersystem:item_tag(c:ingots/bronze)" }, count: 1, id: "ftbfiltersystem:smart_filter" }
-					type: "item"
-				}
-			]
+			tasks: [{
+				id: "60664FB240C4C7EF"
+				item: { count: 1, id: "alltheores:bronze_ingot" }
+				type: "item"
+			}]
 			x: -16.5d
 			y: -6.5d
 		}

--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -378,7 +378,6 @@
 		"&cRemember:&r Chanced outputs increase with the tier of the machine"
 	]
 	quest.03B5D467E76C5B8A.quest_subtitle: "More like futile dust"
-	quest.03B6A49B6E475AD3.title: "Machines and You"
 	quest.03B842E4A2A6B2C9.quest_subtitle: "Good for manganese"
 	quest.03B842E4A2A6B2C9.title: "Grossular Vein"
 	quest.03C40D6A5D722543.quest_desc: ["Variable Cards are necessary for starting Interactions like Importing Items. You will put them in one of the slots of the Importer to add them. \\n\\nFrom there you can edit everything via the + Button. You can change how much is Importer, which Item Slot, which Channel, practically everything with just that Card. \\n\\nIf you're like me just wanting to move items, nothing too fancy just put it in and maybe change the Limit for how much is moved."]
@@ -1292,7 +1291,6 @@
 	quest.0E057B7F76401421.title: "&6Copper Backpack"
 	quest.0E0CAA31480EC0A1.quest_desc: ["Allows the Backpack to pick up items."]
 	quest.0E0CAA31480EC0A1.quest_subtitle: "Allows the backpack to pick up items."
-	quest.0E0CAA31480EC0A1.title: "Pickup Upgrade"
 	quest.0E20A9B79D1C6637.title: "Kill The Warden"
 	quest.0E25CDB09FE88A63.title: "Saltpeter Seeds"
 	quest.0E2AD156E5EF263A.quest_desc: ["Used to inscribe spells on with the Scribe's Table."]
@@ -1444,13 +1442,7 @@
 	quest.0F49E9167B5E97C9.quest_desc: ["Any damage you take when falling (ignoring armor) will also be dealt to nearby mobs."]
 	quest.0F49E9167B5E97C9.quest_subtitle: "Max: 1"
 	quest.0F5549B02D1B383B.quest_desc: ["Kill 16 Cave Spiders. \\n\\nDon't worry there is plenty of things from &6&lBumblezone&r to help with Poison."]
-	quest.0F55D0B4D5094EDB.quest_desc: [
-		"While making a lot of the questlines for ATM7, the Trader Villager thought it'd be funny to constantly push me around in the quest screen."
-		""
-		"\"Take them out. All of them.\""
-		""
-		"- AlfredGG"
-	]
+	quest.0F55D0B4D5094EDB.quest_desc: ["While making a lot of the questlines for ATM7, the Trader Villager thought it'd be funny to constantly push me around in the quest screen.\\n\\n\"Take them out. All of them.\"\\n\\n- AlfredGG"]
 	quest.0F55D0B4D5094EDB.quest_subtitle: "\"This is Personal\" - AlfredGG"
 	quest.0F55D0B4D5094EDB.title: "Kill The Trader Villager and His Annoying Llamas"
 	quest.0F6FB959B352121D.quest_desc: [
@@ -9232,7 +9224,7 @@
 		"Turns Lava into Obsidian."
 	]
 	quest.6581D4AF1A6DE230.quest_desc: ["Demons like Candles. I think.\\n\\nFor almost every Ritual to summon our friends, you'll need some Candles. You can create the &aButcher Knife&r and kill some pigs, cows, sheep, horses, or even the Trader Llamas to get some &aTallow&r to make them. Matter of fact, you should definitely find the Trader Llamas. I hear they make good candles. &mI totally didn't just make that up&r.\\n\\nOtherwise, Vanilla Candles can also work!\\n\\n&9Spirit Attuned Crystals&r are also used in several Rituals, so might as well make some now!"]
-	quest.6581D4AF1A6DE230.title: "Preparing for a Ritual: &aCandles&r"
+	quest.6581D4AF1A6DE230.title: "Preparing for a Ritual: &aCandles"
 	quest.659531F14E62EBEB.quest_desc: ["One Scroll you'll need applied to get Replica is the Scroll of Damage Exchange. To get it do the Ritual of Damage Exchange with 1 Powdered Iron and 2 Powdered Emeralds."]
 	quest.659531F14E62EBEB.title: "Scroll of Damage Exchange"
 	quest.659A903F97F93BE2.quest_subtitle: "Quick and Simple"
@@ -11653,7 +11645,7 @@
 	quest.7E9CD5C38BF5970F.quest_subtitle: "3 ZPM components now"
 	quest.7E9CD5C38BF5970F.title: "Onward to ZPM Machines"
 	quest.7E9E03274A88347D.quest_desc: ["Increases stack size in the Backpack by 2."]
-	quest.7E9E03274A88347D.title: "Stack Upgrade Tier 1"
+	quest.7E9E03274A88347D.title: "&fStack Upgrade Tier 1"
 	quest.7EA6B942D1294ED6.quest_desc: ["This machine can mine for you!\\n\\nIt is completely configurable, and can even replace mined blocks with cobblestone, or whatever block you provide it with!"]
 	quest.7EA6B942D1294ED6.quest_subtitle: "A bigger robot friend."
 	quest.7EAFF64FFE8B5378.quest_subtitle: "Iron + Sweat"
@@ -11685,7 +11677,6 @@
 	quest.7EFBAF3E281D2EBE.quest_subtitle: "The spare chest"
 	quest.7EFBFF5D0DA018E7.quest_desc: ["Adds a filter for items you want to auto-delete in the Backpack."]
 	quest.7EFBFF5D0DA018E7.quest_subtitle: "Adds a filter for items you want to auto-delete in the backpack."
-	quest.7EFBFF5D0DA018E7.title: "Void Upgrade"
 	quest.7F042DED357DEF3C.quest_desc: ["Bookshelves are your starting point, but definitely not your end point. Atleast not normal bookshelves. With only normal bookshelves you can only get &aEterna&r up and to a max of 15. (I will explain the Enchantment Levels soon but just know you need them up)"]
 	quest.7F042DED357DEF3C.title: "Vanilla Max is just the start"
 	quest.7F076FC4F2187692.quest_subtitle: "&f8 &cAttack Damage"
@@ -11835,9 +11826,9 @@
 	task.05072073E048223B.title: "Quests By AllTheMods"
 	task.05256FE880D981D5.title: "Vibranium Tools"
 	task.05A215BE7EE2F35D.title: "Observe Uranium Hexafluoride in a Machine"
-	task.05E237133AC3F46B.title: "Nickel Comb"
 	task.064B1841F9288CC3.title: "Blocks"
 	task.065E5450AC87F1D5.title: "Ancient Comb"
+	task.06D8E0295DAE3C50.title: "Machines and You"
 	task.06F2EC3901908BF1.title: "Plastic Construction Bricks"
 	task.073D1C45B3018BBA.title: "Chests"
 	task.0740BC10E4D2568F.title: "Regions Unexplored Stones"
@@ -12098,6 +12089,7 @@
 	task.3B219688DA1CF9C8.title: "AllRightsReserved"
 	task.3B35F86B42989063.title: "Crimson Shroombee Comb"
 	task.3B3B58C438FD4397.title: "Tier 4 Ore Processing Factory Summary"
+	task.3B6E674F4C958EA6.title: "Hammers"
 	task.3BEA6C6A41D5ABEA.title: "Furnace Augments"
 	task.3C16167530BEC231.title: "AllRightsReserved"
 	task.3C18AB7133946682.title: "Paxels"

--- a/config/ftbquests/quests/lang/es_es.snbt
+++ b/config/ftbquests/quests/lang/es_es.snbt
@@ -10435,7 +10435,6 @@
 	task.04CFF2F4E5B3813B.title: "Observed a Completed Large Chemical Bath"
 	task.04E3568175E66B6D.title: "Observe completed Cracker"
 	task.05A215BE7EE2F35D.title: "Observe Uranium Hexafluoride in a Machine"
-	task.05E237133AC3F46B.title: "Nickel Comb"
 	task.065E5450AC87F1D5.title: "Ancient Comb"
 	task.07896B715ED0E04F.title: "Any Brass Ingot"
 	task.083086610639994F.title: "To &9Everbright&r!"

--- a/config/ftbquests/quests/lang/fr_fr.snbt
+++ b/config/ftbquests/quests/lang/fr_fr.snbt
@@ -23,11 +23,13 @@
 	chapter.3202C575456F57D2.title: "Botania"
 	chapter.37A28F4697946CB4.title: "Basse Tension"
 	chapter.37A5A4A81CCB67E5.title: "Haute Tension"
+	chapter.37BC0E99F564D560.title: "Ère de la vapeur"
 	chapter.3C78926E5D301BA0.title: "Extreme Reactors"
 	chapter.403105E8F21D82C7.title: "Étapes"
 	chapter.415BA265E2C00859.title: "Débuter"
 	chapter.435C9D14D471D326.title: "Ère de la vapeur"
 	chapter.489F28A71282B3E7.title: "Tension Extrême"
+	chapter.5103E2D95685ADFF.title: "&aChapitre 2&r: &6L'Étoile ATM"
 	chapter.560EF4C38DEACA03.title: "EvilCraft"
 	chapter.574AC3A76DC03364.title: "Moyenne Tension"
 	chapter.5B00676D79306EA2.title: "Bienvenue"
@@ -50,6 +52,8 @@
 	quest.001B11C3773022DE.quest_desc: ["La Rectification est une quantité qui fonctionne avec Quanta, elle détermine si les enchantements seront bons ou mauvais. Plus il y a de Rectification, meilleurs sont les enchantements. Probablement nécessaire pour ceux qui veulent de bons équipements."]
 	quest.001B11C3773022DE.title: "Rectification"
 	quest.0060BCEDABC9BE2E.title: "Stockage de l'expérience"
+	quest.019CA0E35F888222.title: "&eModule de restock avancée"
+	quest.0298A17C2AAC5765.title: "&bModule d'empillement Niveau 3"
 	quest.05F186C95510BD4B.title: "Prévention des apparitions de monstres"
 	quest.061244C38F05CBFE.quest_subtitle: "Épique"
 	quest.061244C38F05CBFE.title: "&5Graines Arcanes&r"
@@ -75,13 +79,7 @@
 	quest.0E20A9B79D1C6637.title: "Tuer le Gardien des Profondeurs"
 	quest.0EB5B926E1FBAF0E.quest_desc: ["L'enchantement subit quelques modifications avec Apotheosis. Pour le résumer, 15 bibliothèques ne suffiront plus maintenant. De nouvelles bibliothèques ont été introduites, et des fonctionnalités supplémentaires sont désormais disponibles avec les tables d'enchantement. Nous espérons que ces quêtes vous fourniront les informations nécessaires pour une meilleure compréhension."]
 	quest.0EB5B926E1FBAF0E.title: "Enchantement avec Apotheosis"
-	quest.0F55D0B4D5094EDB.quest_desc: [
-		"'En créant de nombreuses lignes de quêtes pour l'ATM7, le Villageois Marchand a pensé que ce serait amusant de me pousser constamment dans l'écran de quête."
-		""
-		"Éliminez-les. Tous.'"
-		""
-		"- AlfredGG"
-	]
+	quest.0F55D0B4D5094EDB.quest_desc: ["'En créant de nombreuses lignes de quêtes pour l'ATM7, le Villageois Marchand a pensé que ce serait amusant de me pousser constamment dans l'écran de quête.\\n\\nÉliminez-les. Tous.'\\n\\n- AlfredGG"]
 	quest.0F55D0B4D5094EDB.quest_subtitle: "'C'est personnel' - AlfredGG"
 	quest.0F55D0B4D5094EDB.title: "Tuer le Villageois Marchand et ses Ennuyeux Lamas"
 	quest.0F77A9AD1F422537.quest_desc: ["La Bibliothèque de l'Enfer Lumineuse est une amélioration de la Bibliothèque de l'Enfer Infusée. Elle augmente également l'Eterna max, mais ce ne sont pas les statistiques que nous recherchons pour l'enchantement. Indubitablement utile pour l'enchantement ordinaire toutefois!"]
@@ -94,12 +92,14 @@
 	quest.10C527C66EE4E95A.title: "Bibliothèque Skulk touchée par l'Âme"
 	quest.1124A964E1B8E0EE.quest_desc: ["La Fiole de Désignation fait ce qu'elle suggère. Lorsque vous avez un objet avec un nom maladroitement long, vous pouvez le combiner avec la fiole dans une table de forgeron pour vous débarrasser de la plupart du nom. (Seul le matériau et le type d'arme, ainsi que la couleur de rareté, resteront)."]
 	quest.1124A964E1B8E0EE.title: "Fiole de Désignation"
+	quest.11D57C768032E3F7.title: "&eModule d'aimant avancée"
 	quest.12282CBB658F1132.quest_desc: ["Les charmes sont de nouvelles composantes avec Apotheosis qui vous permettent d'obtenir des effets de potion pendant beaucoup plus longtemps. Vous pouvez les infuser pour les rendre incassables. Il vous faut 50 Eterna, entre 8,5 et 13,5 Quanta, et entre 32,5 et 37,5 Arcana. Une façon de le faire est avec 5 Bibliothèques de l'End Draconique, 6 Bibliothèques de l'Enfer Lumineuse, 1 Bibliothèque l'Enfer Ardente, 1 Bibliothèque Marine Forgée par le Cœur et 2 Bibliothèques de Melons. {Au fait, j'ai utilisé n'importe quelle balise de Charme Curieux, donc certains objets qui peuvent être utilisés dans la quête ne peuvent pas être rendus incassables, seuls les charmes d'Apotheosis le peuvent. )"]
 	quest.12282CBB658F1132.title: "Rendre les charmes d'Apotheosis incassables"
 	quest.12F4980CB3BFCE0D.quest_desc: ["Vous avez déjà passé 3 mois à étudier le Code Galactique pour comprendre enfin le langage de la Table d'enchantement juste pour que cela soit du charabia? Non? De même pour moi, cependant, les indices d'enchantement servent de véritable interprète. Chaque indice d'enchantement vous révélera un enchantement avant de l'appliquer."]
 	quest.12F4980CB3BFCE0D.title: "Indices d'enchantement"
 	quest.14C8FC3F19190054.quest_subtitle: "ZZZzzz..."
 	quest.14C8FC3F19190054.title: "Conforts"
+	quest.15CD4BFDC56E9510.title: "&eModule d'échange d'outils avancée"
 	quest.15D56588634665FA.title: "Carotte d'AllTheModium"
 	quest.166DF03D93BC11F1.quest_desc: ["La Table de Recalibrage fait tout ce que fait une table simple mais en mieux, elle peut également ajouter des affixes épiques et mythiques!"]
 	quest.166DF03D93BC11F1.title: "(Meilleure) Table de Recalibrage"
@@ -108,12 +108,14 @@
 	quest.1770FF93638B3F22.quest_desc: ["Le Sigil Supérieur d'Enchatonnage fait exactement ce que fait sa version inférieure, mais avec jusqu'à 4 encoches au lieu de 3."]
 	quest.1770FF93638B3F22.title: "Sigil supérieur d'enchatonnage"
 	quest.17F3AC15ADCFB175.quest_subtitle: "Tuer 5 Enderman"
-	quest.17F3AC15ADCFB175.title: "&l&9Prime dans l'End :&r&e Enderman"
+	quest.17F3AC15ADCFB175.title: "&l&9Prime dans l'End:&r&e Enderman"
 	quest.1827DEEA2DF1B144.title: "Nourriture et Agriculture"
 	quest.186593EBCE3FE8D8.quest_desc: ["La Portée d'Apparition est la zone où les monstres peuvent apparaître. Plus la zone est grande, plus il y a de place pour qu'ils apparaissent. Plus la zone est petite, moins cher est l'usine."]
 	quest.186593EBCE3FE8D8.title: "Portée d'apparition"
+	quest.1985CFD1F0425E88.title: "&eModule de collecte avancée"
 	quest.1A507E77BF750F60.quest_desc: ["La Table de Récupération peut enfin vous procurer des matériaux et de la Poussière de Gemme sans utiliser d'enclumes. Vous pouvez recycler des outils et des armures avec des affixes pour obtenir leurs matériaux. Et démonter des armures pour chevaux, pour une raison quelconque."]
 	quest.1A507E77BF750F60.title: "Table de Récupération"
+	quest.1A739D36D5E3B1AD.title: "&eModule de nourriture avancée"
 	quest.1AD87CB3226ED224.quest_desc: ["La seule fonction de la Laine pour le générateur est de le rendre silencieux. Vous n'aimez pas entendre les bruits stupides du Générateur? Alors utilisez de la Laine! Indépendamment de la couleur, du fil ou du motif!"]
 	quest.1AD87CB3226ED224.title: "Calmez-vous, vous allez réveiller les monstres !"
 	quest.1D06097B6206BA60.quest_desc: ["L'infusion est une version spéciale de l'enchantement qui est ironiquement utilisée pour de meilleurs enchantements. Lorsque la bonne quantité d'Eterna, Quanta et Arcana est atteinte, les enchantements offriront l'infusion. (Pour connaître les niveaux nécessaires, vous pouvez consulter JEI ou suivre ces quêtes)"]
@@ -121,7 +123,7 @@
 	quest.1E92D4FEB8E96BBF.quest_desc: ["Cet objet peut être trouvé en tant que butin à l'intérieur des bibliothèques des &aDonjons&r de l'Autre-Monde."]
 	quest.1E92D4FEB8E96BBF.title: "&dAméliorations d'Unobtainium&r"
 	quest.1F18B64C84C8809D.quest_subtitle: "Tuer 5 Araignées"
-	quest.1F18B64C84C8809D.title: "&l&9Prime dans l'Overworld :&r&e Araignées"
+	quest.1F18B64C84C8809D.title: "&l&9Prime dans l'Overworld:&r&e Araignées"
 	quest.217DB12EA32E1724.title: "&bCrystal d'infusion"
 	quest.218803812A9C332B.quest_desc: ["Pour obtenir des enchantements et niveaux max plus élevés, vous aurez besoin de Bibliothèques Infusées. Pour les obtenir, vous aurez besoin de 22,5 Eterna et de 30% de Quanta. La meilleure façon de les obtenir serait avec 15 bibliothèques classiques et 5 Bibliothèques de l'Enfer."]
 	quest.218803812A9C332B.title: "Bibliothèque de l'Enfer infusée"
@@ -131,6 +133,7 @@
 	quest.21EE522DDBF0BF72.title: "Bibliothèque de l'End"
 	quest.24526FFBA093805A.quest_desc: ["Apotheosis sait à quel point il peut être ennuyeux d'obtenir des Trident, alors ils l'ont facilité... enfin, un peu plus facile. Vous pouvez maintenant fabriquer un trident inerte et l'infuser pour obtenir un trident normal. Le trident nécessite entre 20 et 30 Eterna, entre 20% et 50% de Quanta, et au moins 35% d'Arcana. Vous pouvez obtenir cela avec 4 Bibliothèques Skulk résonnantes ou 2 Bibliothèques Marines Cristallines et 6 Bibliothèques Marine Forgée par le Cœur."]
 	quest.24526FFBA093805A.title: "Création d'un vrai trident"
+	quest.26988E22BD019628.title: "&eModule du haut fourneau automatique"
 	quest.28260B53A3F9E57D.title: "&bArmure en Vibranium&r"
 	quest.29637BD992599915.title: "&6Armure en Allthemodium&r"
 	quest.2A2E3D020B1F5126.title: "Baguettes de construction"
@@ -152,6 +155,9 @@
 		"Note: Pour trouver le minerai, il doit être à découvert et exposé à l'air!"
 	]
 	quest.2DF64CB9298E91EA.title: "Minerai de Vibranium"
+	quest.2F4458E9921DEB86.title: "&aTuyau de gaz"
+	quest.2F9B0C642A6BE30C.title: "&fSac à dos en Fer"
+	quest.2FC15D3916DBF4E4.title: "&eModule du Vide avancée"
 	quest.30E6C6825D78B5F1.quest_desc: ["Note: Bien que le &aModèle d'amélioration&r ne soit pas nécessaire pour créer l'outil initial, il vous fera économiser beaucoup d'&6lingots d'Allthemodium&r!"]
 	quest.30E6C6825D78B5F1.title: "&6Outils en Allthemodium&r"
 	quest.30EB438C66324213.quest_desc: ["Le Conduit fera ce que font les éclats de Prismarine, mais en mieux. Les joueurs n'ont plus besoin d'être près du générateur. Tant qu'il est chargé en chunk, il générera."]
@@ -160,12 +166,15 @@
 	quest.310969B8FE0A94DE.title: "Apothic Spawners"
 	quest.314E41B84C8DD464.quest_desc: ["C'est sans doute l'un des blocs les plus importants ajoutés par Apotheosis, la bibliothèque d'enchantement. Vous placez des livres, ils s'accumulent au fil du temps et peuvent être retirés à tout moment. Attention 1. Il a des limites, des limites élevées mais des limites 2. Il ne peut extraire que le niveau le plus élevé placé, indépendamment de la quantité."]
 	quest.314E41B84C8DD464.title: "Bibliothèque d'enchantement"
+	quest.33433A443B65D252.title: "&bTuyau de fluide"
 	quest.3371F9248D403664.quest_subtitle: "Tuer 5 Wither Squelettes"
-	quest.3371F9248D403664.title: "&l&cPrime dans le Nether :&r&e Wither Squelettes"
+	quest.3371F9248D403664.title: "&l&cPrime dans le Nether:&r&e Wither Squelettes"
 	quest.353C7440B32F0A5E.quest_desc: ["Eterna définit le niveau d'enchantement qui détermine les enchantements que vous pouvez obtenir ou obtiendrez. Sa valeur par défaut est de 0 et le maximum est de 50."]
 	quest.353C7440B32F0A5E.title: "Eterna"
 	quest.359E1FFAB18FE50F.quest_desc: ["Vous avez des outils et des gemmes, alors comment les puis-je les combiner? Tout d'abord, assurez-vous que votre outil a une Encoche ouverte. (Pour plus d'informations sur les Encoches, consultez la section Fioles et Sigils). Si une Encoche est ouverte, vous pouvez combiner votre outil et votre Gemme dans une Table de Forgeron. Si vous n'êtes pas satisfait de vos Gemmes actuelles, vous pourriez avoir besoin d'une..."]
 	quest.359E1FFAB18FE50F.title: "Application de Gemmes (et autres)"
+	quest.36836AD948F96B9F.title: "&eTuyau d'item"
+	quest.36BCE35215B2B6E9.title: "&eModule du fumoir automatique"
 	quest.3708A4780ACEB34E.quest_desc: [
 		"Dans ce modpack, les quêtes sont facultatives. Les mods ne sont pas bloqués derrière l'achèvement de quêtes!"
 		""
@@ -178,6 +187,7 @@
 	quest.378C95C18798D413.title: "Ceinture à outils"
 	quest.37ACDA018D07A4DF.title: "&dOutils en Unobtainium&r"
 	quest.38135FFD9ED64395.title: "Alliage Vibranium-AllTheModium"
+	quest.3A1D07AED2A841E4.title: "&eModule du fourneau automatique"
 	quest.3BC0A50886A3222B.quest_desc: ["ATM10 est un pack 'kitchensink' qui vous permet d'explorer le monde de Minecraft moddé à votre manière!\\n\\nSi vous avez des questions ou des problèmes, n'hésitez pas à rejoindre le discord d'ATM!"]
 	quest.3BC0A50886A3222B.title: "&dBienvenue dans All The Mods 10!"
 	quest.3C322474D2F2BA99.quest_desc: [
@@ -212,19 +222,23 @@
 	]
 	quest.41C0948CD9D50322.quest_subtitle: "Tuer toutes ces choses"
 	quest.42822B1E8A53D051.quest_subtitle: "Tuer 5 Squelettes"
-	quest.42822B1E8A53D051.title: "&l&9Prime dans l'Overworld :&r&e Squelettes"
+	quest.42822B1E8A53D051.title: "&l&9Prime dans l'Overworld:&r&e Squelettes"
 	quest.42D7C8CD8E6F5CD7.quest_desc: ["En appliquant une Pomme d'Or sur un générateur, vous extrayez les âmes des monstres qui seront générées, ne laissant qu'une coquille vide de leur forme originale. Les monstres perdront toute IA, ils feront donc essentiellement ce qu'un support d'armure fait. Ils ne peuvent pas vous frapper, ne peuvent pas se téléporter, ne peuvent pas se déplacer d'eux-mêmes. Ils restent là, prêts à être tués, quelle excitation!"]
 	quest.42D7C8CD8E6F5CD7.title: "Pas d'IA"
 	quest.44D1B410550B6C28.quest_desc: ["Ce ne sont pas seulement les bibliothèques qui peuvent être infusées!"]
 	quest.44D1B410550B6C28.title: "Autres objets d'infusion"
+	quest.45268A619787288F.title: "&eSac à dos en Or"
+	quest.46D756F4DC6CC894.title: "&dSac à dos en Netherite"
 	quest.47317516A98016C0.quest_desc: ["Plus la Gemme est de qualité, meilleures sont les statistiques! Impeccable représente la seconde meilleure qualité, tandis que Parfait est le summum."]
 	quest.47317516A98016C0.title: "Gemmes sans défaut"
+	quest.47358ADC1470C82A.title: "&cFruit du rêve du démon"
 	quest.482190A9DBE834BE.quest_desc: ["Pour les novices d'Apotheosis, les encoches peuvent être déconcertantes et agaçantes. Vos armes et armures ont besoin d'encoches pour utiliser des Gemmes avec elles. Mais que faire s'il n'y a pas d'encoche? Alors vous aurez besoin d'un Sigil d'Enchatonnage! Combinez votre objet et le Sigil dans une Table de Forgeron et vous pourrez obtenir jusqu'à 3 encoches."]
 	quest.482190A9DBE834BE.title: "&5Sigil d'Enchatonnage&r"
 	quest.4881ABF8877BA572.title: "Hache en alliage"
 	quest.4A59DF02128DA9F3.quest_desc: ["La Bibliothèque de l'End Nacrée est la bibliothèque la plus polyvalente. Elle donne également un maximum d'Eterna de 45, mais ce n'est pas la bibliothèque que nous recherchons pour obtenir la configuration parfaite."]
 	quest.4A59DF02128DA9F3.title: "Bibliothèque de l'End Nacrée"
 	quest.4AD2F0AC870672DB.title: "Paxel en alliage"
+	quest.4C0EAB9F795686D0.title: "&eModule de dépose avancée"
 	quest.4C446F22771E2B53.quest_desc: ["Vous voulez LES enchantements les plus parfaits? Alors voici la configuration dont vous avez besoin, pour 100% de tout. 7 Bibliothèques Skulk résonnantes, 4 Bibliothèque Profonde touchée par l'Âme et 5 Bibliothèque Draconique vous donneront 50 Eterna, 100% de Quanta, 100% d'Arcana et 8 indices d'enchantement. 4 étagères de Rectification infusées donneront 100% de Rectification. Et la Bibliothèque Profonde des Trésors Arcanes couronnera le tout avec des enchantements de trésor."]
 	quest.4C446F22771E2B53.title: "Meilleure configuration d'enchantement"
 	quest.4D07B0A4A2E77CDA.quest_desc: ["Le nombre maximal d'entités est la quantité de monstres qui peuvent être générés par un générateur et conservés. S'il n'y a que 6 entités maximales et que 6 monstres sont déjà générés, aucun autre ne sera généré tant qu'ils ne seront pas morts ou déplacés. Chaque Larme de Ghast le fait monter ou descendre de 2 entités. Maximum de 16 entités et minimum de 1."]
@@ -234,6 +248,7 @@
 	quest.4F6E6AF1D9E74CB7.quest_desc: ["Un minerai extrêmement rare que l'on ne peut trouver que dans le biome Highlands de l'End."]
 	quest.4F6E6AF1D9E74CB7.title: "Minerai d'Unobtainium"
 	quest.4F84C91128C9DCED.title: "Pioche en alliage"
+	quest.4FBAB3A0FBF8CE2F.title: "&5Tuyau universel"
 	quest.50EEDDDE129D2742.quest_desc: ["Les bibliothèques de l'Enfer sont votre introduction à Quanta, elles donnent 3% de Quanta et 1,5 Eterna. Mieux que les bibliothèques classique, n'est-ce pas? Vous allez en avoir besoin d'au moins 6 pour la prochaine étape."]
 	quest.50EEDDDE129D2742.title: "Bibliothèques de l'Enfer"
 	quest.51CEE80605BFF40C.quest_subtitle: "Changements de Mahou dans ATM10"
@@ -244,11 +259,14 @@
 		"De manière similaire à l'Overworld->Nether, il existe un ratio de blocs de 1:50 pour l'End->l'Au-Delà."
 	]
 	quest.53DD784E75965947.title: "l'Au-Delà"
+	quest.53EC96FA0E7C4ED4.title: "&cTuyau d'énergie"
 	quest.544011D1C48D8E65.quest_desc: ["Table Tailleuse de Gemmes! Pour changer la Rareté de votre Gemme, vous devrez utiliser cette table. En utilisant 2 Gemmes identiques et des Matériaux de Rareté, vous pouvez augmenter la rareté de vos Gemmes et cela augmente leur puissance."]
 	quest.544011D1C48D8E65.title: "Améliorer les Gemmes"
 	quest.553DD7CBD4351A71.title: "&bOutils en Vibranium&r"
-	quest.56DA46DC82F6665D.quest_subtitle: "Ce n'est même pas ma forme finale."
+	quest.56B80A7EBFE21428.title: "&eModule de pompe amélioré"
+	quest.56DA46DC82F6665D.quest_subtitle: "Ce n'est même pas ma forme finale"
 	quest.56DA46DC82F6665D.title: "Tuer la Chimère Wilden"
+	quest.57CF8C6C867B9BDA.title: "&eModule de filtre avancée"
 	quest.58E3D29E2E034BA2.quest_desc: [
 		"Vous trouverez une tonne de minerais dans l'Autre-Monde. Elle regorge de génération de minerais incroyable, ainsi que de Forêts Anciennes."
 		""
@@ -261,7 +279,7 @@
 	quest.5A0305BB1F8EA932.title: "Équipement d'Apotheosis"
 	quest.5AC1BE754210429E.quest_desc: ["Si vous souhaitez créer une équipe pour vous et vos amis, utilisez la commande &a/ftbteams party create (nom de l'équipe)&r pour créer l'équipe!"]
 	quest.5AC497F76A086A5C.quest_subtitle: "Tuer 5 Sorcières"
-	quest.5AC497F76A086A5C.title: "&l&9Prime dans l'Overworld :&r&e Sorcières"
+	quest.5AC497F76A086A5C.title: "&l&9Prime dans l'Overworld:&r&e Sorcières"
 	quest.5B3CC3F66F2C3DE5.quest_desc: ["Les bibliothèques marines sont votre introduction à l'Arcana, elles donnent 2% d'Arcana et 1,5 Eterna. Mieux que les bibliothèques classique, n'est-ce pas? Vous allez en avoir besoin d'au moins 6 pour la prochaine étape."]
 	quest.5B3CC3F66F2C3DE5.title: "Bibliothèques Marines"
 	quest.5BDBE666E604FCAC.quest_desc: [
@@ -274,12 +292,13 @@
 	quest.5C56452BE7879D0A.title: "Quantités négatives"
 	quest.5D8A3491889F2C4E.quest_desc: ["Besoin de plus de &6Métaux ATM&r ? Élevez des abeilles!"]
 	quest.5D8A3491889F2C4E.title: "&6Productive ATM Bees&r"
+	quest.5E4FE420B6D2C97F.title: "&eModule compacteur avancée"
 	quest.5FD4F40CEC37D9FD.quest_desc: ["La Bibliothèque d'Alexandrie est une meilleure bibliothèque d'enchantement. Elle peut contenir plus, c'est tout. Vous devez infuser une bibliothèque d'enchantement. Il lui faut exactement 50 Eterna, entre 45 % et 50 % de Quanta, et 100 % d'Arcana. Cela peut être fait avec 7 Bibliothèques Skulk résonnantes et 2 Bibliothèques Draconiques."]
 	quest.5FD4F40CEC37D9FD.title: "Bibliothèque d'Alexandrie"
 	quest.606780E5B8CF83BE.quest_desc: ["Il se peut que vous ayez besoin d'éliminer quelques gardiens pour les obtenir, mais Apotheosis facilite la tâche! Cette bibliothèque est principalement destinée à l'Arcana, mais c'est une bonne source pour toutes les quantités. Elle sera nécessaire pour la prochaine infusion."]
 	quest.606780E5B8CF83BE.title: "Bibliothèque Skulk résonnante"
 	quest.6141DE779232C8AA.quest_subtitle: "Tuer 5 Blazes"
-	quest.6141DE779232C8AA.title: "&l&cPrime dans le Nether :&r&e Blazes"
+	quest.6141DE779232C8AA.title: "&l&cPrime dans le Nether:&r&e Blazes"
 	quest.6244032FE2E5F1E1.quest_desc: ["La Bibliothèque Draconique est la dernière bibliothèque dont nous aurons besoin pour une configuration parfaite. Il ne donne peut-être que de l'Eterna, mais il a un maximum d'Eterna de 50."]
 	quest.6244032FE2E5F1E1.title: "Bibliothèque de l'End Draconique"
 	quest.62B2C1A24AE245EA.quest_desc: ["La Bibliothèque Profonde (non dormant) est votre prochaine étape pour l'enchantement. Comme tout le reste, il a besoin d'infusion. La Bibliothèque Profonde a besoin de 30 Eterna, 40% de Quanta et 40% d'Arcana. Vous pouvez obtenir cela avec 5 Bibliothèques Flamboyante et 4 Bibliothèques Marine Forgée par le Cœur."]
@@ -287,8 +306,10 @@
 	quest.6501A410F1543C70.title: "&dEngrais Mystique"
 	quest.6631947900DB54E9.quest_desc: ["La Fiole d'Expulsion (Sismique) peut être utilisée dans une Table de Forgeron pour retirer une Gemme de l'encoche d'un objet. Attention, cela cassera la Gemme et ouvrira simplement une encoche."]
 	quest.6631947900DB54E9.title: "Fiole d'Expulsion Sismique"
+	quest.66ECC26BC81D0093.title: "Tier: &bBasique"
 	quest.67422A235EBAD4CF.quest_desc: ["Les armes avec des affixes peuvent être trouvées de nombreuses manières, mais comment savoir ce qui est affixé ? Les armes avec des affixes auront toujours des noms très longs, généralement avec le type d'arme et le nom de l'ancien propriétaire. Elle sera également colorée selon sa rareté, vert pour peu commune, bleu pour rare, et ainsi de suite. Elle aura également des statistiques bonus ou du moins une augmentation de la capacité d'enchantement."]
 	quest.67422A235EBAD4CF.title: "Objets avec des affixes"
+	quest.67704F7341EDCC49.title: "&bSac à dos en Diamant"
 	quest.68DD99B788216006.title: "&6Perle Forgée par les Dieux&r"
 	quest.6A497B063CF32A5C.quest_desc: ["Le Cœur de Piglich est largué par... eh bien, le Piglich. Il peut être utilisé pour augmenter la quantité de monstres qui PEUVENT apparaître d'un générateur. Les monstres générés sont aléatoires avec une quantité maximale déterminée par les Cœurs de Piglich. Il monte ou descend d'un pour chaque cœur, jusqu'à un maximum de 8."]
 	quest.6A497B063CF32A5C.title: "Nombre d'Apparitions"
@@ -296,6 +317,8 @@
 	quest.6BB9490E23CBD287.title: "Fioles et Sigils"
 	quest.6C76AB8A6110C0C7.quest_desc: ["La Bibliothèque de l'Enfer Flamboyante est une amélioration de la Bibliothèque de l'Enfer Infusée. Elle augmente l'Eterna max à 30. L'indice négatif d'enchantement la rend un peu moins bonne pour l'enchantement normal, mais nous pouvons l'utiliser pour une meilleure infusion."]
 	quest.6C76AB8A6110C0C7.title: "Bibliothèque de l'Enfer Flamboyante"
+	quest.6D88C19F47D0D469.title: "Tier: &7Petit"
+	quest.6E3D53D1C4569A89.title: "&aModule de pompe d'expérience"
 	quest.6F71FD826C29C31A.quest_desc: ["Ceci pourrait sembler nouveau pour ceux qui reviennent des versions précédentes. En utilisant un œuf de tortue sur un générateur, il ne générera que des versions bébé des monstres en lui-même. Cela ne fonctionne qu'avec les versions bébé vanilla des monstres, pas avec ceux des mods."]
 	quest.6F71FD826C29C31A.title: "Jeune"
 	quest.70B6C9409AE69284.quest_subtitle: "Aide à trouver des biomes"
@@ -318,9 +341,12 @@
 	quest.751189465F91B353.title: "Bibliothèque Marine Cristalline"
 	quest.777B6100B321DAA6.title: "&dArmure en Unobtainium&r"
 	quest.77FC692AC94D2EEF.quest_subtitle: "Tuer 5 Creepers"
-	quest.77FC692AC94D2EEF.title: "&l&9Prime dans l'Overworld :&r&e Creepers"
+	quest.77FC692AC94D2EEF.title: "&l&9Prime dans l'Overworld:&r&e Creepers"
+	quest.785951190FFDAA21.title: "&eModule d'empillement Niveau 2"
 	quest.7A9AE63998BB41FF.quest_desc: ["Pour déterminer quand le Générateur générera, il choisit un nombre aléatoire entre le retard de spawn maximum et minimum. Le minimum peut être aussi bas que 100 et aussi haut que 32 767. Chaque Lingot fait monter ou descendre de 10."]
 	quest.7A9AE63998BB41FF.title: "Retard minimum de Spawn"
+	quest.7AE3C8134F5ED726.title: "&dModule d'empillement Niveau 4"
+	quest.7C0F7A1B3AB9A1A1.title: "&eModule de rechargement avancée"
 	quest.7D3648FF86B0EB85.title: "Lame en alliage"
 	quest.7E8FE99A3C448413.quest_desc: [
 		"La &9Dimension minière&r possède plusieurs couches pour trouver des minerais!"
@@ -328,6 +354,7 @@
 		"Cette dimension est dotée des couches habituelles de &3Pierre&r et de &3Deepslate&r de l'Overworld, ainsi que d'une couche de &cNetherrack&r pour trouver des minerais du Nether, et enfin d'une couche de &ePierre de l'End&r pour les minerais de l'End."
 	]
 	quest.7E8FE99A3C448413.title: "Dimension Minière"
+	quest.7E9E03274A88347D.title: "&fModule d'empillement Niveau 1"
 	quest.7EC8814940C4C3D7.quest_desc: ["Utilisez cet objet pour rétrécir. Utile pour travailler sur l'automatisation et aussi juste pour s'amuser en général."]
 	quest.7EC8814940C4C3D7.quest_subtitle: "Chéri(e), j'ai rétréci les dimensions"
 	quest.7EC8814940C4C3D7.title: "Dispositif de rétrécissement personnel"
@@ -338,6 +365,7 @@
 	task.10A16F89D4AD238D.title: "Commandes Utiles"
 	task.3C380961550177C2.title: "Le tableau des primes"
 	task.3E7F26D68D9A166B.title: "Stockage de base"
+	task.41EEE559F6402D81.title: "Module créatif"
 	task.4F13A02FB0055A62.title: "Créer une Équipe"
 	task.52BB142F044075B4.title: "Quêtes"
 	task.5A1784C5676CDC62.title: "Bienvenue!"

--- a/config/ftbquests/quests/lang/ja_jp.snbt
+++ b/config/ftbquests/quests/lang/ja_jp.snbt
@@ -9884,7 +9884,6 @@
 	task.04CFF2F4E5B3813B.title: "完成したラージケミカルバスを観察"
 	task.04E3568175E66B6D.title: "完成したクラッカーを観察"
 	task.05A215BE7EE2F35D.title: "機械で六フッ化ウランを観察する"
-	task.05E237133AC3F46B.title: "ニッケルコーム"
 	task.065E5450AC87F1D5.title: "エンシェントコーム"
 	task.07896B715ED0E04F.title: "任意のブラスインゴット"
 	task.083086610639994F.title: "&9エバーブライト&rへ！"

--- a/config/ftbquests/quests/lang/nb_no.snbt
+++ b/config/ftbquests/quests/lang/nb_no.snbt
@@ -9954,7 +9954,6 @@
 	task.04CFF2F4E5B3813B.title: "Observed a Completed Large Chemical Bath"
 	task.04E3568175E66B6D.title: "Observe completed Cracker"
 	task.05A215BE7EE2F35D.title: "Observe Uranium Hexafluoride in a Machine"
-	task.05E237133AC3F46B.title: "Nickel Comb"
 	task.065E5450AC87F1D5.title: "Ancient Comb"
 	task.07896B715ED0E04F.title: "Any Brass Ingot"
 	task.083086610639994F.title: "To &9Everbright&r!"

--- a/config/ftbquests/quests/lang/pt_br.snbt
+++ b/config/ftbquests/quests/lang/pt_br.snbt
@@ -9953,7 +9953,6 @@
 	task.04CFF2F4E5B3813B.title: "Observou um grande banho químico concluído"
 	task.04E3568175E66B6D.title: "Observe o Cracker concluído"
 	task.05A215BE7EE2F35D.title: "Observe o hexafluoreto de urânio em uma máquina"
-	task.05E237133AC3F46B.title: "Pente de níquel"
 	task.065E5450AC87F1D5.title: "Pente Antigo"
 	task.07896B715ED0E04F.title: "Qualquer lingote de latão"
 	task.083086610639994F.title: "Para &9Everbright&r!"


### PR DESCRIPTION
- Fixed a broken image in the Bounty Board chapter
- Fixed a Productive Bees comb task
- Fixed 2 Smart Filters in the Steam Age chapter
- Fixed a Checkmark quest name in the Steam Age chapter
- Changed some line gaps to \n's
- Removed some useless &r's
- Added a name to a Smart Filter in the Steam Age chapter
- Added a missing colour to a quest name in the Basic Storage chapter
- Adds some French quest titles translations where the name is just the item name but coloured and some ports from ATM9
- Small fixes to French translations (incorrect spaces)