### PR TITLE
Fix spelling of 'valid'

### DIFF
--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -263,7 +263,7 @@
 	quest.027084AE2DF5EBA6.quest_subtitle: "Hot Brine here. Get Your Hot Brine here."
 	quest.027084AE2DF5EBA6.title: "Heating Up our Brine Production"
 	quest.0272E58516A0C284.quest_desc: [
-		"Vaild Upgrades:"
+		"Valid Upgrades:"
 		"- Ore Miner"
 		"- Ore Scanner &4&lDISABLED&r&f"
 		"- Lawnmower"
@@ -1088,7 +1088,7 @@
 	quest.0BFAF1499415DD68.quest_subtitle: "Silver Lime + Cherry"
 	quest.0C096EE635645E43.quest_desc: ["The Crystal Crossbow is a crafted like a Mechanical Crossbow just with Crystals instead of sticks. \\n\\nIt shoots Arrows and does same damage as a normal Crossbow but this one gives Crystal Infection. Crystal Infection does 1 damage every second with the Crystals that spawn on them! And yes it will kill them."]
 	quest.0C1D55AA9CC902BD.quest_desc: [
-		"Vaild Upgrades:"
+		"Valid Upgrades:"
 		"- Lawnmower"
 		"- Sky Sweeper"
 		"- Auto Smelter"
@@ -1141,7 +1141,7 @@
 	quest.0C98503A2F20484D.title: "Frosty Smogstem Forest"
 	quest.0C9C5639D76FDF65.quest_desc: ["Save 12 &6B&8e&6e&8s&r by reattaching their Stinger. \\n\\nWhen a &6B&8e&6e&8s&r hits a Mob or even you they will lose their Stinger which will give them a Fatal Poison. \\n\\nIf you Right Click them with a Stinger you can reattach it and save them!"]
 	quest.0C9DD8E53A1B92C0.quest_desc: [
-		"Vaild Upgrades:"
+		"Valid Upgrades:"
 		"- Ore Miner"
 		"- Auto Smelter"
 		"- Hammer"
@@ -2362,7 +2362,7 @@
 	quest.198EDBAC1D6E2339.quest_desc: ["You'll need these for Ender Bees."]
 	quest.198EDBAC1D6E2339.quest_subtitle: "Prevents Bees from Teleporting in a Hive"
 	quest.199388A311FAC14C.quest_desc: [
-		"Vaild Upgrades:"
+		"Valid Upgrades:"
 		"- Ore Miner"
 		"- Ore Scanner &4&lDISABLED&r&f"
 		"- Auto Smelter"
@@ -2406,7 +2406,7 @@
 	quest.19E356E67EF17E4A.quest_desc: ["Only the greatest Tool in history! Like a swiss army knife but better! \\n\\nHighest Mining Tier, chops down Trees like butter, makes pathways, and of course hits a lot to be hit by!"]
 	quest.19E356E67EF17E4A.title: "&6Allthemodium &5Alloy &3Paxel"
 	quest.19E6757F04098A0C.quest_desc: [
-		"Vaild Upgrades:"
+		"Valid Upgrades:"
 		"- Lawnmower"
 		"- Sky Sweeper"
 	]
@@ -2632,7 +2632,7 @@
 	quest.1DA0A87C471A38AC.title: "&aMob Farms using &cBlood"
 	quest.1DA6B8B2DCC97809.title: "Brass"
 	quest.1DAA5DD81EF96469.quest_desc: [
-		"Vaild Upgrades:"
+		"Valid Upgrades:"
 		"- Lawnmower"
 		"- Sky Sweeper"
 		"- Auto Smelter"
@@ -2942,7 +2942,7 @@
 	quest.20F9EF925DB1CE05.title: "&2Natural Alter"
 	quest.210A0DC6D5CAC236.quest_desc: ["The &dTier 4 Rocket&r is the highest tier Rocket that we can make. This will allow us to travel outside of our Solar System!"]
 	quest.21147C8CBF98AEB4.quest_desc: [
-		"Vaild Upgrades:"
+		"Valid Upgrades:"
 		"- Tree Feller"
 		"- Leaf Breaker"
 		"- Auto Smelter"
@@ -3187,7 +3187,7 @@
 		"- Auto Havesting"
 		"- Accelerated Crop Growth III"
 		""
-		"Vaid Upgrade:"
+		"Valid Upgrade:"
 		"- Drops Teleporter"
 	]
 	quest.238556F4074D52B2.quest_desc: [
@@ -3866,7 +3866,7 @@
 	quest.2B115519A21F9CB7.quest_desc: ["The &dEnder Guardian&r is a hulking beast of endstone,purpur, and obsidian. It has 4995 Hearts and 2 stages. In first stage it will have very basic attacks of punching you, dashing, using shulker orbs, hitting you with Void Runes, and can stunlock you. Once you beat it down half way it's helmet will break exposing it's real head and starting the 2nd stage. To start he will break the floor of the arena exposing the floor below, then he will use the same moves while pulling you closer. (Also he is immune to arrows so I hope you have a good sword!). Once killed it will drop a Gauntlet of Guard and has a chance of dropping its music disc: Eternal."]
 	quest.2B115519A21F9CB7.title: "&dEnder Guardian&r"
 	quest.2B1BAEC5DAAF9DAC.quest_desc: [
-		"Vaild Upgrades:"
+		"Valid Upgrades:"
 		"- Tree Feller"
 		"- Leaf Breaker"
 		"- Auto Smelter"
@@ -4269,7 +4269,7 @@
 	quest.2F71FCE4E576C977.quest_subtitle: "Generates Power using Lava!"
 	quest.2F76D074AEA84A4D.quest_desc: ["By Right Clicking an Ender Dragon with an empty Data Model, you can make the Ender Dragon Data Model. \\n\\nThe Quest only needs any version of it, but the Dragon Soul needs the Data Model to be Self Aware. \\n\\nIn order to get it Self Aware you need to keep killing the Dragon or make a crap-ton of Predictions!"]
 	quest.2F86FB9E4D49E4B0.quest_desc: [
-		"Vaild Upgrades:"
+		"Valid Upgrades:"
 		"- Mob Scanner"
 	]
 	quest.2F90CA5DF9225209.quest_subtitle: "&f12&r &4Damage&r"
@@ -4406,7 +4406,7 @@
 		"- Auto Havesting"
 		"- Accelerated Crop Growth IV"
 		""
-		"Vaid Upgrade:"
+		"Valid Upgrade:"
 		"- Drops Teleporter"
 	]
 	quest.313AA0A45CD2BBB9.quest_desc: ["To make wrought iron you need to smelt iron nuggets into wrought iron nuggets"]
@@ -4949,7 +4949,7 @@
 	quest.37B297640F537383.title: "&fUnattuned Augment"
 	quest.37B805E875D82A8B.quest_subtitle: "Balsa + Teak"
 	quest.37B903620493A354.quest_desc: [
-		"Vaild Upgrades:"
+		"Valid Upgrades:"
 		"- Auto Smoker"
 		"- Cauterize Wounds"
 		"- Drops Teleporter"
@@ -6327,7 +6327,7 @@
 	quest.46DCB235D3FEDA61.quest_desc: ["Similar to Iron Tools just all of these slow down whoever is hit by them. \\n\\nWell besides the Hoe, but do you really care about a simple hoe?"]
 	quest.46DCB235D3FEDA61.title: "&bFroststeel&r Tools"
 	quest.46E6B1600AA8A61E.quest_desc: [
-		"Vaild Upgrades:"
+		"Valid Upgrades:"
 		"- Mob Scanner"
 		"- Auto Smoker"
 		"- Cauterize Wounds"
@@ -7036,7 +7036,7 @@
 	quest.4E02DC8A474A4A2F.title: "Our First Flower"
 	quest.4E03AC9D56202353.quest_desc: ["Combining an &2Elven Mana Spreader&r with the power of Dragonstones and a &6Gaia Spirit&r creates the best Mana Spreader you can get."]
 	quest.4E03AE15BEF86178.quest_desc: [
-		"Vaild Upgrades:"
+		"Valid Upgrades:"
 		"- Mob Scanner"
 		"- Auto Smoker"
 		"- Cauterize Wounds"
@@ -7298,7 +7298,7 @@
 	]
 	quest.504DEE88DFDBD380.quest_subtitle: "Liquidizing your assets"
 	quest.5054977BD5354561.quest_desc: [
-		"Vaild Upgrades:"
+		"Valid Upgrades:"
 		"- Tree Feller"
 		"- Leaf Breaker"
 	]
@@ -8300,7 +8300,7 @@
 	quest.5BB887411B8B38FA.quest_desc: ["As for wirelessly expanding the ME Network itself, the first step is admittedly somewhat unorthodox.\\n\\nThe &bMatter Condenser&f is AE2's take on a trash can, voiding any items inserted into it. When fitted with a &eStorage Component&f, however, the condenser can harness some left-over energy from the item being voided and store it to make two special crafting items out of enough concentrated energy.\\n\\nThe first of these two items is the &bMatter Ball&f, requiring at least a 1k storage component and 256 items' worth of voided material."]
 	quest.5BB887411B8B38FA.title: "Condensed Matter"
 	quest.5BBE8B30ED7518B8.quest_desc: [
-		"Vaild Upgrades:"
+		"Valid Upgrades:"
 		"- Ore Miner"
 		"- Ore Scanner &4&lDISABLED&r&f"
 	]
@@ -9713,7 +9713,7 @@
 	]
 	quest.6A4C49AE72E98727.title: "Tinkering"
 	quest.6A4D31194C4CE156.quest_desc: [
-		"Vaild Upgrades:"
+		"Valid Upgrades:"
 		"- Ore Miner"
 		"- Lawnmower"
 		"- Sky Sweeper"
@@ -10237,7 +10237,7 @@
 	]
 	quest.6FD41DF7704466A4.title: "Clear Skies"
 	quest.6FD4C60B547F4131.quest_desc: [
-		"Vaild Upgrades:"
+		"Valid Upgrades:"
 		"- Ore Miner"
 		"- Ore Scanner &4&lDISABLED&r&f"
 		"- Auto Smelter"
@@ -10270,7 +10270,7 @@
 	]
 	quest.702CE73E39E4D4BD.quest_subtitle: "Things are complicated..."
 	quest.703BDCDC88DD813C.quest_desc: [
-		"Vaild Upgrades:"
+		"Valid Upgrades:"
 		"- Lawnmower"
 		"- Sky Sweeper"
 		"- Auto Smelter"
@@ -11025,7 +11025,7 @@
 	quest.787415570026FFAA.title: "Destructor Upgrade"
 	quest.7878F190BC8ADC82.quest_desc: ["The best of the best. From Diamonds, to the Nether Star, to AllTheModium. This Rod finds only the best Items!"]
 	quest.78840993C7832E89.quest_desc: [
-		"Vaild Upgrades:"
+		"Valid Upgrades:"
 		"- Tree Feller"
 		"- Leaf Breaker"
 		"- Auto Smelter"


### PR DESCRIPTION
The JDT quests have a bunch of spelling errors, such as 'Vaid' or 'Vaild' instead of 'Valid'.