### PR TITLE
Fix quest book spelling and grammar

### DIFF
--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -541,7 +541,7 @@
 	]
 	quest.050D8480EE9D8E62.title: "Wigglewood Forest"
 	quest.0515422E36E4E9A3.quest_desc: ["Grants invisibility when sneaking."]
-	quest.0518551637F76C50.quest_desc: ["A little expensive but the &9Echoing Deep Shelf&r is like a much better &bSeashelf&r. (BTW you'll need to kill quite a few wardens to advance more in Enchanting... should a warned you earlier). Also increases Max &aEterna&r to &a75&r."]
+	quest.0518551637F76C50.quest_desc: ["A little expensive but the &9Echoing Deepshelf&r is like a much better &bSeashelf&r. (BTW you'll need to kill quite a few wardens to advance more in Enchanting... should've warned you earlier). Also increases Max &aEterna&r to &a75&r."]
 	quest.0518551637F76C50.title: "&9Echoing Deepshelf"
 	quest.051E0C85E7B71CE0.quest_desc: ["I'm going to assume you've been out mining, right? It is MINEcraft after all.\\n\\nYou'll find a ton of new ores that might confuse you, but you can stick to the vanilla materials to get you started!\\n\\nCopper is abundant and has plenty of uses for things like &aOre Hammers&r or &eDrawer Upgrades&r, so make sure to grab plenty of it!\\n\\nIron is probably one of the most important ores you'll want to get every time you run into it. The world of modded MC pretty much runs on Iron."]
 	quest.051E0C85E7B71CE0.title: "The &9Metal&r Age"
@@ -798,7 +798,7 @@
 		"Breaks nearby grass and flowers when activated."
 	]
 	quest.076A648E3E3245C9.quest_desc: ["Very fast Rate of making Energy from Fuel which makes it the very efficient. Only problem is it can't be upgraded anymore. Still uses normal Furnace Fuel."]
-	quest.076A648E3E3245C9.title: "&aEmerald Furnace"
+	quest.076A648E3E3245C9.title: "&aEmerald Generator"
 	quest.076DFB0B39A4259F.quest_desc: [
 		"{atm9.quest.enchant.desc.infused_seashelf}"
 		"{image:atm:textures/questpics/apotheosis/enchant_sea.png width:100 height:100 align:1}"
@@ -1133,7 +1133,7 @@
 	quest.0B7F2B63D867D221.quest_desc: ["To find these we'll need a little archeology! \\n\\nIn the giant shaft you'll take to get to the &e&lAncient Remnant&r, there are 3 rooms on the sides of it. \\n\\n2 of these rooms have Suspicious Sand which you can use a Brush on to get Loot! Including the &eNecklace of Desert&r. \\nThen, Right Click the &e&lAncient Remnant&r with the &eNecklace of Desert&r to resurect it!"]
 	quest.0B7F2B63D867D221.quest_subtitle: "Resurecting an Ancient Remnant"
 	quest.0B7F2B63D867D221.title: "&eNecklace of the desert"
-	quest.0B9BBE2A764631BF.quest_desc: ["The simple swaper can teleport items, blocks, mobs or players above it to another simple sawper it is linked to. To link swapers use the Ferricore wrench."]
+	quest.0B9BBE2A764631BF.quest_desc: ["The simple swapper can teleport items, blocks, mobs or players above it to another simple sawper it is linked to. To link swapers use the Ferricore wrench."]
 	quest.0B9F2B443813F43C.quest_desc: ["Have you ever wanted to be able to attack things with a Shovel, and have it hurt? I would ask why, but this is EvilCraft.\\n\\nWell look no further! This serves as both a weapon, and a tool for breaking soft things!"]
 	quest.0BA5A0DDD4A5363C.quest_subtitle: "Cobaltite be here"
 	quest.0BA5A0DDD4A5363C.title: "Garnierite Vein"
@@ -2056,7 +2056,7 @@
 	]
 	quest.1482F2D45E8F761D.quest_subtitle: "Casings and Glass"
 	quest.1482F2D45E8F761D.title: "Fission Reactor Building Basics"
-	quest.148A33CC36B2563A.quest_desc: ["The &dDraconic Shelf&r is the last Shelf we'll need for perfect set up. It might only give &aEterna&r but it has the Max Max &aEterna&r of &a100&r."]
+	quest.148A33CC36B2563A.quest_desc: ["The &dDraconic Endshelf&r is the last Shelf we'll need for perfect set up. It might only give &aEterna&r but it has the Max Max &aEterna&r of &a100&r."]
 	quest.148A33CC36B2563A.title: "&5Draconic Endshelf"
 	quest.149BD1A9F82FA19A.quest_subtitle: "&f6 &cAttack Damage"
 	quest.149C260C10B34BB0.quest_subtitle: "5/5"
@@ -2452,7 +2452,7 @@
 	quest.186826F12973BA28.quest_desc: ["Around twice as fast as the Bronze Macerator. One of the most important machines during this age since you'll need such a huge amount of ores. You'll want a few of these so you can process large quantities of ores."]
 	quest.187281092C0BC9CE.quest_desc: ["Wafers and Silicon Boules need to be cut. This cutter, paired with the Engraving Laser will make sure we keep our stock of Chips up!"]
 	quest.187281092C0BC9CE.quest_subtitle: "Waffles and Boules"
-	quest.1873205CF5247E3E.quest_desc: ["The last sets of Shelves you'll need are &dEndshelves&r, to get them you need Infused Dragon's Breath. This one was hard to get but you need atleast &a80 Eterna&r, &c15%-30% Quanta&r, and atleast &560% Arcana&r. It has to be between &c15%-25% Quanta&r to get that you can try &910 Echoing Skulkshelves&r and &29 Melonshelves &ror &92 Echoing Skulkshelves&r and &b4 Heart-Forged Seashelves&r."]
+	quest.1873205CF5247E3E.quest_desc: ["The last sets of Shelves you'll need are &dEndshelves&r, to get them you need Infused Dragon's Breath. This one was hard to get but you need atleast &a80 Eterna&r, &c15%-30% Quanta&r, and atleast &560% Arcana&r. It has to be between &c15%-25% Quanta&r to get that you can try &910 Echoing Sculkshelves&r and &29 Melonshelves &ror &92 Echoing Sculkshelves&r and &b4 Heart-Forged Seashelves&r."]
 	quest.1873205CF5247E3E.title: "&5Endshelf"
 	quest.187816477B732517.quest_desc: ["The &3Transfer Gadget&r acts like a Hopper that can be placed inbetween blocks."]
 	quest.187816477B732517.quest_subtitle: "Smaller Hopper"
