### PR TITLE
Disable fireproof boats mod custom lava render

### DIFF
--- a/config/fireproofboats-client.toml
+++ b/config/fireproofboats-client.toml
@@ -1,0 +1,3 @@
+[Client]
+	#Changes the rendertype for lava to fix lava being visible inside boats. This is a potential performance hit and it's recommended to turn of on low end systems.
+	changeLavaRenderType = true

--- a/config/fireproofboats-client.toml
+++ b/config/fireproofboats-client.toml
@@ -1,3 +1,3 @@
 [Client]
 	#Changes the rendertype for lava to fix lava being visible inside boats. This is a potential performance hit and it's recommended to turn of on low end systems.
-	changeLavaRenderType = true
+	changeLavaRenderType = false


### PR DESCRIPTION
Disables lava rendering from fireproof boats to restore the behavior intended from shaders. See https://github.com/AllTheMods/ATM-10/issues/1530 Cons of this change: Lava from wave effects will be visible inside the fireproof boats (i am unable to get these boats in survival anyway so no big loss i guess)