### PR TITLE
Fix quest book spelling and grammar

### DIFF
--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -34,7 +34,7 @@
 	chapter.4B9D26E0087CD163.title: "Basic Tools"
 	chapter.4C507C004144BFEE.title: "Occultism"
 	chapter.4EAAE0CEB26378A6.title: "Just Dire Things"
-	chapter.4EBB2171D5A3AAAC.title: "Forbidden \\& Arcanus"
+	chapter.4EBB2171D5A3AAAC.title: "Forbidden and Arcanus"
 	chapter.5103E2D95685ADFF.title: "&aChapter 3&r: &6The ATM Star"
 	chapter.5712300EF4E5E846.title: "Pylons"
 	chapter.59395B6806F2A98A.title: "Cataclysm"
@@ -234,8 +234,8 @@
 	]
 	quest.020E6AF37A0421C8.title: "Water Tank"
 	quest.02190383FEE793ED.quest_desc: ["All that is left to do is use a &eChemical Reaction&r to pull the Chlorine off the Iridium!"]
-	quest.022C38096F79EF07.quest_desc: ["&6&lForbidden Arcanus&r is all about using the Arcane to do rituals with the Forge to become stronger! \\n\\nOr what most know it for, Eternal Stella. There's more to the Mod you know! "]
-	quest.022C38096F79EF07.title: "&6&lForbidden Arcanus"
+	quest.022C38096F79EF07.quest_desc: ["&6&lForbidden and Arcanus&r is all about using the Arcane to do rituals with the Forge to become stronger! \\n\\nOr what most know it for, Eternal Stella. There's more to the Mod you know! "]
+	quest.022C38096F79EF07.title: "&6&lForbidden and Arcanus"
 	quest.0251FD45582C3164.quest_subtitle: "Don't sniff this"
 	quest.0253D241383EC848.quest_desc: ["Raiden is a Fictional Character in the Mortal Kombat Fightin.... Oh wait... It said Radon, not Raiden..."]
 	quest.0253D241383EC848.quest_subtitle: "Raiden"
@@ -791,7 +791,7 @@
 	quest.07AD45DCF9EE3C2E.quest_subtitle: "Upgrading to Factories"
 	quest.07BEB974DF1E5AD3.quest_desc: ["Makes Energy at the same rate as an &aEmerald Generator&r but has a much higher Transfer Rate. Also arguably cheaper as it takes less items but that item is also &5Netherite&r so..."]
 	quest.07BEB974DF1E5AD3.title: "&5Netherite Generator"
-	quest.07BEE6FEC14765DC.quest_desc: ["Pretty simple recipe needing Clay, Iron, Slimeballs, and more... \\n\\nLodestones are best to loot for, Mods add these in Loot Pools all over &c&lThe Nether&r so don't craft one just find one! \\n\\nWax is a new Item added by &6&lForbidden \\& Arcanus&r which is a mix of Bottle of Honey and Slimeballs! \\n\\nYou can use it on a &6Darkstone Pedestal&r to get &7Magnetized Pedestals&r which work in hand with Hoppers (and Hopper like Items like Pipes). \\n\\nYou can also use it with Boots to increase how close Items can be to get dragged into your Inventory!"]
+	quest.07BEE6FEC14765DC.quest_desc: ["Pretty simple recipe needing Clay, Iron, Slimeballs, and more... \\n\\nLodestones are best to loot for, Mods add these in Loot Pools all over &c&lThe Nether&r so don't craft one just find one! \\n\\nWax is a new Item added by &6&lForbidden and Arcanus&r which is a mix of Bottle of Honey and Slimeballs! \\n\\nYou can use it on a &6Darkstone Pedestal&r to get &7Magnetized Pedestals&r which work in hand with Hoppers (and Hopper like Items like Pipes). \\n\\nYou can also use it with Boots to increase how close Items can be to get dragged into your Inventory!"]
 	quest.07CC809B6482AB09.quest_subtitle: "Tier: &a2"
 	quest.07E750F8184C4362.quest_desc: [
 		"&eChemical React&r Hydrogen with Fluorine Gas to make this"
@@ -889,8 +889,8 @@
 	quest.0923C941A9696122.quest_desc: ["Incase you have to bring 256 Million Items on an Adventure with you!"]
 	quest.09282E3864752CEE.quest_subtitle: "Tier: &63"
 	quest.092A23FDA5D50812.quest_subtitle: "Tier: &a2"
-	quest.092BB595F75D5536.quest_desc: ["Welcome to &6&lForbidden \\& Arcanus&r! \\n\\nTo start this Mod we'll need to start Mining underground... deep underground. \\n\\nLike Y Level 1 and below. "]
-	quest.092BB595F75D5536.title: "&6&lForbidden \\& Arcanus"
+	quest.092BB595F75D5536.quest_desc: ["Welcome to &6&lForbidden and Arcanus&r! \\n\\nTo start this Mod we'll need to start Mining underground... deep underground. \\n\\nLike Y Level 1 and below. "]
+	quest.092BB595F75D5536.title: "&6&lForbidden and Arcanus"
 	quest.09408C6DCAC90318.quest_desc: ["This block stores power, and can also be used to charge items."]
 	quest.09408C6DCAC90318.quest_subtitle: "Storing Power"
 	quest.0947B4ED95B0267E.quest_desc: ["Coats an items and tools.\\n\\nNetherite makes a great coating material."]
@@ -2373,7 +2373,7 @@
 	quest.184F98BE0F6710E2.title: "&cTrack Kits&r for using Redstone"
 	quest.185074907753AE77.quest_desc: ["If you are using Routers I hope you have some game knowledge. \\n\\nJust incase, to void an Item means to delete it. \\n\\nAny items that come into the Router, will be deleted forever! \\n\\nRecommend using Filters with this one..."]
 	quest.185DBBDD252CBA0C.quest_desc: [
-		"The &6&lForge&r is the most important Block in &6&lForbidden \\& Arcanus&r! Now that you made the Multiblock you can break the &6&lForge&r block and move it, even though it only works while on the Mutliblock. \\n\\nYou'll need to fill it with all 4 Essences: &bAureal&r, Souls, &4Blood&r, and &aExperience&r! \\n\\nThen, put in Relics if necessary. \\n\\nAfter that, put the center Item in the Recipe, in the middle Slot of the &6&lForge&r, and the outer Items on the &6Pedestals&r."
+		"The &6&lForge&r is the most important Block in &6&lForbidden and Arcanus&r! Now that you made the Multiblock you can break the &6&lForge&r block and move it, even though it only works while on the Mutliblock. \\n\\nYou'll need to fill it with all 4 Essences: &bAureal&r, Souls, &4Blood&r, and &aExperience&r! \\n\\nThen, put in Relics if necessary. \\n\\nAfter that, put the center Item in the Recipe, in the middle Slot of the &6&lForge&r, and the outer Items on the &6Pedestals&r."
 		"{image:atm:textures/questpics/forbidden/forbidden_gui.png width:135 height:100 align:center}"
 		"{image:atm:textures/questpics/forbidden/forbidden_tier3.png width:100 height:100 align:center}"
 	]
@@ -3320,7 +3320,7 @@
 	quest.230463E830D6FFEB.quest_desc: ["Now that we have plastic, the next step is getting some finished PCBs, first make some &3Empty PCBs&r in the Pressure Chamber."]
 	quest.230463E830D6FFEB.quest_subtitle: "The path to PCBs"
 	quest.230582AAFC0A1632.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks.\\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission.\\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
-	quest.230EEE4671B46D0C.quest_desc: ["&9Darkstone&r appears deep underground near Lava Lakes, like at Y Level -54. \\n\\nIt is the most used Block for &6&lForbidden \\& Arcanus&r, all Multiblocks will use them for their base. \\nMake sure to grab a ton of them!"]
+	quest.230EEE4671B46D0C.quest_desc: ["&9Darkstone&r appears deep underground near Lava Lakes, like at Y Level -54. \\n\\nIt is the most used Block for &6&lForbidden and Arcanus&r, all Multiblocks will use them for their base. \\nMake sure to grab a ton of them!"]
 	quest.230EEE4671B46D0C.title: "&9Darkstone"
 	quest.23254CE8487D2E68.quest_desc: ["The &8Wither Builder&r is one of the greatest Machines you can get from &lIndustrial Foregoing&r, and because of that it's expensive. \\n\\nFirst you will need the parts that make a &8Wither&r and a drop from the &8Wither&r. \\n\\nThen, you'll need a &6Supreme Machine Frame&r which you need &bEther Gas&r to make. Guess what you need for &bEther Gas&r? That's right! A &8Wither&r! You'll need a Laser Drill working on a &8Wither&r to get it. \\n\\n&8Withers&r like to leave and kill things so a Stasis Chamber would make milking them easier! "]
 	quest.23254CE8487D2E68.title: "&8Wither Builder"
@@ -3873,7 +3873,7 @@
 	quest.29283BF1B6ED3634.quest_desc: ["The Mechanical Crossbow is made like a normal Crossbow just with Golem Steel. \\n\\nIt works like a normal Crossbow just much stronger! And can be enchanted to do even more!"]
 	quest.29417616D8F673D5.quest_desc: ["Moving forward a lot of mixed metals and alloys will need to be made in the ABS. As Fluids they are then pushed through a Vacuum Freezer with an Ingot Mold to make the ingots. The Multiblock Structures referenced in the following quests all have support blocks which utilize metals which need the ABS to be made. Making at least 1 Alloy Blast Smelter now will be beneficial."]
 	quest.29417616D8F673D5.quest_subtitle: "Anti-Lock Braking System is a Go!"
-	quest.29434DB0CC2E30E6.quest_desc: ["Combining &cMundabitur Dust&r, &bArcane Crystal Dust&r, &8Charcoal&r, and a &eGold Ingot&r we'll get our first Alloy! The &6Deorum Ingot&r! \\n\\nThis is the foundational Ingot of &6&lForbidden \\& Arcanus&r, you will need dozens of it! \\n\\nIt is especially used for Building Blocks for our Multiblock Machines."]
+	quest.29434DB0CC2E30E6.quest_desc: ["Combining &cMundabitur Dust&r, &bArcane Crystal Dust&r, &8Charcoal&r, and a &eGold Ingot&r we'll get our first Alloy! The &6Deorum Ingot&r! \\n\\nThis is the foundational Ingot of &6&lForbidden and Arcanus&r, you will need dozens of it! \\n\\nIt is especially used for Building Blocks for our Multiblock Machines."]
 	quest.29434DB0CC2E30E6.title: "&6Deorum"
 	quest.2943989C642F93AE.quest_desc: ["Finally! We now have a crafting recipe that gives us 2 LuV processors for 1 Craft! Lets Gooo!"]
 	quest.29448D08C8777425.quest_desc: ["By tonight he'll be sleeping with the Fishes. \\n\\nThe &cAngler Hat&r helps you Lure Fish in and makes your chances at getting a Rare Drop higher!"]
@@ -5023,7 +5023,7 @@
 	quest.354086C858E10154.title: "Reprocessing our Waste"
 	quest.355244420EA47546.quest_desc: ["Fabricator is the Auto-Crafter. It will take items from the inventory below and make a set recipe.\\n\\nYou can lock recipes with CTRL Click. It will need to pipe out the created items though."]
 	quest.355244420EA47546.quest_subtitle: "Auto-Crafter"
-	quest.356102D5B5F3CA1E.quest_desc: ["An Alloy added by &6&lForbidden \\& Arcanus&r is &5Obsidiansteel&r. \\n\\nIt's created in the &l&bClibano&r, by combining Raw Iron and &5Obsidian&r. \\n\\nYou'll need an Artisan Relic in order to actually make the Alloy! \\n\\nAlso you'll get &6Copper&r as residue, which probably isn't supposed to happen..."]
+	quest.356102D5B5F3CA1E.quest_desc: ["An Alloy added by &6&lForbidden and Arcanus&r is &5Obsidiansteel&r. \\n\\nIt's created in the &l&bClibano&r, by combining Raw Iron and &5Obsidian&r. \\n\\nYou'll need an Artisan Relic in order to actually make the Alloy! \\n\\nAlso you'll get &6Copper&r as residue, which probably isn't supposed to happen..."]
 	quest.356102D5B5F3CA1E.title: "&5Obsidiansteel&r"
 	quest.356F450F4ADD22D7.title: "2 Dimensional Storage Actuator"
 	quest.358706CA93DC2A9C.quest_desc: ["Cook the dust up in the &aEBF&r and cool it down in the &eChemical Bath&r"]
@@ -8442,7 +8442,7 @@
 		"I gotta go tell Master Splinter about this one..."
 	]
 	quest.57F6323716A0ED24.quest_subtitle: "TMNT"
