### PR TITLE
Recipe fixes

### DIFF
--- a/config/almostunified/unification/materials.json
+++ b/config/almostunified/unification/materials.json
@@ -50,7 +50,8 @@
   ],
   "ignored_tags": [],
   "ignored_items": [
-    "pneumaticcraft:plastic"
+    "pneumaticcraft:plastic",
+    "regions_unexplored:raw_redstone_block"
   ],
   "ignored_recipe_types": [
     "cucumber:shaped_tag"

--- a/config/mysticalcustomization/crops/black_quartz.json
+++ b/config/mysticalcustomization/crops/black_quartz.json
@@ -1,0 +1,13 @@
+{
+  "name": "Black Quartz",
+  "type": "mysticalagriculture:resource",
+  "tier": "mysticalagriculture:3",
+  "ingredient": {
+    "tag": "c:gems/black_quartz"
+  },
+  "color": "1C1C1C",
+  "textures": {
+    "flower": "mysticalagriculture:block/flower_rock",
+    "essence": "mysticalagriculture:item/essence_quartz"
+  }
+}

--- a/kubejs/data/immersiveengineering/recipe/arc_recycling_list.json
+++ b/kubejs/data/immersiveengineering/recipe/arc_recycling_list.json
@@ -1,0 +1,4 @@
+{
+  "replace":true,
+  "values":[]
+}

--- a/kubejs/data/pamhc2trees/loot_table/blocks/pamavocado.json
+++ b/kubejs/data/pamhc2trees/loot_table/blocks/pamavocado.json
@@ -1,0 +1,47 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "pamhc2trees:pamavocado"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "tag": "c:tools/shear"
+          }
+        },
+        {
+          "condition": "minecraft:block_state_property",
+          "block": "pamhc2trees:pamavocado",
+          "properties": {
+            "age": "0"
+          }
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "pamhc2trees:avocadoitem"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:block_state_property",
+          "block": "pamhc2trees:pamavocado",
+          "properties": {
+            "age": "7"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/kubejs/data/sushigocrafting/recipe/fermenting_barrel/soy.json
+++ b/kubejs/data/sushigocrafting/recipe/fermenting_barrel/soy.json
@@ -1,0 +1,4 @@
+{
+  "replace":true,
+  "values":[]
+}

--- a/kubejs/server_scripts/Tweaks/recipes.js
+++ b/kubejs/server_scripts/Tweaks/recipes.js
@@ -80,6 +80,23 @@ ServerEvents.recipes(allthemods => {
         ]
     )
     allthemods.shaped("minecraft:crafting_table", ['XX','XX'], {X: "#minecraft:planks"}).id("minecraft:crafting_table")
+
+    //soy sauce from unified tag
+    allthemods.custom({
+        type: "sushigocrafting:fermenting_barrel",
+        fluid: {
+            amount: 250,
+            id: "minecraft:water"
+        },
+        input: {
+            tag: "c:crops/soybean"
+        },
+        output: {
+            count: 1,
+            id: "sushigocrafting:soy_sauce"
+        }
+    })
+
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.

--- a/kubejs/server_scripts/mods/Immersive Engineering/Compatibility.js
+++ b/kubejs/server_scripts/mods/Immersive Engineering/Compatibility.js
@@ -22,20 +22,25 @@ ServerEvents.recipes(allthemods => {
     }).id(`allthemods:arcfurnace/${input.replace(/^.*?:/, '')}_to_${output.item.replace(/^.*?:/, '')}`)
   }
 
-  const ieIngots = ['electrum', 'aluminum', 'lead', 'silver', 'nickel', 'uranium', 'constantan', 'steel']
+  const ieIngots = ['electrum', 'aluminum', 'lead', 'silver', 'nickel', 'uranium', 'constantan', 'steel', 'osmium', 'platinum', 'tin', 'zinc']
 
   ieIngots.forEach(material => {
     //add sheetmetal scrapping back
+    if(Item.of(`immersiveengineering:sheetmetal_${material}`) !== undefined){
     arcfurnace(`immersiveengineering:sheetmetal_${material}`, 51200, {item: `alltheores:${material}_ingot`})
-    arcfurnace(`immersiveengineering:slab_sheetmetal_${material}`, 51200, {item: `alltheores:${material}_nugget`, count: 4})
+    arcfurnace(`immersiveengineering:slab_sheetmetal_${material}`, 51200, {item: `alltheores:${material}_nugget`, count: 4})}
     //replace nuggets from rod scrapping recipes
-    allthemods.replaceOutput({output: `immersiveengineering:nugget_${material}`}, `immersiveengineering:nugget_${material}`, `alltheores:${material}_nugget`)
+    if(Item.of(`immersiveengineering:nugget_${material}`) !== undefined){ allthemods.replaceOutput({output: `immersiveengineering:nugget_${material}`}, `immersiveengineering:nugget_${material}`, `alltheores:${material}_nugget`)}
     //remove duplicate raw block / raw ore recipes
     allthemods.remove({id: `immersiveengineering:arcfurnace/raw_block_${material}`})
     allthemods.remove({id: `immersiveengineering:arcfurnace/raw_ore_${material}`})
     //replace ingot in ore recipe
     allthemods.remove({id: `immersiveengineering:arcfurnace/ore_${material}`})
     arcfurnace(`#c:ores/${material}`, 102400, {item: `alltheores:${material}_ingot`, count: 2, slag: "#c:slag"})
+    //remove duplicate crusher recipes
+    allthemods.remove({id: `immersiveengineering:crusher/ore_${material}`})
+    allthemods.remove({id: `immersiveengineering:crusher/raw_ore_${material}`})
+    allthemods.remove({id: `immersiveengineering:crusher/raw_block_${material}`})
   })
 
   const ieAlloys = ['invar', 'electrum', 'brass', 'constantan', 'bronze']

--- a/kubejs/server_scripts/mods/Immersive Engineering/Compatibility.js
+++ b/kubejs/server_scripts/mods/Immersive Engineering/Compatibility.js
@@ -1,0 +1,54 @@
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
+
+ServerEvents.recipes(allthemods => {
+  function arcfurnace(input, energy, output) {
+    allthemods.custom(
+      {
+        type: "immersiveengineering:arc_furnace",
+        additives: [],
+        energy: energy,
+        input: Ingredient.of(input).toJson(),
+        results: [
+        {
+          basePredicate: {
+            item: output.item
+          },
+          count: output.count || 1
+        }
+        ],
+        slag: Ingredient.of(output.slag).toJson() || "" ,
+        time: 100
+    }).id(`allthemods:arcfurnace/${input.replace(/^.*?:/, '')}_to_${output.item.replace(/^.*?:/, '')}`)
+  }
+
+  const ieIngots = ['electrum', 'aluminum', 'lead', 'silver', 'nickel', 'uranium', 'constantan', 'steel']
+
+  ieIngots.forEach(material => {
+    //add sheetmetal scrapping back
+    arcfurnace(`immersiveengineering:sheetmetal_${material}`, 51200, {item: `alltheores:${material}_ingot`})
+    arcfurnace(`immersiveengineering:slab_sheetmetal_${material}`, 51200, {item: `alltheores:${material}_nugget`, count: 4})
+    //replace nuggets from rod scrapping recipes
+    allthemods.replaceOutput({output: `immersiveengineering:nugget_${material}`}, `immersiveengineering:nugget_${material}`, `alltheores:${material}_nugget`)
+    //remove duplicate raw block / raw ore recipes
+    allthemods.remove({id: `immersiveengineering:arcfurnace/raw_block_${material}`})
+    allthemods.remove({id: `immersiveengineering:arcfurnace/raw_ore_${material}`})
+    //replace ingot in ore recipe
+    allthemods.remove({id: `immersiveengineering:arcfurnace/ore_${material}`})
+    arcfurnace(`#c:ores/${material}`, 102400, {item: `alltheores:${material}_ingot`, count: 2, slag: "#c:slag"})
+  })
+
+  const ieAlloys = ['invar', 'electrum', 'brass', 'constantan', 'bronze']
+  const ieMachines = ['alloysmelter/', 'arcfurnace/alloy_']
+
+  ieAlloys.forEach(alloy => {
+    ieMachines.forEach(machine =>{
+      //remove duplicate alloy recipes
+      allthemods.remove({id:`immersiveengineering:${machine}${alloy}`})
+    })
+  })
+
+})
+
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.

--- a/kubejs/server_scripts/mods/Mekanism/Compatibility.js
+++ b/kubejs/server_scripts/mods/Mekanism/Compatibility.js
@@ -269,11 +269,11 @@ ServerEvents.recipes(allthemods => {
         chemical: 'mekanism:hydrogen_chloride'
       },      
       item_input: {
-        count: 2,
+        count: 1,
         tag: `c:crystals/${material}`
       },
       output: {
-        count: 1,
+        count: 2,
         id: `kubejs:${material}_shard`
       },  "per_tick_usage": true
     }).id(`allthemods:processing/${material}/shard/from_crystal`)