@@ -3323,7 +3323,7 @@
 	quest.21D323D95F5A7DB3.title: "Strong Stick"
 	quest.21EA29A8C7F950CE.quest_desc: ["&bDiamonds&r the staple of &2Minecraft&r, and of upgraded Furnaces apparently...\\n \\nThese work even faster only taking 80 Ticks or 4 Seconds to smelt items. That's even faster than a Blast Furnace! \\n \\nThese are only crafted by &eGold Furnaces&r and can be crafted into &3Crystal&r or &aEmerald Furnaces&r."]
 	quest.21EA29A8C7F950CE.title: "&bDiamond Furnace"
-	quest.21EE522DDBF0BF72.quest_desc: ["The last sets of Shelves you'll need are &dEndshelves&r, to get them you need Infused Dragon's Breath. This one was hard to get but you need atleast &a40%% Eterna&r, &c15%%-25%% Quanta&r, and atleast &560%% Arcana&r. It has to be between &c15%%-25%% Quanta&r to get that you can try &99 Echoing Skulkshelves&r and 4 Melonshelves or &92 Echoing Skulkshelves&r and &b10 Heart-Forged Seashelves&r."]
+	quest.21EE522DDBF0BF72.quest_desc: ["The last sets of Shelves you'll need are &dEndshelves&r, to get them you need Infused Dragon's Breath. This one was hard to get but you need atleast &a40%% Eterna&r, &c15%%-25%% Quanta&r, and atleast &560%% Arcana&r. It has to be between &c15%%-25%% Quanta&r to get that you can try &99 Echoing Sculkshelves&r and 4 Melonshelves or &92 Echoing Sculkshelves&r and &b10 Heart-Forged Seashelves&r."]
 	quest.21EE522DDBF0BF72.title: "&dEndshelf&r"
 	quest.21F4CFF171246537.quest_subtitle: "Tier: &b4"
 	quest.21F5EED683499B71.quest_desc: [
@@ -3653,7 +3653,7 @@
 	quest.24BD32102AFA1691.quest_desc: ["An upgraded crafter that holds more patterns and has an increased crafting speed."]
 	quest.24BD32102AFA1691.title: "&5Netherite Crafter&r"
 	quest.24C0F267B330CD23.quest_desc: ["With the damage of a Diamond Sword, the &2Terra Blade&r will sometimes fire a beam that will deal as much as a melee hit would."]
-	quest.24C757B8AA6841F6.quest_desc: ["Apothic Spawners knows how annoying Tridents can be to get so they made it easier... well kinda easier. You can now make an Inert Trident and Infuse it to get a normal Trident. The Trident requires between &a40 Eterna&r, &c20%-50% Quanta&r, and atleast &535% Arcana&r. You can get this with &94 Echoing Skulkshelves&r, &2Melonshelf &rand Normal Bookshelf."]
+	quest.24C757B8AA6841F6.quest_desc: ["Apothic Spawners knows how annoying Tridents can be to get so they made it easier... well kinda easier. You can now make an Inert Trident and Infuse it to get a normal Trident. The Trident requires between &a40 Eterna&r, &c20%-50% Quanta&r, and atleast &535% Arcana&r. You can get this with &94 Echoing Sculkshelves&r, &2Melonshelf &rand Normal Bookshelf."]
 	quest.24C757B8AA6841F6.title: "Making a real Trident"
 	quest.24C9BA6DC32CFAD9.quest_desc: ["Coal is your first real source of power. If you are running low and cant find any Coal a better alternative for you will be Charcoal. "]
 	quest.24C9BA6DC32CFAD9.quest_subtitle: "Smelt your logs"
@@ -5745,7 +5745,7 @@
 	quest.3B577572FA7A413E.title: "&3Wrath of the &eDesert"
 	quest.3B6F1BD64C0C570F.quest_desc: ["Just like wind generation this will give you lots of power without giving it any resources. The only downside here is it has to be daytime. "]
 	quest.3B6F1BD64C0C570F.title: "Solar Power"
-	quest.3B6F723B03C4BF55.quest_desc: ["Digestion (very prude way of processing) is how we change &3Alchemical Niters&r to different forms. \\n\\nFirst we'll need Purified Gold which can be made from putting Gold, &bAlchemical Salt&r, and &9Water&r into the Disgestion Vat and Shift Right Click to close it like the Fermentation Vat. \\n\\nThen we can either combine 4 of one &3Alchemical Niter&r with Purified Gold and &dSal Ammoniac&r to get a higher Tier or do the reverse for a lower Tier."]
+	quest.3B6F723B03C4BF55.quest_desc: ["Digestion (very prude way of processing) is how we change &3Alchemical Niters&r to different forms. \\n\\nFirst we'll need Purified Gold which can be made from putting Gold, &bAlchemical Salt&r, and &9Water&r into the Digestion Vat and Shift Right Click to close it like the Fermentation Vat. \\n\\nThen we can either combine 4 of one &3Alchemical Niter&r with Purified Gold and &dSal Ammoniac&r to get a higher Tier or do the reverse for a lower Tier."]
 	quest.3B6F723B03C4BF55.title: "Digestion Vat"
 	quest.3B7BB08D6AA2E7FE.quest_desc: [
 		"Now the &cRed Super Candles&r finally look in place! We know it's the &cRed one&r by the &cRed Flowers&r and &cRed Luminescent Ancient Wax&r. \\n\\nVenture through the &cfirey red rooms&r to get to the &cRed Essence&r. \\n\\nDozens of different angry Mobs will spawn: Wolves, Polar Bears, and Hoglins. Kill them all to win!"
@@ -7956,7 +7956,7 @@
 		""
 		"It will show things as rotation speed and stress."
 	]
-	quest.4F9932477EDDCB8E.quest_desc: ["The Advanced Portal Gun is the upgrades version of the Portal Gun that requres both power and portal fluid to operate. Unlike the Portal Gun the Adavanced Portal Gun allows the player to teleport between locations that have been encoded. Using \"V\" (default keybind) the menu used to encode and select desinations for teleportion."]
+	quest.4F9932477EDDCB8E.quest_desc: ["The Advanced Portal Gun is the upgraded version of the Portal Gun that requres both power and portal fluid to operate. Unlike the Portal Gun the Adavanced Portal Gun allows the player to teleport between locations that have been encoded. Using \"V\" (default keybind) the menu used to encode and select desinations for teleportion."]
 	quest.4F9D6109EEA5D26A.quest_desc: ["Breaking &eGolden Leaves&r has a high chance to drop a &eGold Leaf&r, which is needed for &eGold Powder&r. "]
 	quest.4F9D6109EEA5D26A.quest_subtitle: "Aura with Fireflies"
 	quest.4F9D6109EEA5D26A.title: "&eGold Leaves"
@@ -9756,7 +9756,7 @@
 	quest.616ED6C49C37EB91.quest_desc: ["&b&lPaths and Pathways&r adds tons of different Carpet like Blocks (and full Blocks and Slab versions). \\n\\nThese are obviously used as Paths, they just look much nicer than the &2&lMinecraft&r Path Block. "]
 	quest.616ED6C49C37EB91.title: "&b&lMacaw's Paths and Pavings"
 	quest.616F9B78B16B42A5.quest_desc: ["The recipe for the &6Tesla Coil&r might seem complicated, especially in a recipe tree, but we can break it down to be simpler!\\n\\nThe &7Aluminum Plates&r are very simple, just needing to use a Hammer on Ingots or the Metal Press Multiblock.\\n\\nThe &8Iron Mechanical Component&r is simple as well, just a few Iron Plates and a &6Copper Ingot&r.\\n\\n&eElectrum Coil Block&r will need a bunch of &eElectrum Ingots&r cut up into Wires. &eElectrum&r is an alloy of &eGold&r and Silver.\\n\\nThe &6Advanced Electronic Component&r is a whole array of using the Engineers Workbench and &9Blueprints&r. It's Duroplast Sheet requires a lot of refining and fermenting with Multiblock Machines!\\n\\nThe last item, the &cHV Accumulator&r needs some simple Items like &8Steel&r, &7Aluminum Plate&r, &cRedstone Acid&r, and &4Treated Wood&r. It also needs a more complicated Item called &8HOP Graphite Ingot&r."]
-	quest.616F9B78B16B42A5.title: "&6Telsa Coil"
+	quest.616F9B78B16B42A5.title: "&6Tesla Coil"
 	quest.61768CFEDA041E4D.quest_desc: ["Once you enter the &6&lBumblezone&r you might need to return to the &2Overworld&r. Like incase you left your Stove on! \\n\\nTo get out the &6&lBumblezone&r you can mine either down or up past the &eBeehive Beeswax&r in order to enter the Void. \\n\\nThis Void won't kill you, instead it will teleport you back to where you were in the &2Overworld&r!"]
 	quest.61768CFEDA041E4D.quest_subtitle: "Let me outta here!"
 	quest.61768CFEDA041E4D.title: "Escaping"
@@ -9794,7 +9794,7 @@
 	quest.61D6C9461F10CCF1.title: "&dEvilCraft&r"
 	quest.61D9E67FFA14A8F8.quest_desc: ["We have seen many liquids that are the result of processing by the Fusion Reactor."]
 	quest.61D9E67FFA14A8F8.quest_subtitle: "Nitrogen Plasma"
-	quest.61DA3D61D7103647.quest_desc: ["&eAlchemical Sulfurs&r can be made from practically anything and can be made into practically anything! \\n\\nThere's a few different groups of Items in &eAlchemical Sulfurs&r which might be explained more in another Quest. \\n\\nThere's 3 different paths you can take with processing &eAlchemical Sulfurs&r. 1. Fermentation and Disgestion for making Niter. 2. Incubation for making those Items again and 3. Changing the Item with Reformation."]
+	quest.61DA3D61D7103647.quest_desc: ["&eAlchemical Sulfurs&r can be made from practically anything and can be made into practically anything! \\n\\nThere's a few different groups of Items in &eAlchemical Sulfurs&r which might be explained more in another Quest. \\n\\nThere's 3 different paths you can take with processing &eAlchemical Sulfurs&r. 1. Fermentation and Digestion for making Niter. 2. Incubation for making those Items again and 3. Changing the Item with Reformation."]
 	quest.61DA3D61D7103647.title: "&eAlchemical Sulfurs"
 	quest.61DCECE1FC38E151.title: "Reactor (Nitro)"
 	quest.61E2FC5D363A5CA4.quest_subtitle: "Increases Efficiency at the cost of Speed"

--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -244,8 +244,8 @@
 	]
 	quest.020E6AF37A0421C8.title: "Water Tank"
 	quest.02190383FEE793ED.quest_desc: ["All that is left to do is use a &eChemical Reaction&r to pull the Chlorine off the Iridium!"]
