### PR TITLE
ATO Sulfur Block Item Tag

### DIFF
--- a/kubejs/server_scripts/mods/AllTheOres/Tags.js
+++ b/kubejs/server_scripts/mods/AllTheOres/Tags.js
@@ -1,4 +1,11 @@
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
+
 ServerEvents.tags('item', allthemods => {
   allthemods.add('c:dusts', 'alltheores:netherite_dust')
   allthemods.add('c:dusts/netherite', 'alltheores:netherite_dust')
+  allthemods.add('c:storage_blocks/sulfur', 'alltheores:sulfur_block')
 })
+
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.


### PR DESCRIPTION
Adds the `c:storage_blocks/sulfur` item tag to ATO Sulfur Blocks
Adds ARR to the ATO tags file