### PR TITLE
Fixed RailCraft Machine Recipes that use Steel Shovels

### DIFF
--- a/kubejs/server_scripts/Tweaks/recipes.js
+++ b/kubejs/server_scripts/Tweaks/recipes.js
@@ -28,8 +28,7 @@ ServerEvents.recipes(allthemods => {
         }
     )
 
-    // Remove Duplicate Paper Recipe
-    allthemods.remove({ id: 'minecraft:paper' })
+    allthemods.replaceInput({ mod: "railcraft"}, "railcraft:steel_shovel", "mekanismtools:steel_shovel")
 
     // Concrete from Concrete Powder using Water Buckets
     const colors = [
@@ -46,12 +45,11 @@ ServerEvents.recipes(allthemods => {
             }
         )
     });
-    
-    // Remove The Raw Redstone Block Recipe As It Allows A Redstone Dupe
+
+    // Remove Raw Redstone Block Recipe
     allthemods.remove({id: 'regions_unexplored:raw_redstone_block'});
 
-    
-    // Fix dense uraninite ore energizing recipes
+    // Dense Uraninite Ore Energizing Recipes
     allthemods.remove({ id: 'powah:energizing/uraninite_from_ore' })
     allthemods.custom({
         "type": "powah:energizing",


### PR DESCRIPTION
- Changed the recipes for RailCraft machines that use RailCraft Steel Shovels to use Mekanism Steel Shovels.
- Added back alternate paper recipe since the other one has since changed.

Resolves: https://github.com/AllTheMods/ATM-10/issues/1240