### PR TITLE
Fixed entro and sky steel seeds.

### DIFF
--- a/kubejs/server_scripts/mods/MysticalAgriculture/Tags.js
+++ b/kubejs/server_scripts/mods/MysticalAgriculture/Tags.js
@@ -9,7 +9,9 @@ const seedID = [
     'mysticalagriculture:unobtainium_seeds',
     'mysticalagriculture:vibranium_seeds',
     'mysticalagriculture:crimson_iron_seeds',
-    'mysticalagriculture:azure_silver_seeds'
+    'mysticalagriculture:azure_silver_seeds',
+    'mysticalagriculture:entro_seeds',
+    'mysticalagriculture:sky_steel_seeds'
 ]
 
 ServerEvents.tags('item', allthemods => {


### PR DESCRIPTION
The new entro and sky steel seeds were not working with the growth accelerator. Fixed this by adding the new seeds to the seedID array!