### PR TITLE
Update KubeJS code to include crafting recipes to smooth out usability of a few items

### DIFF
--- a/kubejs/server_scripts/mods/Aquaculture_2/tags.js
+++ b/kubejs/server_scripts/mods/Aquaculture_2/tags.js
@@ -1,0 +1,8 @@
+//adds Aquaculture Raw Fish Fillet to the Pam's Harvestcraft recipes
+ServerEvents.tags('item', allthemods => {
+    //Raw Fish Fillet
+    allthemods.add('c:rawfish', 'aquaculture:fish_fillet_raw')
+    allthemods.add('c:rawmeats', 'aquaculture:fish_fillet_raw')
+    allthemods.add('livingthings:penguin_food', 'aquaculture:fish_fillet_raw')
+    allthemods.add('c:stock_ingredients', 'aquaculture:fish_fillet_raw')
+})

--- a/kubejs/server_scripts/mods/Farmer's Delight/tags.js
+++ b/kubejs/server_scripts/mods/Farmer's Delight/tags.js
@@ -3,5 +3,5 @@
 ServerEvents.tags('item', allthemods => {
   //Dough
   allthemods.add('c:dough', 'farmersdelight:wheat_dough')
-  allthemods.add('cdough/dough', 'farmersdelight:wheat_dough')
+  allthemods.add('c:dough/dough', 'farmersdelight:wheat_dough')
 })

--- a/kubejs/server_scripts/mods/Farmer's Delight/tags.js
+++ b/kubejs/server_scripts/mods/Farmer's Delight/tags.js
@@ -1,0 +1,7 @@
+//This file adds the Pam's Dough tags to the Farmer's Delight Dough
+
+ServerEvents.tags('item', allthemods => {
+  //Dough
+  allthemods.add('c:dough', 'farmersdelight:wheat_dough')
+  allthemods.add('cdough/dough', 'farmersdelight:wheat_dough')
+})

--- a/kubejs/server_scripts/mods/Regions Unexplored/Recipes.js
+++ b/kubejs/server_scripts/mods/Regions Unexplored/Recipes.js
@@ -1,0 +1,9 @@
+//This file adds a recipe to craft Redstone from the Pointed Redstone item
+ServerEvents.recipes(allthemods => {
+  allthemods.shapeless(
+    Item.of('minecraft:redstone', 1),
+    [
+      'regions_unexplored:pointed_redstone'
+      ]
+    )
+})