--- a/kubejs/server_scripts/mods/MysticalAgriculture/Compatibility.js
+++ b/kubejs/server_scripts/mods/MysticalAgriculture/Compatibility.js
@@ -59,7 +59,8 @@ const dusts = [
 //gems to be switched to tags
 const gems = [
   {resource: 'quartz', essence: 'tertium', seed: 'nether_quartz'},
-  {resource: 'fluorite', essence: 'imperium', seed: undefined}
+  {resource: 'fluorite', essence: 'imperium', seed: undefined},
+  {resource: 'peridot', essence: 'imperium', seed: undefined}
 ]
 
 //ingredients in a different format to use tags

--- a/kubejs/server_scripts/mods/MysticalAgriculture/FusionCrafting.js
+++ b/kubejs/server_scripts/mods/MysticalAgriculture/FusionCrafting.js
@@ -17,6 +17,7 @@ ServerEvents.recipes(allthemods => {
     essenceCircle('6x silentgear:crimson_iron_ingot', 'crimson_iron')
     essenceCircle('3x extendedae:entro_crystal', 'entro')
     essenceCircle('2x megacells:sky_steel_ingot', 'sky_steel')
+    essenceCircle('3x actuallyadditions:black_quartz', 'black_quartz')
 
     // infusion seed crafting
     function seedCrafting(output, middle, item1, item2, item3, item4, item5, item6, item7, item8){

--- a/kubejs/server_scripts/mods/MysticalAgriculture/Tags.js
+++ b/kubejs/server_scripts/mods/MysticalAgriculture/Tags.js
@@ -12,7 +12,8 @@ const seedID = [
     'mysticalagriculture:azure_silver_seeds',
     'mysticalagriculture:entro_seeds',
     'mysticalagriculture:sky_steel_seeds',
-    'mysticalagriculture:xychorium_gem_seeds'
+    'mysticalagriculture:xychorium_gem_seeds',
+    'mysticalagriculture:black_quartz_seeds'
 ]
 
 ServerEvents.tags('item', allthemods => {


### PR DESCRIPTION
fixed mek ore processing
de-dupe IE recipes
change sushigocrafting soy sauce bean tag to unified
unhide raw redstone block from JEI
unify peridot for MA seeds
patch pams avocado tree
add black quartz MA seed (with tags this time)

- closes: #2058 
- closes: #2056 
- closes: #2047 
- closes: #1994 
(not sure if you want to stop them from being processed instead, but they currently can be)
- closes: #1837 
- closes: #1859 
