### PR TITLE
Fix quest description of 148A33CC36B2563A / "Draconic Endshelf" in "Apothic Enchanting" questline

### DIFF
--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -1991,7 +1991,7 @@
 	]
 	quest.1482F2D45E8F761D.quest_subtitle: "Casings and Glass"
 	quest.1482F2D45E8F761D.title: "Fission Reactor Building Basics"
-	quest.148A33CC36B2563A.quest_desc: ["The &dDraconic Shelf&r is the last Shelf we'll need for perfect set up. It might only give &aEterna&r but it has a Max &aEterna&r of &a100&r."]
+	quest.148A33CC36B2563A.quest_desc: ["The &dDraconic Endshelf&r is the last Shelf we'll need for perfect set up. It might only give &aEterna&r but it has a Max &aEterna&r of &a100&r."]
 	quest.148A33CC36B2563A.title: "&5Draconic Endshelf"
 	quest.149BD1A9F82FA19A.quest_subtitle: "&f6 &cAttack Damage"
 	quest.149C260C10B34BB0.quest_subtitle: "5/5"

--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -1991,7 +1991,7 @@
 	]
 	quest.1482F2D45E8F761D.quest_subtitle: "Casings and Glass"
 	quest.1482F2D45E8F761D.title: "Fission Reactor Building Basics"
-	quest.148A33CC36B2563A.quest_desc: ["The &dDraconic Shelf&r is the last Shelf we'll need for perfect set up. It might only give &aEterna&r but it has the Max Max &aEterna&r of &a100&r."]
+	quest.148A33CC36B2563A.quest_desc: ["The &dDraconic Shelf&r is the last Shelf we'll need for perfect set up. It might only give &aEterna&r but it has a Max &aEterna&r of &a100&r."]
 	quest.148A33CC36B2563A.title: "&5Draconic Endshelf"
 	quest.149BD1A9F82FA19A.quest_subtitle: "&f6 &cAttack Damage"
 	quest.149C260C10B34BB0.quest_subtitle: "5/5"


### PR DESCRIPTION
PR #1651 also fixes the "Draconic *End*shelf" description, but this PR also corrects it being incorrectly called "Draconic Shelf".
Secondly, this PR also fixes the word "the" being used instead of "a".