### PR TITLE
Add tooltips to easy villagers trader and auto trader

### DIFF
--- a/kubejs/client_scripts/tooltips.js
+++ b/kubejs/client_scripts/tooltips.js
@@ -161,6 +161,11 @@ ItemEvents.modifyTooltips(allthemods => {
         Text.of("§7Check your Keybinds for \"Open Belt Slot Inventory\"")
     ])
 
+	//Easy Villagers
+    allthemods.add(['easy_villagers:trader', 'easy_villagers:auto_trader'], [
+        Text.of("§aRight click with job site block to put it inside and allow trade restocking")
+    ])
+
 })
 
 


### PR DESCRIPTION
As requested by a user in https://github.com/AllTheMods/ATM-10/issues/1527
In JEI these blocks will now have this tooltip added
![image](https://github.com/user-attachments/assets/b8dec71f-1546-4db1-abe1-87fe1b09eab1)