-	quest.022C38096F79EF07.quest_desc: ["&6&lForbidden Arcanus&r is all about using the Arcane to do rituals with the Forge to become stronger! \\n\\nOr what most know it for, Eternal Stella. There's more to the Mod you know! "]
-	quest.022C38096F79EF07.title: "&6&lForbidden Arcanus"
+	quest.022C38096F79EF07.quest_desc: ["&6&lForbidden \\& Arcanus&r is all about using the Arcane to do rituals with the Forge to become stronger! \\n\\nOr what most know it for, Eternal Stella. There's more to the Mod you know! "]
+	quest.022C38096F79EF07.title: "&6&lForbidden \\& Arcanus"
 	quest.0251FD45582C3164.quest_subtitle: "Don't sniff this"
 	quest.0253D241383EC848.quest_desc: ["Raiden is a Fictional Character in the Mortal Kombat Fightin.... Oh wait... It said Radon, not Raiden..."]
 	quest.0253D241383EC848.quest_subtitle: "Raiden"

--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -2156,7 +2156,7 @@
 	quest.158F48B73171BDE1.title: "Metal Tools"
 	quest.1591013DDD4766E1.quest_desc: ["&l&cCooking for Blockheads&r is all about making the Kitchen your home. \\n\\nI recommend using everything it gives as every Item has a use and looks amazing!"]
 	quest.1591013DDD4766E1.title: "&l&cCooking for Blockheads&r"