-	quest.580148D1141446A6.quest_desc: ["&c&lNether&r too scary for you? Then, you can look for Souls in the &2&lOverworld&r! \\n\\nWithin your World (I made you go to Dark Forests because old &l&6Forbidden \\& Arcanus&r used to have Blocks there) you might find some Lost Souls wandering around. \\n\\nYou can kill them for the Souls that they drop! It is much less efficient though..."]
+	quest.580148D1141446A6.quest_desc: ["&c&lNether&r too scary for you? Then, you can look for Souls in the &2&lOverworld&r! \\n\\nWithin your World (I made you go to Dark Forests because old &l&6Forbidden and Arcanus&r used to have Blocks there) you might find some Lost Souls wandering around. \\n\\nYou can kill them for the Souls that they drop! It is much less efficient though..."]
 	quest.580148D1141446A6.title: "Lost Souls"
 	quest.58095E9EBC6FF9B2.title: "Creative Power"
 	quest.5820EDEF71340A1A.quest_desc: [
@@ -8674,7 +8674,7 @@
 	quest.5A6670364ADE0858.quest_subtitle: "&f29 &cAttack Damage"
 	quest.5A6831E0BD2F6AB5.quest_desc: ["You'll need a lotta &8Dark Gems&r!"]
 	quest.5A6831E0BD2F6AB5.title: "2 &4Piercing Vengeance Focuses"
-	quest.5A6FF0D4BA894306.quest_desc: ["The poster child of &6&lForbidden \\& Arcanus&r, the &aEternal Stella&r. \\n\\nFor 1 &6Allthemodium&r Ingot, 3 &aXpetrified Orbs&r, and a &2Stellarite Piece&r we can make one of the most overpowered Items in this Modpack! \\n\\nYou can use the &aEternal Stella&r with an Item and an Apply Item Modifier to make Items lose their Durability. No, wait I mean lose their need for Durability! Basically Indestructible Items. \\n\\nThis can be used on almost every Item with Durability from &bDiamond Axes&r, to Fishing Rods, to even &eRefined Glowstone Armor&r! \\n\\nThere are some limitations, it only works with Items with Durability not uses: like Infusion Crystals or Energy: like Meka-Tool!"]
+	quest.5A6FF0D4BA894306.quest_desc: ["The poster child of &6&lForbidden and Arcanus&r, the &aEternal Stella&r. \\n\\nFor 1 &6Allthemodium&r Ingot, 3 &aXpetrified Orbs&r, and a &2Stellarite Piece&r we can make one of the most overpowered Items in this Modpack! \\n\\nYou can use the &aEternal Stella&r with an Item and an Apply Item Modifier to make Items lose their Durability. No, wait I mean lose their need for Durability! Basically Indestructible Items. \\n\\nThis can be used on almost every Item with Durability from &bDiamond Axes&r, to Fishing Rods, to even &eRefined Glowstone Armor&r! \\n\\nThere are some limitations, it only works with Items with Durability not uses: like Infusion Crystals or Energy: like Meka-Tool!"]
 	quest.5A6FF0D4BA894306.title: "&aEternal Stella"
 	quest.5A7FF6D0AED656DC.quest_desc: ["Decreases the amount of time that it takes for a Mana Burst to start losing its Mana, but will also decrease its rate of loss."]
 	quest.5A84A64CB3D3E6F5.quest_subtitle: "White Willow + Oak/Birch/Silver Lime"
@@ -9829,7 +9829,7 @@
 		"You can find all of the descriptions within the &aLexica Botania&r."
 	]
 	quest.66F1609053B5407C.title: "&aGaia Gear and Trinkets&r"
