### PR TITLE
Fixed bug #1794 to allow modded planks in crafting table recipe

### DIFF
--- a/kubejs/server_scripts/Tweaks/recipes.js
+++ b/kubejs/server_scripts/Tweaks/recipes.js
@@ -80,6 +80,12 @@ ServerEvents.recipes(allthemods => {
         ]
     )
 
+    // Allow modded planks in the crafting table recipe.
+    allthemods.replaceInput(
+        { input: '#minecraft:vanilla_planks', output: 'minecraft:crafting_table' },
+        '#minecraft:vanilla_planks',
+        '#minecraft:planks'
+    )
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.


### PR DESCRIPTION
Updated recipes.js to replace the crafting table recipe with a recipe that allows more plank types.