-	quest.15978093237448FE.quest_desc: ["Why upgrade &cNetherite&r to &6AllTheModium&r or even anything else when we can upgrade it to &3Warden Armor&r! \\n\\nYou'll need a few Warden Drops in order to make it though!"]
+	quest.15978093237448FE.quest_desc: ["Why upgrade &cNetherite&r to &6Allthemodium&r or even anything else when we can upgrade it to &3Warden Armor&r! \\n\\nYou'll need a few Warden Drops in order to make it though!"]
 	quest.15978093237448FE.quest_subtitle: "24"
 	quest.15978093237448FE.title: "&3Warden Armor"
 	quest.15A1D6D05A785919.quest_desc: ["Did you know that NOR logic gates can be used to make every other logic gate? That's why we use it so much for making circuits!"]
@@ -2503,7 +2503,7 @@
 	quest.18F88DE24EFBA7A7.title: "Fuel for our Furnace"
 	quest.18F948FF9FE015FB.quest_subtitle: "Feed a Vanilla Bee TNT"
 	quest.18F948FF9FE015FB.title: "CreeBee"
-	quest.18FAD56CDE05646A.quest_desc: ["Before Quarries in the &7&lMining Dimension&r used to mine everything but leave &6AllTheModium Ore&r. \\n\\nNow it will Mine &6AllTheModium&r but Void the drops... might want to be careful with your Quarries now! \\n\\nI recommend Mining with Ore Sight Potions if you are looking strictly for &6AllTheModium&r!"]
+	quest.18FAD56CDE05646A.quest_desc: ["Before Quarries in the &7&lMining Dimension&r used to mine everything but leave &6Allthemodium Ore&r. \\n\\nNow it will Mine &6Allthemodium&r but Void the drops... might want to be careful with your Quarries now! \\n\\nI recommend Mining with Ore Sight Potions if you are looking strictly for &6Allthemodium&r!"]
 	quest.18FEFB1BC6DFE49C.quest_desc: ["Bringing more power output to our Substations, which as we progress will help immensely in ensuring our equipment stays running!"]
 	quest.18FEFB1BC6DFE49C.quest_subtitle: "Substation Tier up!"
 	quest.1906C5D1C80035E4.quest_desc: [
@@ -3082,7 +3082,7 @@
 		""
 		"Tip: In the Mining Dimension, this ore is a lot more common."
 	]
-	quest.1FD4C32B3937E1C7.title: "AllTheModium Ore"
+	quest.1FD4C32B3937E1C7.title: "Allthemodium Ore"
 	quest.1FD60B7448CED1EB.quest_desc: ["This &b&lMacaw&r Mod adds new types of Fences, Gates, and Walls. \\n\\nYes, the barbed wire will hurt you. \\n\\nNo, you can't jump over any of them normally."]
 	quest.1FD60B7448CED1EB.title: "&b&lMacaw's Fences and Walls"
 	quest.1FDC8725105D822A.quest_desc: ["The Kitchen holds many Blocks that can hold, preserve, and Cook Food! \\n\\nMost the Blocks that cook or prepare Food do need Energy, so check out the Electrical Set to learn more!"]
@@ -3140,7 +3140,7 @@
 		"At least we can get our Naquadah Coils going now, and help our EBF's to process more metals!"
 	]
 	quest.2036ED4A823C1456.quest_subtitle: "We're going to need more Naq"
-	quest.203C91B992BA8CF9.quest_desc: ["In order to remake the &6&lATM Star&r we'll need an Infused &dPatrick &aStar&r, which also needs a &dPatrick &aStar&r for it. Both are made via &6&lRunic Star Altar&r. \\n\\nThe other items needed to make Infused &dPatrick &aStar&r are the 4 &5Mending Books&r and &dInfused Dragon's Breath&r which are obtained through &5&lRunic Enchanting&r. \\n\\n&6Star Shards&r which we get from our Bees! \\n\\nAnd Alloy Ingots: &3Vibranium&f-&6AllTheModium&r, &5Unobtainium&f-&6AllTheModium&r, and &5Unobtainium&f-&3Vibranium&r Ingots. \\n\\nAll three are crafted in their own unique ways described in the &6&lAllTheModium&r chapter! \\n\\nThrow all of these into a &6&lRunic Star Altar&r, plus 85MFE, and we'll get our Infused &dPatrick &aStar&r!"]
+	quest.203C91B992BA8CF9.quest_desc: ["In order to remake the &6&lATM Star&r we'll need an Infused &dPatrick &aStar&r, which also needs a &dPatrick &aStar&r for it. Both are made via &6&lRunic Star Altar&r. \\n\\nThe other items needed to make Infused &dPatrick &aStar&r are the 4 &5Mending Books&r and &dInfused Dragon's Breath&r which are obtained through &5&lRunic Enchanting&r. \\n\\n&6Star Shards&r which we get from our Bees! \\n\\nAnd Alloy Ingots: &3Vibranium&f-&6Allthemodium&r, &5Unobtainium&f-&6Allthemodium&r, and &5Unobtainium&f-&3Vibranium&r Ingots. \\n\\nAll three are crafted in their own unique ways described in the &6&lAllthemodium&r chapter! \\n\\nThrow all of these into a &6&lRunic Star Altar&r, plus 85MFE, and we'll get our Infused &dPatrick &aStar&r!"]
 	quest.203C91B992BA8CF9.title: "Infused &dPatrick &aStar"
 	quest.20436AFCC7E6855D.quest_desc: ["With Magic Beans and Uberous Soil, you'll want to look for a large cloud in the highland biomes.\\n\\nPlant the magic beans in the soil to grow a beanstalk all the way up. Here, you'll find the Giants.\\n\\nYou'll need to kill the Miner Giant and get their pickaxe to continue on."]
 	quest.20436AFCC7E6855D.quest_subtitle: "The giants look like me, but are nothing LIKE me"
@@ -3391,9 +3391,9 @@
 	]
 	quest.229455730219F7B1.quest_subtitle: "Red Iron"
 	quest.229455730219F7B1.title: "&cVentium"
-	quest.2296CE4418AE62D4.quest_desc: ["&6AllTheModium Armor&r but with buffs to &d&lArs Nouveau&r Spells!"]
+	quest.2296CE4418AE62D4.quest_desc: ["&6Allthemodium Armor&r but with buffs to &d&lArs Nouveau&r Spells!"]
 	quest.2296CE4418AE62D4.quest_subtitle: "24"
