### PR TITLE
add apotheosis config to reforge sgear axes

### DIFF
--- a/config/apotheosis/apotheosis.cfg
+++ b/config/apotheosis/apotheosis.cfg
@@ -1,0 +1,136 @@
+# File Specification: https://gist.github.com/Shadows-of-Fire/88ac714a758636c57a52e32ace5474c1
+
+# Apotheosis Adventure Module Config
+
+affixes {
+    # A list of type overrides for the affix loot system.  Format is <itemname>|<type>.
+    # Valid types are: none, melee_weapon, trident, shield, breaker, bow
+    # Synced.
+    # Default: [minecraft:iron_sword|melee_weapon], [minecraft:shulker_shell|none]
+    S:"Equipment Type Overrides" <
+        minecraft:iron_sword|melee_weapon
+        minecraft:shulker_shell|none
+	silentgear:axe|melee_weapon
+     >
+
+    # The chance that a naturally spawned mob will be granted an affix item. 0 = 0%, 1 = 100%
+    # Server-authoritative.
+    # Default: 0.075; Range: [0.0 ~ 1.0]
+    S:"Random Affix Chance"=0.075
+
+    # If affixes that cleave can hit players (excluding the user).
+    # Server-authoritative.
+    # Default: false
+    B:"Cleave Players"=false
+
+    # If Quark's Attribute Tooltip handling is disabled for affix items.
+    # Clientside.
+    # Default: true
+    B:"Disable Quark Tooltips for Affix Items"=true
+
+    # The item that will be used when attempting to place torches with the torch placer affix.  Must be a valid item that places a block on right click.
+    # Synced.
+    # Default: minecraft:torch
+    S:"Torch Placement Item"=minecraft:torch
+}
+
+
+bosses {
+    # If boss items are always cursed.  Enable this if you want bosses to be less overpowered by always giving them a negative effect.
+    # Server-authoritative.
+    # Default: false
+    B:"Curse Boss Items"=false
+
+    # The range at which boss spawns will be announced.  If you are closer than this number of blocks (ignoring y-level), you will receive the announcement.
+    # Server-authoritative.
+    # Default: 96.0; Range: [0.0 ~ 1024.0]
+    S:"Boss Announce Range"=96.0
+
+    # The volume of the boss announcement sound. 0 to disable.
+    # Clientside.
+    # Default: 0.75; Range: [0.0 ~ 1.0]
+    S:"Boss Announce Volume"=0.75
+
+    # If the boss announcement range ignores y-level.
+    # Server-authoritative.
+    # Default: false
+    B:"Boss Announce Ignore Y"=false
+
+    # The time, in ticks, that must pass between any two natural boss spawns in a single dimension.
+    # Server-authoritative.
+    # Default: 3600; Range: [0 ~ 720000]
+    I:"Boss Spawn Cooldown"=3600
+
+    # If true, invading bosses will automatically target the closest player.
+    # Server-authoritative.
+    # Default: false
+    B:"Boss Auto-Aggro"=false
+
+    # If true, bosses will glow when they spawn.
+    # Server-authoritative.
+    # Default: true
+    B:"Boss Glowing On Spawn"=true
+
+    # Dimensions where bosses can spawn naturally, spawn chance, and spawn rules.
+    # Format is dimname|chance|rule, chance is a float from 0..1.
+    # Valid rules are visible here https://github.com/Shadows-of-Fire/Apotheosis/blob/1.19/src/main/java/shadows/apotheosis/adventure/boss/BossEvents.java#L174C27-L174C27
+    # Server-authoritative.
+    # Default: [minecraft:overworld|0.018|NEEDS_SKY], [minecraft:the_nether|0.025|ANY], [minecraft:the_end|0.018|SURFACE_OUTER_END], [twilightforest:twilight_forest|0.05|NEEDS_SURFACE]
+    S:"Boss Spawn Dimensions" <
+        minecraft:overworld|0.018|NEEDS_SKY
+        minecraft:the_nether|0.025|ANY
+        minecraft:the_end|0.018|SURFACE_OUTER_END
+        twilightforest:twilight_forest|0.05|NEEDS_SURFACE
+     >
+}
+
+
+worldgen {
+    # The dimensions that the deadly module will generate in.
+    # Server-authoritative.
+    # Default: [overworld]
+    S:"Generation Dimension Whitelist" <
+        overworld
+     >
+}
+
+
+spawners {
+    # The chance that a Rogue Spawner has a "valuable" chest instead of a standard one. 0 = 0%, 1 = 100%
+    # Server-authoritative.
+    # Default: 0.11; Range: [0.0 ~ 1.0]
+    S:"Spawner Value Chance"=0.11
+}
+
+
+wanderer {
+    # If the Wandering Trader can attempt to spawn underground.
+    # Server-authoritative.
+    # Default: true
+    B:"Underground Trader"=true
+}
+
+
+augmenting {
+    # The number of Sigils of Enhancement it costs to upgrade an affix in the Augmenting Table.
+    # Synced.
+    # Default: 2; Range: [0 ~ 64]
+    I:"Upgrade Sigil Cost"=2
+
+    # The number of experience levels it costs to upgrade an affix in the Augmenting Table.
+    # Synced.
+    # Default: 225; Range: [0 ~ 65536]
+    I:"Upgrade Level Cost"=225
+
+    # The number of Sigils of Enhancement it costs to reroll an affix in the Augmenting Table.
+    # Synced.
+    # Default: 1; Range: [0 ~ 64]
+    I:"Reroll Sigil Cost"=1
+
+    # The number of experience levels it costs to reroll an affix in the Augmenting Table.
+    # Synced.
+    # Default: 175; Range: [0 ~ 65536]
+    I:"Reroll Level Cost"=175
+}
+
+


### PR DESCRIPTION
https://github.com/Shadows-of-Fire/Apotheosis/issues/1477

All that I added was the line right under minecraft:shulker_shell|none.

This change allows silentgear axes to be reforged in the reforging table.

I'm not sure how much of the apotheosis.cfg file is necessary, but I just copied the cfg file with my 1 change.