-	quest.66FE4552E09B5EFF.quest_desc: ["Prisms are important for many of &6&lForbidden \\& Arcanus&r recipes and other Mods later! \\n\\nIn order to craft them we'll need &3Elementarium&r, which is found in Jungle Temples, Desert Pyramids, and Underwater Ruins. \\n\\nI think it would be easier to tell us where you can't find it!"]
+	quest.66FE4552E09B5EFF.quest_desc: ["Prisms are important for many of &6&lForbidden and Arcanus&r recipes and other Mods later! \\n\\nIn order to craft them we'll need &3Elementarium&r, which is found in Jungle Temples, Desert Pyramids, and Underwater Ruins. \\n\\nI think it would be easier to tell us where you can't find it!"]
 	quest.66FE4552E09B5EFF.title: "&3Elementarium"
 	quest.6718043D0F2D1830.quest_desc: ["DireWolf was asked to make an addition of his Cards to work with &5&lMekanism&r and its... other states of matter. Everything Pressurized Tubes can move, these cards can. Gas, Infuse Types, and Pigments."]
 	quest.6718043D0F2D1830.title: "&5Chemical Card"
@@ -10313,7 +10313,7 @@
 	quest.6B747129A85AA768.quest_desc: ["Now even more like the Absorption Hopper! \\n\\nVacuum Module will now pickup XP Orbs as well as Items. Whatever you do with the XP is up to you!"]
 	quest.6B78378BC8036227.title: "Tier 1 Grader Catalyst"
 	quest.6BA2BC09E23B34A9.quest_desc: [
-		"This one needs another &9Chiseled Polished Darkstone&r, just now with 4 &7Runes&r and 4 &2Stellarite&r Pieces. \\n\\nThis &6&lForge&r is the last for the basic &6&lForbidden \\& Arcanus&r. \\n\\nOf course it has the rest of the Recipes plus every space for Relics is open now!"
+		"This one needs another &9Chiseled Polished Darkstone&r, just now with 4 &7Runes&r and 4 &2Stellarite&r Pieces. \\n\\nThis &6&lForge&r is the last for the basic &6&lForbidden and Arcanus&r. \\n\\nOf course it has the rest of the Recipes plus every space for Relics is open now!"
 		"{image:atm:textures/questpics/forbidden/forbidden_tier4.png width:100 height:100 align:center}"
 	]
 	quest.6BA2BC09E23B34A9.title: "&l&dTier 4 &6Forge"

--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -520,7 +520,7 @@
 	]
 	quest.050D8480EE9D8E62.title: "Wigglewood Forest"
 	quest.0515422E36E4E9A3.quest_desc: ["Grants invisibility when sneaking."]
-	quest.0518551637F76C50.quest_desc: ["A little expensive but the &9Echoing Deep Shelf&r is like a much better &bSeashelf&r. (BTW you'll need to kill quite a few wardens to advance more in Enchanting... should a warned you earlier). Also increases Max &aEterna&r to &a75&r."]
+	quest.0518551637F76C50.quest_desc: ["A little expensive but the &9Echoing Deepshelf&r is like a much better &bSeashelf&r. (BTW you'll need to kill quite a few wardens to advance more in Enchanting... should've warned you earlier). Also increases Max &aEterna&r to &a75&r."]
 	quest.0518551637F76C50.title: "&9Echoing Deepshelf"
 	quest.051E0C85E7B71CE0.quest_desc: ["I'm going to assume you've been out mining, right? It is MINEcraft after all.\\n\\nYou'll find a ton of new ores that might confuse you, but you can stick to the vanilla materials to get you started!\\n\\nCopper is abundant and has plenty of uses for things like &aOre Hammers&r or &eDrawer Upgrades&r, so make sure to grab plenty of it!\\n\\nIron is probably one of the most important ores you'll want to get every time you run into it. The world of modded MC pretty much runs on Iron."]
 	quest.051E0C85E7B71CE0.title: "The &9Metal&r Age"
@@ -2001,7 +2001,7 @@
 	]
 	quest.1482F2D45E8F761D.quest_subtitle: "Casings and Glass"
 	quest.1482F2D45E8F761D.title: "Fission Reactor Building Basics"
-	quest.148A33CC36B2563A.quest_desc: ["The &dDraconic Shelf&r is the last Shelf we'll need for perfect set up. It might only give &aEterna&r but it has the Max Max &aEterna&r of &a100&r."]
+	quest.148A33CC36B2563A.quest_desc: ["The &dDraconic Endshelf&r is the last Shelf we'll need for perfect set up. It might only give &aEterna&r but it has the Max Max &aEterna&r of &a100&r."]
 	quest.148A33CC36B2563A.title: "&5Draconic Endshelf"
 	quest.149BD1A9F82FA19A.quest_subtitle: "&f6 &cAttack Damage"
 	quest.149C260C10B34BB0.quest_subtitle: "5/5"
@@ -2386,7 +2386,7 @@
 	quest.186826F12973BA28.quest_desc: ["Around twice as fast as the Bronze Macerator. One of the most important machines during this age since you'll need such a huge amount of ores. You'll want a few of these so you can process large quantities of ores."]
 	quest.187281092C0BC9CE.quest_desc: ["Wafers and Silicon Boules need to be cut. This cutter, paired with the Engraving Laser will make sure we keep our stock of Chips up!"]
 	quest.187281092C0BC9CE.quest_subtitle: "Waffles and Boules"
-	quest.1873205CF5247E3E.quest_desc: ["The last sets of Shelves you'll need are &dEndshelves&r, to get them you need Infused Dragon's Breath. This one was hard to get but you need atleast &a80 Eterna&r, &c15%-30% Quanta&r, and atleast &560% Arcana&r. It has to be between &c15%-25% Quanta&r to get that you can try &910 Echoing Skulkshelves&r and &29 Melonshelves &ror &92 Echoing Skulkshelves&r and &b4 Heart-Forged Seashelves&r."]
+	quest.1873205CF5247E3E.quest_desc: ["The last sets of Shelves you'll need are &dEndshelves&r, to get them you need Infused Dragon's Breath. This one was hard to get but you need atleast &a80 Eterna&r, &c15%-30% Quanta&r, and atleast &560% Arcana&r. It has to be between &c15%-25% Quanta&r to get that you can try &910 Echoing Sculkshelves&r and &29 Melonshelves &ror &92 Echoing Sculkshelves&r and &b4 Heart-Forged Seashelves&r."]
 	quest.1873205CF5247E3E.title: "&5Endshelf"
 	quest.187816477B732517.quest_desc: ["The &3Transfer Gadget&r acts like a Hopper that can be placed inbetween blocks."]
 	quest.187816477B732517.quest_subtitle: "Smaller Hopper"
@@ -3201,7 +3201,7 @@
 	quest.21D323D95F5A7DB3.title: "Strong Stick"
 	quest.21EA29A8C7F950CE.quest_desc: ["&bDiamonds&r the staple of &2Minecraft&r, and of upgraded Furnaces apparently...\\n \\nThese work even faster only taking 80 Ticks or 4 Seconds to smelt items. That's even faster than a Blast Furnace! \\n \\nThese are only crafted by &eGold Furnaces&r and can be crafted into &3Crystal&r or &aEmerald Furnaces&r."]
 	quest.21EA29A8C7F950CE.title: "&bDiamond Furnace"