-	quest.2296CE4418AE62D4.title: "&6AllTheModium Arcanist Gear"
+	quest.2296CE4418AE62D4.title: "&6Allthemodium Arcanist Gear"
 	quest.22A0A9C81A5C85A1.quest_subtitle: "Holding everything together"
 	quest.22A1C68078EFB38B.quest_subtitle: "Amplifies Potion Effect"
 	quest.22AC248B6BB88486.quest_desc: [
@@ -4318,7 +4318,7 @@
 	quest.2BEBF66D7EA594FA.title: "&2Steeleaf Armor"
 	quest.2BF119DD5D977409.title: "Tier 2 Starlight Charger Catalyst"
 	quest.2BF9B347D1FC037A.quest_desc: ["This can be found by &2brushing&r &aSuspicious Clay&r in the &dAncient City&r."]
-	quest.2BF9B347D1FC037A.title: "&6AllTheModium Upgrades&r"
+	quest.2BF9B347D1FC037A.title: "&6Allthemodium Upgrades&r"
 	quest.2C04B3BA507D5673.quest_desc: ["&bPatterns&f are what hold an encoded recipe to be fulfilled by a Pattern Provider. To encode a recipe onto a Pattern, the &bME Pattern Encoding Terminal&f must be used.\\n\\nPatterns can be set to hold either a regular &ecrafting&f recipe, which will require the use of a &eMolecular Assembler&f on the face of its Provider, or a more general '&eprocessing&f' recipe, wherein any input items can be sent out by the provider into some other machine block or specialised processing plant."]
 	quest.2C04B3BA507D5673.title: "Patterns"
 	quest.2C0984E03F308959.quest_subtitle: "Pink Ipe + Luck"
@@ -4467,7 +4467,7 @@
 	quest.2DA8CE213AC3869B.quest_desc: ["Starlight Crystals can be found all over and even under the Crystallized Deserts. \\n\\nThey work similar to Amethyst and even sound like it!"]
 	quest.2DB53A77C3CD90F1.quest_desc: ["The Botanist's Pickaxe turns blocks that it interacts with into their mossy variants, assuming they have one."]
 	quest.2DB53A77C3CD90F1.quest_subtitle: "Tier: &b3"
-	quest.2DB81CE6F647D08A.title: "Unobtainium-AllTheModium Alloy"
+	quest.2DB81CE6F647D08A.title: "Unobtainium-Allthemodium Alloy"
 	quest.2DC639C39AE90272.quest_subtitle: "Yellow Meranti + Rose Gum"
 	quest.2DD5F0693780B10A.quest_desc: ["Used with the Extruder MK2, blocks extruded will mimic the actual blocks. Redstone Blocks will emit Redstone, Glowstone will emit light, Grass will act transparent. But only with this Augment! \\nDoesn't work with Block Entities like Furnaces or Enrichment Chambers."]
 	quest.2DDA04088C8220D2.quest_desc: ["Prosperity Shards are a core crafting ingrediant in the mod. To find some Prosperity Ore, go mining."]
@@ -4943,7 +4943,7 @@
 		"If you want to build the Crusher, navigate to the &aHeavy Machinery&r section in your &eEngineer's Manual&r to learn how to build the multiblock!"
 	]
 	quest.323F39FC300F7E30.title: "Coke Dust"
-	quest.32543DA54C684E4E.quest_desc: ["&cModularium&r, the aptly named, Ingot is what we'll need for getting into &c&lModular Machinery&r. \\n\\nYou'll need a &9&lTier 5 &6Forge&r along with an &6Artisan Relic&r and &3Elementarium&r and Items. These Items being 4 &6Deorum Ingots&r, 4 End Steel Ingots, and an &6AllTheModium Ingot&r! \\n\\nCombine these all together with the needed Essences and you'll get 24 &cModularium Ingots&r"]
+	quest.32543DA54C684E4E.quest_desc: ["&cModularium&r, the aptly named, Ingot is what we'll need for getting into &c&lModular Machinery&r. \\n\\nYou'll need a &9&lTier 5 &6Forge&r along with an &6Artisan Relic&r and &3Elementarium&r and Items. These Items being 4 &6Deorum Ingots&r, 4 End Steel Ingots, and an &6Allthemodium Ingot&r! \\n\\nCombine these all together with the needed Essences and you'll get 24 &cModularium Ingots&r"]
 	quest.32543DA54C684E4E.title: "Building block of &l&cModulary Machinery"
 	quest.325483DEB0C602F8.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks. \\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission. \\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
 	quest.3260EDAD3A619479.quest_desc: ["&5Aethersent Ore&r is found during Meteorite Showers in &5&lEternal Starlight&r. Small ones break on impact, you'll need to wait for big Meteors! \\n\\nOr is it Meteorites? What's the difference?"]
@@ -5467,7 +5467,7 @@
 		"{image:atm:textures/questpics/undergarden/undergarden_rotwalker.png width:100 height:200 align:center}"
 	]
 	quest.380D3212D1CBA593.title: "&cRotwalker&r"
