### PR TITLE
More mystical agriculture seeds

### DIFF
--- a/config/mysticalcustomization/configure-crops.json
+++ b/config/mysticalcustomization/configure-crops.json
@@ -1,0 +1,7 @@
+{
+  "mysticalagriculture:enderium": {
+  "ingredient": {
+    "tag": "c:ingots/enderium"
+  },
+  "enabled": "true"
+}}

--- a/config/mysticalcustomization/crops/entro.json
+++ b/config/mysticalcustomization/crops/entro.json
@@ -1,0 +1,13 @@
+{
+  "name": "Entro",
+  "type": "mysticalagriculture:resource",
+  "tier": "mysticalagradditions:6",
+  "ingredient": {
+    "item": "allthecompressed:entro_block_1x"
+  },
+  "color": "52DD85",
+  "textures": {
+    "flower": "mysticalagriculture:block/flower_rock",
+    "essence": "mysticalagriculture:item/essence_quartz"
+  }
+}

--- a/config/mysticalcustomization/crops/sky_steel.json
+++ b/config/mysticalcustomization/crops/sky_steel.json
@@ -1,0 +1,13 @@
+{
+  "name": "Sky Steel",
+  "type": "mysticalagriculture:resource",
+  "tier": "mysticalagradditions:6",
+  "ingredient": {
+    "item": "allthecompressed:sky_steel_block_1x"
+  },
+  "color": "2C2E2C",
+  "textures": {
+    "flower": "mysticalagriculture:block/flower_ingot",
+    "essence": "mysticalagriculture:item/essence_ingot"
+  }
+}

--- a/kubejs/server_scripts/mods/MysticalAgriculture/FusionCrafting.js
+++ b/kubejs/server_scripts/mods/MysticalAgriculture/FusionCrafting.js
@@ -15,6 +15,8 @@ ServerEvents.recipes(allthemods => {
     essenceCircle('12x forbidden_arcanus:darkstone', 'darkstone')
     essenceCircle('6x silentgear:azure_silver_ingot', 'azure_silver')
     essenceCircle('6x silentgear:crimson_iron_ingot', 'crimson_iron')
+    essenceCircle('3x extendedae:entro_crystal', 'entro')
+    essenceCircle('2x megacells:sky_steel_ingot', 'sky_steel')
 
     // infusion seed crafting
     function seedCrafting(output, middle, item1, item2, item3, item4, item5, item6, item7, item8){


### PR DESCRIPTION
Enderium: T5 - 8 essence - > 2 ingots
Sky Steel: T6 - 8 essence -> 2 ingots
Entro seeds: T6 - 8 essence -> 3 crystals

Sky Steel and Entro both require 1x compressed blocks for the seeds