-	quest.21EE522DDBF0BF72.quest_desc: ["The last sets of Shelves you'll need are &dEndshelves&r, to get them you need Infused Dragon's Breath. This one was hard to get but you need atleast &a40%% Eterna&r, &c15%%-25%% Quanta&r, and atleast &560%% Arcana&r. It has to be between &c15%%-25%% Quanta&r to get that you can try &99 Echoing Skulkshelves&r and 4 Melonshelves or &92 Echoing Skulkshelves&r and &b10 Heart-Forged Seashelves&r."]
+	quest.21EE522DDBF0BF72.quest_desc: ["The last sets of Shelves you'll need are &dEndshelves&r, to get them you need Infused Dragon's Breath. This one was hard to get but you need atleast &a40%% Eterna&r, &c15%%-25%% Quanta&r, and atleast &560%% Arcana&r. It has to be between &c15%%-25%% Quanta&r to get that you can try &99 Echoing Skclkshelves&r and 4 Melonshelves or &92 Echoing Sculkshelves&r and &b10 Heart-Forged Seashelves&r."]
 	quest.21EE522DDBF0BF72.title: "&dEndshelf&r"
 	quest.21F4CFF171246537.quest_subtitle: "Tier: &b4"
 	quest.21F5EED683499B71.quest_desc: [
@@ -3294,7 +3294,7 @@
 	quest.22D2CFDDB06C720C.quest_desc: ["Tools are very important in &2&lMinecraft&r but so is inventory space. So why not clear some space up by making a Paxel! \\nPaxels are a combination of Pickaxes (P), Axes (axe), and Shovels (els). \\n\\nThey can strip wood, make paths, and mine any blocks that same pickaxe/axe/shovel tier can!"]
 	quest.22D2CFDDB06C720C.title: "Paxel"
 	quest.22D716F330A6D4CE.quest_desc: [
-		"You might want to fight the &dEnder Dragon&r a few more times.... "
+		"You might want to fight the &dEnder Dragon&r a few more times.. .. "
 		""
 		"You'll need a few &dDragon Eggs&r and several other items like &dDragon Scales&r to make the &6Star&r! "
 		""
@@ -3521,7 +3521,7 @@
 	quest.24BD32102AFA1691.quest_desc: ["An upgraded crafter that holds more patterns and has an increased crafting speed."]
 	quest.24BD32102AFA1691.title: "&5Netherite Crafter&r"
 	quest.24C0F267B330CD23.quest_desc: ["With the damage of a Diamond Sword, the &2Terra Blade&r will sometimes fire a beam that will deal as much as a melee hit would."]
-	quest.24C757B8AA6841F6.quest_desc: ["Apothic Spawners knows how annoying Tridents can be to get so they made it easier... well kinda easier. You can now make an Inert Trident and Infuse it to get a normal Trident. The Trident requires between &a40 Eterna&r, &c20%-50% Quanta&r, and atleast &535% Arcana&r. You can get this with &94 Echoing Skulkshelves&r, &2Melonshelf &rand Normal Bookshelf."]
+	quest.24C757B8AA6841F6.quest_desc: ["Apothic Spawners knows how annoying Tridents can be to get so they made it easier... well kinda easier. You can now make an Inert Trident and Infuse it to get a normal Trident. The Trident requires between &a40 Eterna&r, &c20%-50% Quanta&r, and atleast &535% Arcana&r. You can get this with &94 Echoing Sculkshelves&r, &2Melonshelf &rand Normal Bookshelf."]
 	quest.24C757B8AA6841F6.title: "Making a real Trident"
 	quest.24C9BA6DC32CFAD9.quest_desc: ["Coal is your first real source of power. If you are running low and cant find any Coal a better alternative for you will be Charcoal. "]
 	quest.24C9BA6DC32CFAD9.quest_subtitle: "Smelt your logs"
@@ -11678,7 +11678,7 @@
 		"You will still need to be under the effects of the &3Third Eye&r to be able to harvest the Otherworld block."
 	]
 	quest.78ECC28DD4BA9696.title: "Hunting For &dOtherworld&r Materials"
-	quest.78FEDE6FA4845585.quest_desc: ["Some infusions need very very exact amounts of &aEterna&r, &cQuanta&r, or &5Arcana&r to get these you might need one of these shelves. Each lowers the amount of its respective amounts."]
+	quest.78FEDE6FA4845585.quest_desc: ["Some infusions need very, very exact amounts of &aEterna&r, &cQuanta&r, or &5Arcana&r. To get these, you might need one of these shelves. Each lowers the amount of its respective amounts."]
 	quest.78FEDE6FA4845585.title: "&cNegative amounts"
 	quest.790EC3EDC2DB1FB0.quest_desc: ["Like it was mentioned before. This mod adds a ton of fun ways to generate power that require specific builds."]
 	quest.790EC3EDC2DB1FB0.title: "Generators Galore"

--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -2099,7 +2099,7 @@
 	quest.158F48B73171BDE1.title: "Metal Tools"
 	quest.1591013DDD4766E1.quest_desc: ["&l&cCooking for Blockheads&r is all about making the Kitchen your home. \\n\\nI recommend using everything it gives as every Item has a use and looks amazing!"]
 	quest.1591013DDD4766E1.title: "&l&cCooking for Blockheads&r"
-	quest.15978093237448FE.quest_desc: ["Why upgrade &cNetherite&r to &6AllTheModium&r or even anything else when we can upgrade it to &3Warden Armor&r! \\n\\nYou'll need a few Warden Drops in order to make it though!"]
+	quest.15978093237448FE.quest_desc: ["Why upgrade &cNetherite&r to &6Allthemodium&r or even anything else when we can upgrade it to &3Warden Armor&r! \\n\\nYou'll need a few Warden Drops in order to make it though!"]
 	quest.15978093237448FE.quest_subtitle: "24"
 	quest.15978093237448FE.title: "&3Warden Armor"
 	quest.15A1D6D05A785919.quest_desc: ["Did you know that NOR logic gates can be used to make every other logic gate? That's why we use it so much for making circuits!"]
@@ -2963,7 +2963,7 @@
 		""
 		"Tip: In the Mining Dimension, this ore is a lot more common."
 	]
-	quest.1FD4C32B3937E1C7.title: "AllTheModium Ore"
+	quest.1FD4C32B3937E1C7.title: "Allthemodium Ore"
 	quest.1FD60B7448CED1EB.quest_desc: ["This &b&lMacaw&r Mod adds new types of Fences, Gates, and Walls. \\n\\nYes, the barbed wire will hurt you. \\n\\nNo, you can't jump over any of them normally."]
 	quest.1FD60B7448CED1EB.title: "&b&lMacaw's Fences and Walls"
 	quest.1FDC8725105D822A.quest_desc: ["The Kitchen holds many Blocks that can hold, preserve, and Cook Food! \\n\\nMost the Blocks that cook or prepare Food do need Energy, so check out the Electrical Set to learn more!"]
@@ -3021,7 +3021,7 @@
 		"At least we can get our Naquadah Coils going now, and help our EBF's to process more metals!"
 	]
 	quest.2036ED4A823C1456.quest_subtitle: "We're going to need more Naq"