-	quest.38135FFD9ED64395.title: "Vibranium-AllTheModium Alloy"
+	quest.38135FFD9ED64395.title: "Vibranium-Allthemodium Alloy"
 	quest.3813F5C1760C3A79.quest_desc: ["Piglin Brutes being here might cause controversey but I consider them Minibosses. \\n\\nThey spawn in Bastions with regular Piglins but these are Hostile not Neutral. Personally I hate that, especially since if you hit them all Piglins will turn Hostile on you. \\n\\nThey have 50 Hearts and a Golden Axe to hit you. Usually Golden Axes barely do any damage, but when they use it, it is god somehow! \\n\\nThey drop nothing and act more like an obstacle for Bastions!"]
 	quest.3813F5C1760C3A79.title: "Kill A Piglin Brute"
 	quest.38451B61E3FC075B.quest_desc: [
@@ -5789,7 +5789,7 @@
 	quest.3BDB94F17765EE77.quest_desc: ["If you're looking to generate a ton of power, you can start by scaling up some of the options from the &9Mid Game Power&r section. Make your &aReactors&r bigger. Upgrade your &9Thermo Generators&r to Nitro. Go wild.\\n\\nHowever, you may need even more power."]
 	quest.3BDB94F17765EE77.quest_subtitle: "More Power Than You'll Need"
 	quest.3BDB94F17765EE77.title: "End Game Power Options"
-	quest.3BE5CD0C7CC4BCC6.quest_desc: ["Soul Lava is a part of &6&lAllTheModium&r. It can be found in &b&lThe Other&r very rarely underground, or common in Piglich Villages!\\n\\nWe'll need to feed a Bucket of &9Soul Lava&r to a Ghostly Bee to make a &9Soul Lava Bee&r.\\n\\nThen, you'll need to squish them or poke them for it's DNA to make a Spawn Egg!  "]
+	quest.3BE5CD0C7CC4BCC6.quest_desc: ["Soul Lava is a part of &6&lAllthemodium&r. It can be found in &b&lThe Other&r very rarely underground, or common in Piglich Villages!\\n\\nWe'll need to feed a Bucket of &9Soul Lava&r to a Ghostly Bee to make a &9Soul Lava Bee&r.\\n\\nThen, you'll need to squish them or poke them for it's DNA to make a Spawn Egg!  "]
 	quest.3BE5CD0C7CC4BCC6.title: "&9Soul Lava Bee&r Spawn Egg"
 	quest.3BEDF19CD79D53D5.quest_desc: [
 		"The &aDistillation Tower&r serves as the foundation for &dOil Processing&r which can turn oil into many more useful forms"
@@ -5829,7 +5829,7 @@
 		""
 		"To get to the &5Beyond&r, use the Teleport Pad in the End."
 	]
-	quest.3C322474D2F2BA99.title: "AllTheModium Dimensions"
+	quest.3C322474D2F2BA99.title: "Allthemodium Dimensions"
 	quest.3C3FE45CEF5E242B.quest_desc: ["While the other &aReprocessor Parts&r have a mandatory spot when building, these three parts can be placed on any vertical face as long as they aren't on the frame!\\n\\nThe &cPower Port&r is used to give power to the multiblock machine to process waste.\\n\\nThe &9Fluid Injector Port&r is used to inject the liquid needed, which will depend on the type of waste injected. For Cyanite, that means water!\\n\\nThe &aOutput Port&r is used to output the reprocessed material. You can right click it to grab the material out by hand, or pipe it out for automation."]
 	quest.3C413D4A210A3BDE.title: "Honey Bee"
 	quest.3C49F2EEDCCAF1DF.quest_desc: [
@@ -9031,7 +9031,7 @@
 	quest.5A6670364ADE0858.quest_subtitle: "&f29 &cAttack Damage"
 	quest.5A6831E0BD2F6AB5.quest_desc: ["You'll need a lotta &8Dark Gems&r!"]
 	quest.5A6831E0BD2F6AB5.title: "2 &4Piercing Vengeance Focuses"
-	quest.5A6FF0D4BA894306.quest_desc: ["The poster child of &6&lForbidden \\& Arcanus&r, the &aEternal Stella&r. \\n\\nFor 1 &6AllTheModium&r Ingot, 3 &aXpetrified Orbs&r, and a &2Stellarite Piece&r we can make one of the most overpowered Items in this Modpack! \\n\\nYou can use the &aEternal Stella&r with an Item and an Apply Item Modifier to make Items lose their Durability. No, wait I mean lose their need for Durability! Basically Indestructible Items. \\n\\nThis can be used on almost every Item with Durability from &bDiamond Axes&r, to Fishing Rods, to even &eRefined Glowstone Armor&r! \\n\\nThere are some limitations, it only works with Items with Durability not uses: like Infusion Crystals or Energy: like Meka-Tool!"]
+	quest.5A6FF0D4BA894306.quest_desc: ["The poster child of &6&lForbidden \\& Arcanus&r, the &aEternal Stella&r. \\n\\nFor 1 &6Allthemodium&r Ingot, 3 &aXpetrified Orbs&r, and a &2Stellarite Piece&r we can make one of the most overpowered Items in this Modpack! \\n\\nYou can use the &aEternal Stella&r with an Item and an Apply Item Modifier to make Items lose their Durability. No, wait I mean lose their need for Durability! Basically Indestructible Items. \\n\\nThis can be used on almost every Item with Durability from &bDiamond Axes&r, to Fishing Rods, to even &eRefined Glowstone Armor&r! \\n\\nThere are some limitations, it only works with Items with Durability not uses: like Infusion Crystals or Energy: like Meka-Tool!"]
 	quest.5A6FF0D4BA894306.title: "&aEternal Stella"
 	quest.5A7FF6D0AED656DC.quest_desc: ["Decreases the amount of time that it takes for a Mana Burst to start losing its Mana, but will also decrease its rate of loss."]
 	quest.5A84A64CB3D3E6F5.quest_subtitle: "White Willow + Oak/Birch/Silver Lime"
@@ -9121,9 +9121,9 @@
 	quest.5B95C5B5B3A9CB2E.title: "&dLoot Chests&r"
 	quest.5B9F933ECD6B24FD.quest_desc: ["Allows you to jump higher than with Tier II."]
 	quest.5B9F933ECD6B24FD.quest_subtitle: "Max: 1"
-	quest.5BA84F6282D9CAF1.quest_desc: ["&6AllTheModium Armor&r but with buffs to &e&lIron's Spells&r Spells!"]
+	quest.5BA84F6282D9CAF1.quest_desc: ["&6Allthemodium Armor&r but with buffs to &e&lIron's Spells&r Spells!"]
 	quest.5BA84F6282D9CAF1.quest_subtitle: "24"
-	quest.5BA84F6282D9CAF1.title: "&6AllTheModium Mage Outfit"
+	quest.5BA84F6282D9CAF1.title: "&6Allthemodium Mage Outfit"
 	quest.5BA986D7928BF09F.quest_desc: ["The Piglich is a Boss added by &6&lAllthemodium&r. \\n\\nHas he 1000 Hearts and currently has no attacks but trust me when he does they will be devastating! \\n\\nWhen killed he'll drop his Heart which will be needed for Alloys and the ATM Star! \\n\\n(Look into ways of farming them like with HNN or EnderIO!)"]
 	quest.5BA986D7928BF09F.title: "Piglich Boss"
 	quest.5BB7648DC10E1E08.quest_desc: ["Has 27 more filter slots and is 6x faster than the regular Exporter. Also has the Stack Upgrade integrated."]
@@ -9418,7 +9418,7 @@
 	quest.5E799B92358A8732.quest_desc: ["In the &cNether&r, you'll run into &6Ancient Debris&r. This can be smelted down into Scraps that can be combined with Gold to create &6Netherite Ingots&r, which is an endgame metal use to craft some of the strongest tools and armor in the game."]
 	quest.5E799B92358A8732.title: "&dAncient Metals"
 	quest.5E7CCDE9229A646A.quest_desc: ["{image:atm:textures/questpics/basicarmor/armor_allthemodium.png width:100 height:150 align:center}"]
-	quest.5E7CCDE9229A646A.title: "&6AllTheModium&r"
+	quest.5E7CCDE9229A646A.title: "&6Allthemodium&r"
 	quest.5E7E35CCAF1C88EE.quest_desc: ["The &bME Import Bus&f periodically sucks items in from whatever external storage the bus is facing. It can optionally be filtered to only take in certain items from said inventory."]
 	quest.5E7E35CCAF1C88EE.quest_subtitle: "The I"
 	quest.5E90EF7FF530C477.quest_desc: [
@@ -10819,9 +10819,9 @@
 		"This ones a funny one; you can either find it, craft it, or trade for it.\\n\\nThen you can dye it whatever color you want and of course wear it on your Head!\\n\\nThe &6B&8e&6e&8s&r will then think that you are a Flower and will follow you.\\n\\nIt also makes you look like Daffy from \"Duck Amuck\"."
 		"{image:atm:textures/questpics/bumblezone/bumble_duckamuck.png width:100 height:100 align:center}"
 	]
-	quest.6C5F9D0D447EFB9C.quest_desc: ["What you think &l&2Vanilla&r was all we got? \\n\\n&6AllTheModium Armor&r has more Armor Points and Armor Toughness, plus increased Protection against Magic and other buffs you can read about in &6&lAllTheModium&r Quest Page! \\n\\nBTW you will need &cNetherite&r to craft it."]
+	quest.6C5F9D0D447EFB9C.quest_desc: ["What you think &l&2Vanilla&r was all we got? \\n\\n&6Allthemodium Armor&r has more Armor Points and Armor Toughness, plus increased Protection against Magic and other buffs you can read about in &6&lAllthemodium&r Quest Page! \\n\\nBTW you will need &cNetherite&r to craft it."]
 	quest.6C5F9D0D447EFB9C.quest_subtitle: "24"
-	quest.6C5F9D0D447EFB9C.title: "&6AllTheModium Armor"
+	quest.6C5F9D0D447EFB9C.title: "&6Allthemodium Armor"
 	quest.6C6F4EB5CBE2FBC2.quest_desc: ["The Iron Divination Rod is a slight bit higher, being able to find Ores that an Iron Pickaxe can mine! So Diamonds, Redstone, and Gold."]
 	quest.6C706326381CE611.title: "Creative Pressure"
 	quest.6C76AB8A6110C0C7.quest_desc: ["The &4Blazing Hellshelf&r is an upgrade to the &4Infused Hellshelf&r. It increases max &aEterna&r to &a30&r. The negative Enchanting Clue makes it a little worse for normal Enchanting, instead we can use it for better Infusion."]
@@ -11142,7 +11142,7 @@
 	quest.6F709652A2B88C78.quest_desc: ["The energy transmitter provides power to blocks within it's working range, it can only accept power from the bottom."]
 	quest.6F71FD826C29C31A.quest_desc: ["This one might be new to ones returning from earlier versions. By using a turtle egg on a spawner, it will only spawn in baby versions of the mobs in it. This only works with Vanilla baby versions of mobs, not modded."]
 	quest.6F71FD826C29C31A.title: "Youthful"
-	quest.6F76DA3BBAE8337B.quest_desc: ["The greatest Armor we can get from &6&lAllTheModium&r, &5Unobtainium&r! \\n\\nNow with 100% Knockback Resistance and higher stats everywhere! \\n\\nAlso needs &3Vibranium Armor&r to make it."]
+	quest.6F76DA3BBAE8337B.quest_desc: ["The greatest Armor we can get from &6&lAllthemodium&r, &5Unobtainium&r! \\n\\nNow with 100% Knockback Resistance and higher stats everywhere! \\n\\nAlso needs &3Vibranium Armor&r to make it."]
 	quest.6F76DA3BBAE8337B.quest_subtitle: "40"
 	quest.6F76DA3BBAE8337B.title: "&5Unobtainium Armor"
 	quest.6F7AC41B703028CC.quest_subtitle: "Silver + Copper"
@@ -11361,7 +11361,7 @@
 		"- Night Vision"
 	]
 	quest.7154D73516548149.quest_desc: ["&6&lAllthemodium&r is a mod added specifically by the &6AllTheMods Team&r to add more content after Netherite! \\n\\nYou'll need to adventure through it to get some Items needed for the &6&lATM Star&r. \\n\\nThere is a Quest page now that you can follow for it!"]
-	quest.7154D73516548149.title: "&l&6AllTheModium"
+	quest.7154D73516548149.title: "&l&6Allthemodium"
 	quest.71581992E8E4C43E.quest_desc: ["Throw a few &8Wither Skeleton Skulls&r and an &dAbjuration Essence&r to make a &8Wither &3Glyph&r! \\n\\nIf it didn't work you might need more &aEXP&r."]
 	quest.71581992E8E4C43E.title: "&3Glyph of &8Wither"
 	quest.715B86DC82EA636B.quest_desc: [
@@ -11556,7 +11556,7 @@
 	quest.72DB967E59EEA729.title: "&3&lGlassential&r"
 	quest.72DC025BC059DF96.quest_desc: ["Mixing &6Nitric Acid&r with &cSulfuric Acid&r makes a &eNitration Mixture&r"]
 	quest.72DCE154E1714890.quest_desc: ["The &n&5Saw&r will harvest trees in front of it. It can also be used as a Sawmill. If it has a connected inventory, the items will be stored in it."]
-	quest.72DDA413D73E3235.quest_desc: ["Much higher stats in everything with the next in line for &6&lAllTheModium&r Armors, &3Vibranium&r! \\n\\nYou will need &6AllTheModium Armor&r to create it."]
+	quest.72DDA413D73E3235.quest_desc: ["Much higher stats in everything with the next in line for &6&lAllthemodium&r Armors, &3Vibranium&r! \\n\\nYou will need &6Allthemodium Armor&r to create it."]
 	quest.72DDA413D73E3235.quest_subtitle: "32"
 	quest.72DDA413D73E3235.title: "&3Vibranium Armor"
 	quest.72DEF9BA758BCDC0.quest_desc: ["Once the ritual has started you will notice the Lake being made. It will grow to about a 20x20 block area full of murky water. The Murky Water will not kill you unless you forget to go for air."]
@@ -11911,7 +11911,7 @@
 	quest.7666D2DA3D0C3F00.quest_desc: ["The ZPM Mixer is needed to craft the Uranium Rhodium Dinaquadide that we need for our Fusion Reactor Mk.II."]
 	quest.7666D2DA3D0C3F00.quest_subtitle: "Mixin' it up!"
 	quest.766C80E5D7B7A916.quest_subtitle: "Pick one!"
-	quest.766EEB89C6DF3575.quest_desc: ["Eternal Stella can be used to either make an Item Unbreakable by combining it with the Item in a Smithing Table. Or you can use it to craft Alloy Tools! \\n\\nFirst, you'll need a Tier 3 Forge with plenty Materials in it. \\n\\nThen, you'll need 3 Xpetrified Orbs. Which you need to feed a Black Hole Items to get. \\n\\nPlus, a Stellarite Piece which you need to Mine for! And &6AllTheModium Ingot&r which is the same."]
+	quest.766EEB89C6DF3575.quest_desc: ["Eternal Stella can be used to either make an Item Unbreakable by combining it with the Item in a Smithing Table. Or you can use it to craft Alloy Tools! \\n\\nFirst, you'll need a Tier 3 Forge with plenty Materials in it. \\n\\nThen, you'll need 3 Xpetrified Orbs. Which you need to feed a Black Hole Items to get. \\n\\nPlus, a Stellarite Piece which you need to Mine for! And &6Allthemodium Ingot&r which is the same."]
 	quest.7671AFAA1EFD287F.quest_desc: ["You want to slowly automate &bAureal&r for your &6&lForge&r? Then, you'll need 2 &bArcane Crystal Blocks&r, &6Arcane Polished Darkstone&r, and &cMundabitur Dust&r! \\n\\nPlace down the &6Arcane Polished Darkstone&r, then on top of it place both &bArcane Crystal Blocks&r. \\n\\nOnce you get this 1x3x1 Structure, Right Click it with &cMundabitur Dust&r to make the &bObelisk&r! \\n\\nYou can place these, where the Pedestals usually go, in the &6&lForge Multiblock&r in order to automate &bAureal&r!"]
 	quest.7671AFAA1EFD287F.title: "&bArcane Crystal Obelisk"
 	quest.7678B5DD1339833E.quest_desc: ["The Solar Panel generates FE when given direct access to the sun. However, you can use a &7Lens of Ender&r to ignore blocks in its way."]
@@ -12058,7 +12058,7 @@
 		"Wondering why you would use this? Imagine having a Builder or Quarry pump Silk-Touched Ores into your system. You can have a Constructor place these ores, then a Destructor with Fortune on it to break it for even more raw ores."
 	]
 	quest.787415570026FFAA.title: "Destructor Upgrade"
-	quest.7878F190BC8ADC82.quest_desc: ["The best of the best. From Diamonds, to the Nether Star, to AllTheModium. This Rod finds only the best Items!"]
+	quest.7878F190BC8ADC82.quest_desc: ["The best of the best. From Diamonds, to the Nether Star, to Allthemodium. This Rod finds only the best Items!"]
 	quest.787E714014EC2C02.quest_subtitle: "Tier: &63"
 	quest.78840993C7832E89.quest_desc: [
 		"Valid Upgrades:"
@@ -12782,7 +12782,7 @@
 	quest.7F2D696AC9F4C4E4.quest_desc: ["'&bMirror Mirror&r on the wall how do I get back to my Respawn Point from my travels?' \\n \\n'After setting the &bMagic Mirror&r to a Bed by right clicking with it, you can hold right click for the &bMagic Mirror&r to teleport you back to your bed!' \\n \\n'Thank you &bMirror&r!'"]
 	quest.7F2D696AC9F4C4E4.quest_subtitle: "Found in Mineshafts or Strongholds"
 	quest.7F2D696AC9F4C4E4.title: "&bMagic Mirror"
-	quest.7F3B96033AB7A21E.title: "AllTheModium Apple"
+	quest.7F3B96033AB7A21E.title: "Allthemodium Apple"
 	quest.7F4963FCAE5337EC.quest_desc: ["Because just fighting the &b&lIgnis&r isn't hard enough, you'll have to fight the &bIgnited Revenant&r first to get &bBurning Ashes&r. \\n\\nOnce you have them, use them on the Altar of Fire to summon the &b&lIgnis&r."]
 	quest.7F4963FCAE5337EC.quest_subtitle: "Relighting the Ignis"
 	quest.7F4963FCAE5337EC.title: "&bBurning Ashes"
@@ -12838,7 +12838,7 @@
 	quest.7FA79ED5DABCF998.quest_subtitle: "Mix it up!"
 	quest.7FA85713C86166DA.quest_desc: ["Allows you to access your fluid grid wirelessly."]
 	quest.7FA85713C86166DA.title: "Wireless Fluid Grid"
-	quest.7FABB77A60E7962C.quest_desc: ["By infusing Obsidian with &bDiamonds&r we can get Refined Obsidian Dust! \\n\\nThen, we can compress &7Osmium&r into it to get it in Ingot form. \\n\\nAfter that, we can turn those Ingots into Armor with better stats than even &6AllTheModium Armor&r!"]
+	quest.7FABB77A60E7962C.quest_desc: ["By infusing Obsidian with &bDiamonds&r we can get Refined Obsidian Dust! \\n\\nThen, we can compress &7Osmium&r into it to get it in Ingot form. \\n\\nAfter that, we can turn those Ingots into Armor with better stats than even &6Allthemodium Armor&r!"]
 	quest.7FABB77A60E7962C.quest_subtitle: "31"
 	quest.7FABB77A60E7962C.title: "&5Refined Obsidian Armor"
 	quest.7FB12EC3A5888123.quest_desc: ["The &3Tube Junction&r gives you more control over the transportation of your pressure by allowing you to move your Pressure Tubes in more directions."]


### PR DESCRIPTION
- Reimplement grammar and spelling fixes in Apothic Enchanting quests from #1651 that at some point got overwritten and add new fixes (spelling and "Emerald Generator" quest accedentally being renamed "Emerald Furnace")
- Fix Allthemodium (official capitalization) incorrectly being capitalized as AllTheModium in quest descriptions
- Fix Forbidden & Arcanus missing "&" in some places in the quest book

This is an updated version of my previously closed PR #1983, which includes updated versions of those previous commits to not affect any quest book changes made since that PR (mainly merge conflict fixes to avoid removing any quest book text formatting codes added since then that would have accidentally been removed by my commits as assumed intentional removals).