### PR TITLE
Add menril logs to FTB ultimine tags

### DIFF
--- a/defaultconfigs/ftbultimine/ftbultimine-server.snbt
+++ b/defaultconfigs/ftbultimine/ftbultimine-server.snbt
@@ -11,6 +11,7 @@
 			"c:*_ores"
 			"c:ores/*"
 			"forge:ores/*"
+			"integrateddynamics:menril_logs"
 		]
 	}
 }


### PR DESCRIPTION
Allows ultimining the whole menril tree without the menace of those special logs getting in the way. Change is to default config, and will usually only appear after serverconfig gets refreshed.
Requested in https://github.com/AllTheMods/ATM-10/issues/1304
Tested in ATM10 version 2.9