-	quest.203C91B992BA8CF9.quest_desc: ["In order to remake the &6&lATM Star&r we'll need an Infused &dPatrick &aStar&r, which also needs a &dPatrick &aStar&r for it. Both are made via &6&lRunic Star Altar&r. \\n\\nThe other items needed to make Infused &dPatrick &aStar&r are the 4 &5Mending Books&r and &dInfused Dragon's Breath&r which are obtained through &5&lRunic Enchanting&r. \\n\\n&6Star Shards&r which we get from our Bees! \\n\\nAnd Alloy Ingots: &3Vibranium&f-&6AllTheModium&r, &5Unobtainium&f-&6AllTheModium&r, and &5Unobtainium&f-&3Vibranium&r Ingots. \\n\\nAll three are crafted in their own unique ways described in the &6&lAllTheModium&r chapter! \\n\\nThrow all of these into a &6&lRunic Star Altar&r, plus 85MFE, and we'll get our Infused &dPatrick &aStar&r!"]
+	quest.203C91B992BA8CF9.quest_desc: ["In order to remake the &6&lATM Star&r we'll need an Infused &dPatrick &aStar&r, which also needs a &dPatrick &aStar&r for it. Both are made via &6&lRunic Star Altar&r. \\n\\nThe other items needed to make Infused &dPatrick &aStar&r are the 4 &5Mending Books&r and &dInfused Dragon's Breath&r which are obtained through &5&lRunic Enchanting&r. \\n\\n&6Star Shards&r which we get from our Bees! \\n\\nAnd Alloy Ingots: &3Vibranium&f-&6Allthemodium&r, &5Unobtainium&f-&6Allthemodium&r, and &5Unobtainium&f-&3Vibranium&r Ingots. \\n\\nAll three are crafted in their own unique ways described in the &6&lAllthemodium&r chapter! \\n\\nThrow all of these into a &6&lRunic Star Altar&r, plus 85MFE, and we'll get our Infused &dPatrick &aStar&r!"]
 	quest.203C91B992BA8CF9.title: "Infused &dPatrick &aStar"
 	quest.20436AFCC7E6855D.quest_desc: ["With Magic Beans and Uberous Soil, you'll want to look for a large cloud in the highland biomes.\\n\\nPlant the magic beans in the soil to grow a beanstalk all the way up. Here, you'll find the Giants.\\n\\nYou'll need to kill the Miner Giant and get their pickaxe to continue on."]
 	quest.20436AFCC7E6855D.quest_subtitle: "The giants look like me, but are nothing LIKE me"
@@ -3264,9 +3264,9 @@
 	]
 	quest.229455730219F7B1.quest_subtitle: "Red Iron"
 	quest.229455730219F7B1.title: "&cVentium"
-	quest.2296CE4418AE62D4.quest_desc: ["&6AllTheModium Armor&r but with buffs to &d&lArs Nouveau&r Spells!"]
+	quest.2296CE4418AE62D4.quest_desc: ["&6Allthemodium Armor&r but with buffs to &d&lArs Nouveau&r Spells!"]
 	quest.2296CE4418AE62D4.quest_subtitle: "24"
-	quest.2296CE4418AE62D4.title: "&6AllTheModium Arcanist Gear"
+	quest.2296CE4418AE62D4.title: "&6Allthemodium Arcanist Gear"
 	quest.22A0A9C81A5C85A1.quest_subtitle: "Holding everything together"
 	quest.22A1C68078EFB38B.quest_subtitle: "Amplifies Potion Effect"
 	quest.22AC248B6BB88486.quest_desc: [
@@ -3413,7 +3413,7 @@
 	]
 	quest.23ADD20D9B1AE0F3.quest_desc: ["Use a &bPure Daisy&r to convert Stone into Livingrock!"]
 	quest.23ADD20D9B1AE0F3.title: "&7Livingrock"
-	quest.23AE395433AED3C0.quest_desc: ["The &6&lATM Star&r needs a few Blocks to hold together the different Items, and make its star shape! \\n\\nThe first Blocks are &5Unobtainium&r-&6AllTheModium&r &5Alloy&r &6Blocks&r. You need to use an Enchanting Apparatus from &d&lArs Nouveau&r to make them! To make 28 to be exact. \\n\\nFor 17 X3 Netherstar Blocks you'll need 111,537 Netherstars. (Please I am begging you use &l&bHNN&r just don't spawn and kill 111,537, please!)"]
+	quest.23AE395433AED3C0.quest_desc: ["The &6&lATM Star&r needs a few Blocks to hold together the different Items, and make its star shape! \\n\\nThe first Blocks are &5Unobtainium&r-&6Allthemodium&r &5Alloy&r &6Blocks&r. You need to use an Enchanting Apparatus from &d&lArs Nouveau&r to make them! To make 28 to be exact. \\n\\nFor 17 X3 Netherstar Blocks you'll need 111,537 Netherstars. (Please I am begging you use &l&bHNN&r just don't spawn and kill 111,537, please!)"]
 	quest.23AE395433AED3C0.title: "&6&lThe Star's&r Casing"
 	quest.23B55A8C7D6482FF.quest_desc: [
 		"Grab your tools and open up the maintenance hatch, there are problems to fix!"
@@ -4168,7 +4168,7 @@
 	quest.2BEBF66D7EA594FA.title: "&2Steeleaf Armor"
 	quest.2BF119DD5D977409.title: "Tier 2 Starlight Charger Catalyst"
 	quest.2BF9B347D1FC037A.quest_desc: ["This can be found by &2brushing&r &aSuspicious Clay&r in the &dAncient City&r."]
-	quest.2BF9B347D1FC037A.title: "&6AllTheModium Upgrades&r"
+	quest.2BF9B347D1FC037A.title: "&6Allthemodium Upgrades&r"
 	quest.2C04B3BA507D5673.quest_desc: ["&bPatterns&f are what hold an encoded recipe to be fulfilled by a Pattern Provider. To encode a recipe onto a Pattern, the &bME Pattern Encoding Terminal&f must be used.\\n\\nPatterns can be set to hold either a regular &ecrafting&f recipe, which will require the use of a &eMolecular Assembler&f on the face of its Provider, or a more general '&eprocessing&f' recipe, wherein any input items can be sent out by the provider into some other machine block or specialised processing plant."]
 	quest.2C04B3BA507D5673.title: "Patterns"
 	quest.2C28217E1131A63A.quest_desc: [
@@ -4261,7 +4261,7 @@
 	quest.2CCFEE98FE3B2E97.title: "Blocks"
 	quest.2CD58FC229BC0C28.quest_desc: ["The Gauntlet of Guard is more of a tool than a weapon, it brings in mobs closer when you hold right click with it. Then you can smack the enemies with it to do a bit of damage."]
 	quest.2CD58FC229BC0C28.title: "Gauntlet of Guard"
-	quest.2CECCA9D05D3EF12.quest_desc: ["The &2Eternal Stella&r is quite expensive. You'll need a Tier 3 Forge first! \\n\\nThen, you'll need &7Stellarite Piece&r which you can mine for. And you have to get 3 &aXpetried Orbs&r which you can no longer mine for. Instead you'll have to feed a Black Hole &aEXP&r to get it! \\n\\nFinally, you'll need an &6AllTheModium Ingot&r to get the &2Eternal Stella&r. It makes sense why it is so expensive as it can be combined with any Tool to make it Invincibile!"]
+	quest.2CECCA9D05D3EF12.quest_desc: ["The &2Eternal Stella&r is quite expensive. You'll need a Tier 3 Forge first! \\n\\nThen, you'll need &7Stellarite Piece&r which you can mine for. And you have to get 3 &aXpetried Orbs&r which you can no longer mine for. Instead you'll have to feed a Black Hole &aEXP&r to get it! \\n\\nFinally, you'll need an &6Allthemodium Ingot&r to get the &2Eternal Stella&r. It makes sense why it is so expensive as it can be combined with any Tool to make it Invincibile!"]
 	quest.2CECCA9D05D3EF12.title: "&2Eternal Stella"
 	quest.2CF11A70229000AB.title: "Getting Create-ive."
 	quest.2CF6EA138B53CE1B.quest_desc: ["&3Vibranium&r combined with &5Unobtainium&r!"]
@@ -4316,7 +4316,7 @@
 	quest.2DA8CE213AC3869B.quest_desc: ["Starlight Crystals can be found all over and even under the Crystallized Deserts. \\n\\nThey work similar to Amethyst and even sound like it!"]
 	quest.2DB53A77C3CD90F1.quest_desc: ["The Botanist's Pickaxe turns blocks that it interacts with into their mossy variants, assuming they have one."]
 	quest.2DB53A77C3CD90F1.quest_subtitle: "Tier: &b3"
-	quest.2DB81CE6F647D08A.title: "Unobtainium-AllTheModium Alloy"
+	quest.2DB81CE6F647D08A.title: "Unobtainium-Allthemodium Alloy"
 	quest.2DC639C39AE90272.quest_subtitle: "Yellow Meranti + Rose Gum"
 	quest.2DD5F0693780B10A.quest_desc: ["Used with the Extruder MK2, blocks extruded will mimic the actual blocks. Redstone Blocks will emit Redstone, Glowstone will emit light, Grass will act transparent. But only with this Augment! \\nDoesn't work with Block Entities like Furnaces or Enrichment Chambers."]
 	quest.2DDA04088C8220D2.quest_desc: ["Prosperity Shards are a core crafting ingrediant in the mod. To find some, go mining."]
@@ -4769,7 +4769,7 @@
 		"If you want to build the Crusher, navigate to the &aHeavy Machinery&r section in your &eEngineer's Manual&r to learn how to build the multiblock!"
 	]
 	quest.323F39FC300F7E30.title: "Coke Dust"
-	quest.32543DA54C684E4E.quest_desc: ["&cModularium&r, the aptly named, Ingot is what we'll need for getting into &c&lModular Machinery&r. \\n\\nYou'll need a &9&lTier 5 &6Forge&r along with an &6Artisan Relic&r and &3Elementarium&r and Items. These Items being 4 &6Deorum Ingots&r, 4 End Steel Ingots, and an &6AllTheModium Ingot&r! \\n\\nCombine these all together with the needed Essences and you'll get 24 &cModularium Ingots&r"]
+	quest.32543DA54C684E4E.quest_desc: ["&cModularium&r, the aptly named, Ingot is what we'll need for getting into &c&lModular Machinery&r. \\n\\nYou'll need a &9&lTier 5 &6Forge&r along with an &6Artisan Relic&r and &3Elementarium&r and Items. These Items being 4 &6Deorum Ingots&r, 4 End Steel Ingots, and an &6Allthemodium Ingot&r! \\n\\nCombine these all together with the needed Essences and you'll get 24 &cModularium Ingots&r"]
 	quest.32543DA54C684E4E.title: "Building block of &l&cModulary Machinery"
 	quest.325483DEB0C602F8.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks. \\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission. \\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
 	quest.3260EDAD3A619479.quest_desc: ["&5Aethersent Ore&r is found during Meteorite Showers in &5&lEternal Starlight&r. Small ones break on impact, you'll need to wait for big Meteors! \\n\\nOr is it Meteorites? What's the difference?"]
@@ -5279,7 +5279,7 @@
 		"{image:atm:textures/questpics/undergarden/undergarden_rotwalker.png width:100 height:200 align:center}"
 	]
 	quest.380D3212D1CBA593.title: "&cRotwalker&r"