--- a/kubejs/server_scripts/mods/Silent Gear/Recipes.js
+++ b/kubejs/server_scripts/mods/Silent Gear/Recipes.js
@@ -50,7 +50,7 @@ ServerEvents.recipes(allthemods => {
     //Chainmail Boots
     allthemods.custom(
 	    { "type": "silentgear:salvaging",
-		    "ingredient": {"item":"minecraft:chainmail_helmet" },
+		    "ingredient": {"item":"minecraft:chainmail_boots" },
 		    "results": [{"count": 2, "id": "minecraft:iron_nugget" }, {"count":2,"id":"minecraft:iron_ingot"}]
 	    }
     )

--- a/kubejs/server_scripts/mods/Silent Gear/Recipes.js
+++ b/kubejs/server_scripts/mods/Silent Gear/Recipes.js
@@ -25,6 +25,64 @@ ServerEvents.recipes(allthemods => {
             }
         }
     )
+    //adds a chainmail salvage, mirroring the crafting recipe from MineColonies, which uses vanilla Iron items rather than Modern Industrialization Iron Rings
+    //Chainmail Helmet
+    allthemods.custom(
+	    { "type": "silentgear:salvaging",
+		    "ingredient": {"item":"minecraft:chainmail_helmet" },
+		    "results": [{"count": 5, "id": "minecraft:iron_nugget" }, {"count":1,"id":"minecraft:iron_ingot"}]
+	    }
+    )
+    //Chainmail Chestplate
+    allthemods.custom(
+	    { "type": "silentgear:salvaging",
+		    "ingredient": {"item":"minecraft:chainmail_chestplate" },
+		    "results": [{"count": 6, "id": "minecraft:iron_nugget" }, {"count":2,"id":"minecraft:iron_ingot"}]
+	    }
+    )
+    //Chainmail Leggings
+    allthemods.custom(
+	    { "type": "silentgear:salvaging",
+		    "ingredient": {"item":"minecraft:chainmail_leggings" },
+		    "results": [{"count": 4, "id": "minecraft:iron_nugget" }, {"count":3,"id":"minecraft:iron_ingot"}]
+	    }
+    )
+    //Chainmail Boots
+    allthemods.custom(
+	    { "type": "silentgear:salvaging",
+		    "ingredient": {"item":"minecraft:chainmail_helmet" },
+		    "results": [{"count": 2, "id": "minecraft:iron_nugget" }, {"count":2,"id":"minecraft:iron_ingot"}]
+	    }
+    )
+    //Adds Pneumaticraft's Compressed Iron Armor to the Salvager
+    //Compressed Iron Helmet
+    allthemods.custom(
+	    { "type": "silentgear:salvaging",
+		    "ingredient": {"item":"pneumaticcraft:compressed_iron_helmet" },
+		    "results": [{"count": 5, "id": "minecraft:leather" }, {"count":5,"id":"pneumaticcraft:ingot_iron_compressed"}]
+	    }
+    )
+    //Compressed Iron Chestplate
+    allthemods.custom(
+	    { "type": "silentgear:salvaging",
+		    "ingredient": {"item":"pneumaticcraft:compressed_iron_chestplate" },
+		    "results": [{"count": 8, "id": "minecraft:leather" }, {"count":8,"id":"pneumaticcraft:ingot_iron_compressed"}]
+	    }
+    )
+    //Compressed Iron Leggings
+    allthemods.custom(
+	    { "type": "silentgear:salvaging",
+		    "ingredient": {"item":"pneumaticcraft:compressed_iron_leggings" },
+		    "results": [{"count": 7, "id": "minecraft:leather" }, {"count":7,"id":"pneumaticcraft:ingot_iron_compressed"}]
+	    }
+    )
+    //Compressed Iron Boots
+    allthemods.custom(
+	    { "type": "silentgear:salvaging",
+		    "ingredient": {"item":"pneumaticcraft:compressed_iron_boots" },
+		    "results": [{"count": 4, "id": "minecraft:leather" }, {"count":4,"id":"pneumaticcraft:ingot_iron_compressed"}]
+	    }
+    )
 	//adds Everything is Copper gear to the Salvager
 	//Copper Pickaxe
     allthemods.custom(

--- a/kubejs/server_scripts/mods/Silent Gear/Recipes.js
+++ b/kubejs/server_scripts/mods/Silent Gear/Recipes.js
@@ -25,6 +25,84 @@ ServerEvents.recipes(allthemods => {
             }
         }
     )
+	//adds Everything is Copper gear to the Salvager
+	//Copper Pickaxe
+    allthemods.custom(
+	    {
+		    "type": "silentgear:salvaging",
+		    "ingredient": {
+			    "item": "everythingcopper:copper_pickaxe" },
+		    "results": [
+			    { "count": 3,
+			      "id": "minecraft:copper_ingot" },
+			    { "count": 2,
+			      "id": "minecraft:stick" }
+		    ]
+	    }
+    )
+	//Copper Horse Armor
+    allthemods.custom(
+	    { "type": "silentgear:salvaging",
+		    "ingredient": { "item": "everythingcopper:copper_horse_armor" },
+		    "results": [{"count": 6, "id": "minecraft:copper_ingot" }, {"count": 1, "id": "minecraft:leather"}]
+	    }
+    )
+	//Copper Sword
+    allthemods.custom(
+	    { "type": "silentgear:salvaging",
+		    "ingredient": { "item": "everythingcopper:copper_sword" },
+		    "results": [{"count": 2, "id": "minecraft:copper_ingot" }, {"count": 1, "id": "minecraft:stick" }]
+	    }
+    )
+	//Copper Axe
+    allthemods.custom(
+	    { "type": "silentgear:salvaging",
+		    "ingredient": { "item": "everythingcopper:copper_axe" },
+		    "results": [{"count": 3, "id": "minecraft:copper_ingot" }, {"count": 2, "id": "minecraft:stick" }]
+	    }
+    )
+    //Copper Helmet
+    allthemods.custom(
+	    { "type": "silentgear:salvaging",
+		    "ingredient": {"item":"everythingcopper:copper_helmet" },
+		    "results": [{"count": 5, "id": "minecraft:copper_ingot" }]
+	    }
+    )
+	//Copper Chestplate
+    allthemods.custom(
+	    { "type": "silentgear:salvaging",
+		    "ingredient": {"item":"everythingcopper:copper_chestplate" },
+		    "results": [{"count": 8, "id": "minecraft:copper_ingot" }]
+	    }
+    )
+	//Copper Leggings
+    allthemods.custom(
+	    { "type": "silentgear:salvaging",
+		    "ingredient": {"item":"everythingcopper:copper_leggings" },
+		    "results": [{"count":7, "id": "minecraft:copper_ingot" }]
+	    }
+    )
+    //Copper Boots
+    allthemods.custom(
+	    { "type": "silentgear:salvaging",
+		    "ingredient": {"item":"everythingcopper:copper_boots" },
+		    "results": [{"count":4, "id": "minecraft:copper_ingot" }]
+	    }
+    )
+    //Copper Hoe
+    allthemods.custom(
+	    { "type": "silentgear:salvaging",
+		    "ingredient": {"item":"everythingcopper:copper_hoe" },
+		    "results": [{"count":2, "id": "minecraft:copper_ingot" }, {"count":2,"id":"minecraft:stick"}]
+	    }
+    )
+    //Copper Shovel
+    allthemods.custom(
+	    { "type": "silentgear:salvaging",
+		    "ingredient": {"item":"everythingcopper:copper_shovel" },
+		    "results": [{"count":1, "id": "minecraft:copper_ingot" }, {"count":2,"id":"minecraft:stick"}]
+	    }
+    )
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.


### PR DESCRIPTION
Adds the Aquaculture 2 Raw Fish Fillet to Pam's Harvestcraft as a valid rawfish / rawmeat item for it's recipes. Went this route rather than the original "fish" items because it's faster.