-	quest.38135FFD9ED64395.title: "Vibranium-AllTheModium Alloy"
+	quest.38135FFD9ED64395.title: "Vibranium-Allthemodium Alloy"
 	quest.3813F5C1760C3A79.quest_desc: ["Piglin Brutes being here might cause controversey but I consider them Minibosses. \\n\\nThey spawn in Bastions with regular Piglins but these are Hostile not Neutral. Personally I hate that, especially since if you hit them all Piglins will turn Hostile on you. \\n\\nThey have 50 Hearts and a Golden Axe to hit you. Usually Golden Axes barely do any damage, but when they use it, it is god somehow! \\n\\nThey drop nothing and act more like an obstacle for Bastions!"]
 	quest.3813F5C1760C3A79.title: "Kill A Piglin Brute"
 	quest.38451B61E3FC075B.quest_desc: [
@@ -5600,7 +5600,7 @@
 	]
 	quest.3BDB94F17765EE77.quest_subtitle: "More Power Than You'll Need"
 	quest.3BDB94F17765EE77.title: "End Game Power Options"
-	quest.3BE5CD0C7CC4BCC6.quest_desc: ["Soul Lava is a part of &6&lAllTheModium&r. It can be found in &b&lThe Other&r very rarely underground, or common in Piglich Villages!\\n\\nWe'll need to feed a Bucket of &9Soul Lava&r to a Ghostly Bee to make a &9Soul Lava Bee&r.\\n\\nThen, you'll need to squish them or poke them for it's DNA to make a Spawn Egg!  "]
+	quest.3BE5CD0C7CC4BCC6.quest_desc: ["Soul Lava is a part of &6&lAllthemodium&r. It can be found in &b&lThe Other&r very rarely underground, or common in Piglich Villages!\\n\\nWe'll need to feed a Bucket of &9Soul Lava&r to a Ghostly Bee to make a &9Soul Lava Bee&r.\\n\\nThen, you'll need to squish them or poke them for it's DNA to make a Spawn Egg!  "]
 	quest.3BE5CD0C7CC4BCC6.title: "&9Soul Lava Bee&r Spawn Egg"
 	quest.3BEDF19CD79D53D5.quest_desc: [
 		"The &aDistillation Tower&r serves as the foundation for &dOil Processing&r which can turn oil into many more useful forms"
@@ -5639,7 +5639,7 @@
 		""
 		"To get to the &5Beyond&r, use the Teleport Pad in the End."
 	]
-	quest.3C322474D2F2BA99.title: "AllTheModium Dimensions"
+	quest.3C322474D2F2BA99.title: "Allthemodium Dimensions"
 	quest.3C3FE45CEF5E242B.quest_desc: ["While the other &aReprocessor Parts&r have a mandatory spot when building, these three parts can be placed on any vertical face as long as they aren't on the frame!\\n\\nThe &cPower Port&r is used to give power to the multiblock machine to process waste.\\n\\nThe &9Fluid Injector Port&r is used to inject the liquid needed, which will depend on the type of waste injected. For Cyanite, that means water!\\n\\nThe &aOutput Port&r is used to output the reprocessed material. You can right click it to grab the material out by hand, or pipe it out for automation."]
 	quest.3C413D4A210A3BDE.title: "Honey Bee"
 	quest.3C49F2EEDCCAF1DF.quest_desc: [
@@ -7123,7 +7123,7 @@
 		"- Extinguish"
 		"- Elytra"
 	]
-	quest.4B2146C9527C54E7.quest_desc: ["Obviously now that you are in Chapter 2, you have beaten &2&lVanilla Minecraft&r! \\n\\nBy now you should have &5Netherite&r and have killed all the bosses &2&lMinecraft&r has. So what's next? \\n\\n&6&lAllTheModium&r is what's next! In order to start getting &6AllTheModium&r though you will need &5Netherite&r. Let's start there!"]
+	quest.4B2146C9527C54E7.quest_desc: ["Obviously now that you are in Chapter 2, you have beaten &2&lVanilla Minecraft&r! \\n\\nBy now you should have &5Netherite&r and have killed all the bosses &2&lMinecraft&r has. So what's next? \\n\\n&6&lAllthemodium&r is what's next! In order to start getting &6Allthemodium&r though you will need &5Netherite&r. Let's start there!"]
 	quest.4B2146C9527C54E7.title: "&6&lAllthemodium"
 	quest.4B3F20E5C7E3BCFB.quest_desc: ["Primal Coal is a new material added by JDT. Primal Coal is aquired by performing Goo Spread on Coal Blocks using tier one goo or higher. Primal Coal Ore is affected by fortune."]
 	quest.4B4F5341D6DBDD19.quest_desc: ["Keep your breathing underwater, once your bubbles go down to 5 they will be refilled! It also allows you to see much more easily underwater!"]
@@ -8674,7 +8674,7 @@
 	quest.5A6670364ADE0858.quest_subtitle: "&f29 &cAttack Damage"
 	quest.5A6831E0BD2F6AB5.quest_desc: ["You'll need a lotta &8Dark Gems&r!"]
 	quest.5A6831E0BD2F6AB5.title: "2 &4Piercing Vengeance Focuses"
-	quest.5A6FF0D4BA894306.quest_desc: ["The poster child of &6&lForbidden \\& Arcanus&r, the &aEternal Stella&r. \\n\\nFor 1 &6AllTheModium&r Ingot, 3 &aXpetrified Orbs&r, and a &2Stellarite Piece&r we can make one of the most overpowered Items in this Modpack! \\n\\nYou can use the &aEternal Stella&r with an Item and an Apply Item Modifier to make Items lose their Durability. No, wait I mean lose their need for Durability! Basically Indestructible Items. \\n\\nThis can be used on almost every Item with Durability from &bDiamond Axes&r, to Fishing Rods, to even &eRefined Glowstone Armor&r! \\n\\nThere are some limitations, it only works with Items with Durability not uses: like Infusion Crystals or Energy: like Meka-Tool!"]
+	quest.5A6FF0D4BA894306.quest_desc: ["The poster child of &6&lForbidden \\& Arcanus&r, the &aEternal Stella&r. \\n\\nFor 1 &6Allthemodium&r Ingot, 3 &aXpetrified Orbs&r, and a &2Stellarite Piece&r we can make one of the most overpowered Items in this Modpack! \\n\\nYou can use the &aEternal Stella&r with an Item and an Apply Item Modifier to make Items lose their Durability. No, wait I mean lose their need for Durability! Basically Indestructible Items. \\n\\nThis can be used on almost every Item with Durability from &bDiamond Axes&r, to Fishing Rods, to even &eRefined Glowstone Armor&r! \\n\\nThere are some limitations, it only works with Items with Durability not uses: like Infusion Crystals or Energy: like Meka-Tool!"]
 	quest.5A6FF0D4BA894306.title: "&aEternal Stella"
 	quest.5A7FF6D0AED656DC.quest_desc: ["Decreases the amount of time that it takes for a Mana Burst to start losing its Mana, but will also decrease its rate of loss."]
 	quest.5A84A64CB3D3E6F5.quest_subtitle: "White Willow + Oak/Birch/Silver Lime"
@@ -8763,9 +8763,9 @@
 	quest.5B95C5B5B3A9CB2E.title: "&dLoot Chests&r"
 	quest.5B9F933ECD6B24FD.quest_desc: ["Allows you to jump higher than with Tier II."]
 	quest.5B9F933ECD6B24FD.quest_subtitle: "Max: 1"
-	quest.5BA84F6282D9CAF1.quest_desc: ["&6AllTheModium Armor&r but with buffs to &e&lIron's Spells&r Spells!"]
+	quest.5BA84F6282D9CAF1.quest_desc: ["&6Allthemodium Armor&r but with buffs to &e&lIron's Spells&r Spells!"]
 	quest.5BA84F6282D9CAF1.quest_subtitle: "24"
-	quest.5BA84F6282D9CAF1.title: "&6AllTheModium Mage Outfit"
+	quest.5BA84F6282D9CAF1.title: "&6Allthemodium Mage Outfit"
 	quest.5BA986D7928BF09F.quest_desc: ["The Piglich is a Boss added by &6&lAllthemodium&r. \\n\\nHas he 1000 Hearts and currently has no attacks but trust me when he does they will be devastating! \\n\\nWhen killed he'll drop his Heart which will be needed for Alloys and the ATM Star! \\n\\n(Look into ways of farming them like with HNN or EnderIO!)"]
 	quest.5BA986D7928BF09F.title: "Piglich Boss"
 	quest.5BB7648DC10E1E08.quest_desc: ["Has 27 more filter slots and is 6x faster than the regular Exporter. Also has the Stack Upgrade integrated."]
@@ -9042,7 +9042,7 @@
 	quest.5E799B92358A8732.quest_desc: ["In the &cNether&r, you'll run into &6Ancient Debris&r. This can be smelted down into Scraps that can be combined with Gold to create &6Netherite Ingots&r, which is an endgame metal use to craft some of the strongest tools and armor in the game."]
 	quest.5E799B92358A8732.title: "&dAncient Metals"
 	quest.5E7CCDE9229A646A.quest_desc: ["{image:atm:textures/questpics/basicarmor/armor_allthemodium.png width:100 height:150 align:center}"]
-	quest.5E7CCDE9229A646A.title: "&6AllTheModium&r"
+	quest.5E7CCDE9229A646A.title: "&6Allthemodium&r"
 	quest.5E7E35CCAF1C88EE.quest_desc: ["The &bME Import Bus&f periodically sucks items in from whatever external storage the bus is facing. It can optionally be filtered to only take in certain items from said inventory."]
 	quest.5E7E35CCAF1C88EE.quest_subtitle: "The I"
 	quest.5E90EF7FF530C477.quest_desc: [
@@ -10384,9 +10384,9 @@
 		"This ones a funny one; you can either find it, craft it, or trade for it.\\n\\nThen you can dye it whatever color you want and of course wear it on your Head!\\n\\nThe &6B&8e&6e&8s&r will then think that you are a Flower and will follow you.\\n\\nIt also makes you look like Daffy from \"Duck Amuck\"."
 		"{image:atm:textures/questpics/bumblezone/bumble_duckamuck.png width:100 height:100 align:center}"
 	]
-	quest.6C5F9D0D447EFB9C.quest_desc: ["What you think &l&2Vanilla&r was all we got? \\n\\n&6AllTheModium Armor&r has more Armor Points and Armor Toughness, plus increased Protection against Magic and other buffs you can read about in &6&lAllTheModium&r Quest Page! \\n\\nBTW you will need &cNetherite&r to craft it."]
+	quest.6C5F9D0D447EFB9C.quest_desc: ["What you think &l&2Vanilla&r was all we got? \\n\\n&6Allthemodium Armor&r has more Armor Points and Armor Toughness, plus increased Protection against Magic and other buffs you can read about in &6&lAllthemodium&r Quest Page! \\n\\nBTW you will need &cNetherite&r to craft it."]
 	quest.6C5F9D0D447EFB9C.quest_subtitle: "24"
-	quest.6C5F9D0D447EFB9C.title: "&6AllTheModium Armor"
+	quest.6C5F9D0D447EFB9C.title: "&6Allthemodium Armor"
 	quest.6C6F4EB5CBE2FBC2.quest_desc: ["The Iron Divination Rod is a slight bit higher, being able to find Ores that an Iron Pickaxe can mine! So Diamonds, Redstone, and Gold."]
 	quest.6C706326381CE611.title: "Creative Pressure"
 	quest.6C76AB8A6110C0C7.quest_desc: ["The &4Blazing Hellshelf&r is an upgrade to the &4Infused Hellshelf&r. It increases max &aEterna&r to &a30&r. The negative Enchanting Clue makes it a little worse for normal Enchanting, instead we can use it for better Infusion."]
@@ -10708,7 +10708,7 @@
 	quest.6F709652A2B88C78.quest_desc: ["The energy transmitter provides power to blocks within it's working range, it can only accept power from the bottom."]
 	quest.6F71FD826C29C31A.quest_desc: ["This one might be new to ones returning from earlier versions. By using a turtle egg on a spawner, it will only spawn in baby versions of the mobs in it. This only works with Vanilla baby versions of mobs, not modded."]
 	quest.6F71FD826C29C31A.title: "Youthful"
-	quest.6F76DA3BBAE8337B.quest_desc: ["The greatest Armor we can get from &6&lAllTheModium&r, &5Unobtainium&r! \\n\\nNow with 100% Knockback Resistance and higher stats everywhere! \\n\\nAlso needs &3Vibranium Armor&r to make it."]
+	quest.6F76DA3BBAE8337B.quest_desc: ["The greatest Armor we can get from &6&lAllthemodium&r, &5Unobtainium&r! \\n\\nNow with 100% Knockback Resistance and higher stats everywhere! \\n\\nAlso needs &3Vibranium Armor&r to make it."]
 	quest.6F76DA3BBAE8337B.quest_subtitle: "40"
 	quest.6F76DA3BBAE8337B.title: "&5Unobtainium Armor"
 	quest.6F7AC41B703028CC.quest_subtitle: "Silver + Copper"
@@ -11109,7 +11109,7 @@
 	quest.72DB967E59EEA729.title: "&3&lGlassential&r"
 	quest.72DC025BC059DF96.quest_desc: ["Mixing &6Nitric Acid&r with &cSulfuric Acid&r makes a &eNitration Mixture&r"]
 	quest.72DCE154E1714890.quest_desc: ["The &n&5Saw&r will harvest trees in front of it. It can also be used as a Sawmill. If it has a connected inventory, the items will be stored in it."]
-	quest.72DDA413D73E3235.quest_desc: ["Much higher stats in everything with the next in line for &6&lAllTheModium&r Armors, &3Vibranium&r! \\n\\nYou will need &6AllTheModium Armor&r to create it."]
+	quest.72DDA413D73E3235.quest_desc: ["Much higher stats in everything with the next in line for &6&lAllthemodium&r Armors, &3Vibranium&r! \\n\\nYou will need &6Allthemodium Armor&r to create it."]
 	quest.72DDA413D73E3235.quest_subtitle: "32"
 	quest.72DDA413D73E3235.title: "&3Vibranium Armor"
 	quest.72DEF9BA758BCDC0.quest_desc: ["Once the ritual has started you will notice the Lake being made. It will grow to about a 20x20 block area full of murky water. The Murky Water will not kill you unless you forget to go for air."]
@@ -11452,7 +11452,7 @@
 	quest.7666D2DA3D0C3F00.quest_desc: ["The ZPM Mixer is needed to craft the Uranium Rhodium Dinaquadide that we need for our Fusion Reactor Mk.II."]
 	quest.7666D2DA3D0C3F00.quest_subtitle: "Mixin' it up!"
 	quest.766C80E5D7B7A916.quest_subtitle: "Pick one!"
-	quest.766EEB89C6DF3575.quest_desc: ["Eternal Stella can be used to either make an Item Unbreakable by combining it with the Item in a Smithing Table. Or you can use it to craft Alloy Tools! \\n\\nFirst, you'll need a Tier 3 Forge with plenty Materials in it. \\n\\nThen, you'll need 3 Xpetrified Orbs. Which you need to feed a Black Hole Items to get. \\n\\nPlus, a Stellarite Piece which you need to Mine for! And &6AllTheModium Ingot&r which is the same."]
+	quest.766EEB89C6DF3575.quest_desc: ["Eternal Stella can be used to either make an Item Unbreakable by combining it with the Item in a Smithing Table. Or you can use it to craft Alloy Tools! \\n\\nFirst, you'll need a Tier 3 Forge with plenty Materials in it. \\n\\nThen, you'll need 3 Xpetrified Orbs. Which you need to feed a Black Hole Items to get. \\n\\nPlus, a Stellarite Piece which you need to Mine for! And &6Allthemodium Ingot&r which is the same."]
 	quest.7671AFAA1EFD287F.quest_desc: ["You want to slowly automate &bAureal&r for your &6&lForge&r? Then, you'll need 2 &bArcane Crystal Blocks&r, &6Arcane Polished Darkstone&r, and &cMundabitur Dust&r! \\n\\nPlace down the &6Arcane Polished Darkstone&r, then on top of it place both &bArcane Crystal Blocks&r. \\n\\nOnce you get this 1x3x1 Structure, Right Click it with &cMundabitur Dust&r to make the &bObelisk&r! \\n\\nYou can place these, where the Pedestals usually go, in the &6&lForge Multiblock&r in order to automate &bAureal&r!"]
 	quest.7671AFAA1EFD287F.title: "&bArcane Crystal Obelisk"
 	quest.7678B5DD1339833E.quest_desc: ["The Solar Panel generates FE when given direct access to the sun. However, you can use a &7Lens of Ender&r to ignore blocks in its way."]
@@ -11596,7 +11596,7 @@
 		"Wondering why you would use this? Imagine having a Builder or Quarry pump Silk-Touched Ores into your system. You can have a Constructor place these ores, then a Destructor with Fortune on it to break it for even more raw ores."
 	]
 	quest.787415570026FFAA.title: "Destructor Upgrade"
-	quest.7878F190BC8ADC82.quest_desc: ["The best of the best. From Diamonds, to the Nether Star, to AllTheModium. This Rod finds only the best Items!"]
+	quest.7878F190BC8ADC82.quest_desc: ["The best of the best. From Diamonds, to the Nether Star, to Allthemodium. This Rod finds only the best Items!"]
 	quest.78840993C7832E89.quest_desc: [
 		"Valid Upgrades:"
 		"- Tree Feller"
@@ -12302,7 +12302,7 @@
 	quest.7F2D696AC9F4C4E4.quest_desc: ["'&bMirror Mirror&r on the wall how do I get back to my Respawn Point from my travels?' \\n \\n'After setting the &bMagic Mirror&r to a Bed by right clicking with it, you can hold right click for the &bMagic Mirror&r to teleport you back to your bed!' \\n \\n'Thank you &bMirror&r!'"]
 	quest.7F2D696AC9F4C4E4.quest_subtitle: "Found in Mineshafts or Strongholds"
 	quest.7F2D696AC9F4C4E4.title: "&bMagic Mirror"
-	quest.7F3B96033AB7A21E.title: "AllTheModium Apple"
+	quest.7F3B96033AB7A21E.title: "Allthemodium Apple"
 	quest.7F4963FCAE5337EC.quest_desc: ["Because just fighting the &bIgnis&r isn't hard enough, you'll have to fight the &bIgnited Revenant&r first to get Burning Ashes. Once you have them use them on the Altar of Fire to summon the &bIgnis&r."]
 	quest.7F4963FCAE5337EC.quest_subtitle: "Relighting the Ignis"
 	quest.7F4963FCAE5337EC.title: "Burning Ashes"
@@ -12358,7 +12358,7 @@
 	quest.7FA79ED5DABCF998.quest_subtitle: "Mix it up!"
 	quest.7FA85713C86166DA.quest_desc: ["Allows you to access your fluid grid wirelessly."]
 	quest.7FA85713C86166DA.title: "Wireless Fluid Grid"
-	quest.7FABB77A60E7962C.quest_desc: ["By infusing Obsidian with &bDiamonds&r we can get Refined Obsidian Dust! \\n\\nThen, we can compress &7Osmium&r into it to get it in Ingot form. \\n\\nAfter that, we can turn those Ingots into Armor with better stats than even &6AllTheModium Armor&r!"]
+	quest.7FABB77A60E7962C.quest_desc: ["By infusing Obsidian with &bDiamonds&r we can get Refined Obsidian Dust! \\n\\nThen, we can compress &7Osmium&r into it to get it in Ingot form. \\n\\nAfter that, we can turn those Ingots into Armor with better stats than even &6Allthemodium Armor&r!"]
 	quest.7FABB77A60E7962C.quest_subtitle: "31"
 	quest.7FABB77A60E7962C.title: "&5Refined Obsidian Armor"
 	quest.7FB12EC3A5888123.quest_desc: ["The &3Tube Junction&r gives you more control over the transportation of your pressure by allowing you to move your Pressure Tubes in more directions."]


### PR DESCRIPTION
- Reimplement grammar and spelling fixes in Apothic Enchanting quests from #1651 that at some point got overwritten and add new fixes
- Fix Allthemodium (official capitalization) incorrectly being capitalized as AllTheModium in quest descriptions
- Fix Forbidden and Arcanus (official mod name) being incorrectly referenced in the quest book with "&" instead of "and" or as Forbidden Arcanus