### PR TITLE
Occultism Questline Rework

### DIFF
--- a/config/ftbquests/quests/chapters/occultism.snbt
+++ b/config/ftbquests/quests/chapters/occultism.snbt
@@ -15,8 +15,8 @@
 			order: -1
 			rotation: 0.0d
 			width: 5.0d
-			x: 12.5d
-			y: 0.0d
+			x: 3.0d
+			y: 8.0d
 		}
 		{
 			color: 16711680
@@ -24,8 +24,8 @@
 			image: "occultism:textures/gui/book/robe.png"
 			rotation: 0.0d
 			width: 1.0d
-			x: 11.0d
-			y: 2.0d
+			x: 1.3571428571428399d
+			y: 10.285714285714242d
 		}
 		{
 			color: 16711680
@@ -33,8 +33,8 @@
 			image: "occultism:textures/gui/book/robe.png"
 			rotation: 0.0d
 			width: 1.0d
-			x: 13.95d
-			y: 2.0d
+			x: 4.642857142857125d
+			y: 10.285714285714242d
 		}
 		{
 			color: 16711680
@@ -42,8 +42,8 @@
 			image: "occultism:textures/gui/book/robe.png"
 			rotation: 0.0d
 			width: 1.0d
-			x: 15.0d
-			y: -0.5d
+			x: 5.5d
+			y: 7.5d
 		}
 		{
 			color: 16711680
@@ -51,8 +51,8 @@
 			image: "occultism:textures/gui/book/robe.png"
 			rotation: 0.0d
 			width: 1.0d
-			x: 10.0d
-			y: -0.5d
+			x: 0.5d
+			y: 7.5d
 		}
 		{
 			color: 16711680
@@ -60,8 +60,8 @@
 			image: "occultism:textures/gui/book/robe.png"
 			rotation: 0.0d
 			width: 1.0d
-			x: 12.5d
-			y: -2.5d
+			x: 3.0d
+			y: 5.5d
 		}
 		{
 			color: 255
@@ -69,8 +69,8 @@
 			image: "ftbquests:tasks/input_only"
 			rotation: 45.0d
 			width: 2.0d
-			x: 12.5d
-			y: 0.0d
+			x: 3.0d
+			y: 8.0d
 		}
 		{
 			color: 255
@@ -79,8 +79,8 @@
 			order: -1
 			rotation: -30.0d
 			width: 2.0d
-			x: 9.5d
-			y: 5.5d
+			x: 14.0d
+			y: 3.0d
 		}
 		{
 			color: 16711680
@@ -89,24 +89,24 @@
 			order: -1
 			rotation: 90.0d
 			width: 2.0d
-			x: 15.5d
-			y: 5.5d
+			x: 8.0d
+			y: 10.5d
 		}
 		{
 			height: 1.0d
 			image: "occultism:textures/gui/book/familiar_shub_niggurath.png"
 			rotation: 0.0d
 			width: 1.0d
-			x: 13.5d
-			y: 5.0d
+			x: 9.0d
+			y: 7.0d
 		}
 		{
 			height: 1.0d
 			image: "occultism:textures/gui/book/otherworld_bird.png"
 			rotation: 0.0d
 			width: 1.0d
-			x: 11.5d
-			y: 5.0d
+			x: 7.0d
+			y: 7.0d
 		}
 		{
 			alpha: 150
@@ -114,24 +114,24 @@
 			image: "occultism:block/stable_wormhole_frame"
 			rotation: 0.0d
 			width: 2.0d
-			x: 12.5d
-			y: 9.5d
+			x: 22.5d
+			y: 3.5d
 		}
 		{
 			height: 2.0d
 			image: "occultism:item/divination_rod/divination_rod_animation"
 			rotation: -45.0d
 			width: 2.0d
-			x: 12.5d
-			y: 14.0d
+			x: 18.0d
+			y: 15.5d
 		}
 		{
 			height: 0.5d
 			image: "occultism:block/chalk_glyph/0"
 			rotation: 0.0d
 			width: 0.5d
-			x: 10.5d
-			y: 1.0d
+			x: 1.0d
+			y: 9.0d
 		}
 		{
 			color: 6111187
@@ -139,8 +139,8 @@
 			image: "occultism:block/chalk_glyph/11"
 			rotation: 0.0d
 			width: 0.5d
-			x: 14.5d
-			y: 1.0d
+			x: 5.0d
+			y: 9.0d
 		}
 		{
 			color: 16711680
@@ -148,8 +148,8 @@
 			image: "occultism:block/chalk_glyph/12"
 			rotation: 0.0d
 			width: 0.5d
-			x: 14.0d
-			y: -1.5d
+			x: 4.5d
+			y: 6.5d
 		}
 		{
 			color: 16766720
@@ -157,32 +157,32 @@
 			image: "occultism:block/chalk_glyph/4"
 			rotation: 0.0d
 			width: 0.5d
-			x: 11.0d
-			y: -1.5d
+			x: 1.5d
+			y: 6.5d
 		}
 		{
 			height: 3.0d
 			image: "occultism:textures/gui/book/familiar_beholder.png"
 			rotation: 0.0d
 			width: 3.0d
-			x: 16.5d
-			y: 12.5d
+			x: 23.071428571428527d
+			y: 13.678571428571423d
 		}
 		{
 			height: 3.0d
 			image: "occultism:textures/gui/book/familiar_headless_ratman.png"
 			rotation: 0.0d
 			width: 3.0d
-			x: 8.5d
-			y: 12.5d
+			x: 13.5d
+			y: 13.5d
 		}
 		{
 			height: 3.0d
 			image: "occultism:textures/gui/book/infusion.png"
 			rotation: 0.0d
 			width: 3.0d
-			x: 0.0d
-			y: 0.0d
+			x: 2.0d
+			y: 3.0d
 		}
 		{
 			alpha: 100
@@ -191,7 +191,7 @@
 			rotation: 45.0d
 			width: 1.25d
 			x: 8.0d
-			y: 0.0d
+			y: 3.0d
 		}
 		{
 			alpha: 150
@@ -201,15 +201,15 @@
 			rotation: 45.0d
 			width: 1.5d
 			x: 8.0d
-			y: 0.0d
+			y: 3.0d
 		}
 		{
 			height: 9.0d
 			image: "atm:textures/questpics/occultism/maridlogo.png"
 			rotation: 0.0d
 			width: 6.0d
-			x: 1.0d
-			y: 7.0d
+			x: -3.0d
+			y: 8.0d
 		}
 		{
 			color: 16766720
@@ -217,32 +217,42 @@
 			image: "occultism:block/chalk_glyph/8"
 			rotation: 0.0d
 			width: 0.5d
-			x: 12.5d
-			y: 2.5d
+			x: 3.0d
+			y: 10.5d
 		}
 		{
 			height: 0.3d
 			image: "allthetweaks:item/atm_star"
 			rotation: 0.0d
 			width: 0.3d
-			x: 7.0d
-			y: 4.4d
+			x: 13.5d
+			y: 2.5d
 		}
 		{
 			height: 3.0d
 			image: "atm:textures/questpics/occultism/occultism_title.png"
 			rotation: 0.0d
 			width: 8.4d
-			x: 13.0d
-			y: -4.0d
+			x: 17.0d
+			y: 0.0d
 		}
 		{
 			height: 3.0d
 			image: "atm:textures/questpics/occultism/occultism_logo.png"
 			rotation: 0.0d
 			width: 3.0d
-			x: 12.5d
-			y: 6.5d
+			x: 8.0d
+			y: 8.0d
+		}
+		{
+			color: 255
+			height: 2.0d
+			image: "occultism:textures/gui/book/summoning.png"
+			order: -1
+			rotation: -30.0d
+			width: 2.0d
+			x: 38.0d
+			y: 5.0d
 		}
 	]
 	order_index: 6
@@ -269,8 +279,8 @@
 				item: { count: 1, id: "occultism:datura_seeds" }
 				type: "item"
 			}]
-			x: 0.0d
-			y: 0.0d
+			x: 2.0d
+			y: 3.0d
 		}
 		{
 			dependencies: ["5316DF321B45D2CA"]
@@ -286,11 +296,11 @@
 				item: { count: 1, id: "occultism:dictionary_of_spirits" }
 				type: "item"
 			}]
-			x: 2.0d
-			y: 0.0d
+			x: 4.0d
+			y: 2.0d
 		}
 		{
-			dependencies: ["6C1BBA559963B3DF"]
+			dependencies: ["5316DF321B45D2CA"]
 			id: "47358ADC1470C82A"
 			rewards: [{
 				id: "3BB86ECD39545201"
@@ -303,10 +313,13 @@
 				type: "item"
 			}]
 			x: 4.0d
-			y: 0.0d
+			y: 4.0d
 		}
 		{
-			dependencies: ["47358ADC1470C82A"]
+			dependencies: [
+				"47358ADC1470C82A"
+				"6C1BBA559963B3DF"
+			]
 			icon: {
 				components: {
 					"ftbquests:icon": "occultism:block/spirit_fire_0"
@@ -339,7 +352,7 @@
 				type: "item"
 			}]
 			x: 6.0d
-			y: 0.0d
+			y: 3.0d
 		}
 		{
 			dependencies: ["3D41D0092D94636B"]
@@ -379,11 +392,10 @@
 				}
 			]
 			x: 8.0d
-			y: 0.0d
+			y: 3.0d
 		}
 		{
-			dependencies: ["4C873491F6F0FFAF"]
-			hide_dependency_lines: true
+			dependencies: ["4DF0D7B85065ADC9"]
 			id: "6581D4AF1A6DE230"
 			shape: "diamond"
 			tasks: [
@@ -400,11 +412,11 @@
 					type: "item"
 				}
 			]
-			x: 13.5d
-			y: -1.0d
+			x: 2.0d
+			y: 7.0d
 		}
 		{
-			dependencies: ["4C873491F6F0FFAF"]
+			dependencies: ["5ACE97EE75813006"]
 			hide_dependency_lines: true
 			id: "1B5177A774FCEF64"
 			min_width: 350
@@ -426,11 +438,11 @@
 					type: "item"
 				}
 			]
-			x: 11.5d
-			y: 1.0d
+			x: 2.0d
+			y: 9.0d
 		}
 		{
-			dependencies: ["4C873491F6F0FFAF"]
+			dependencies: ["5ACE97EE75813006"]
 			hide_dependency_lines: true
 			id: "7F09F8F98C13F11B"
 			shape: "diamond"
@@ -447,11 +459,11 @@
 					type: "item"
 				}
 			]
-			x: 13.5d
-			y: 1.0d
+			x: 4.0d
+			y: 9.0d
 		}
 		{
-			dependencies: ["4C873491F6F0FFAF"]
+			dependencies: ["5ACE97EE75813006"]
 			hide_dependency_lines: true
 			id: "0B3EA604C5172D98"
 			shape: "diamond"
@@ -467,8 +479,8 @@
 					type: "item"
 				}
 			]
-			x: 11.5d
-			y: -1.0d
+			x: 4.0d
+			y: 7.0d
 		}
 		{
 			dependencies: [
@@ -478,10 +490,7 @@
 				"1B5177A774FCEF64"
 			]
 			icon: {
-				components: {
-					"ftbquests:icon": "occultism:block/chalk_glyph/5"
-				}
-				id: "ftbquests:custom_icon"
+				id: "occultism:ritual_dummy/custom_ritual_summon"
 			}
 			id: "4F35D04721DFC9FF"
 			min_width: 300
@@ -519,10 +528,11 @@
 					type: "item"
 				}
 			]
-			x: 12.5d
-			y: 0.0d
+			x: 3.0d
+			y: 8.0d
 		}
 		{
+			dependencies: ["4F35D04721DFC9FF"]
 			id: "1DE0F289821F55D1"
 			rewards: [{
 				id: "1B9CD287CB41E0E8"
@@ -542,58 +552,17 @@
 					item: { count: 1, id: "occultism:chalk_purple_impure" }
 					type: "item"
 				}
-			]
-			x: 12.5d
-			y: 6.5d
-		}
-		{
-			dependencies: ["1DE0F289821F55D1"]
-			icon: {
-				components: {
-					"occultism:spirit_name": "Crosorryn"
-				}
-				id: "occultism:book_of_binding_bound_djinni"
-			}
-			id: "08B1A64B01A8A604"
-			rewards: [{
-				id: "3EE821F59A85DDED"
-				type: "xp"
-				xp: 100
-			}]
-			shape: "diamond"
-			tasks: [
 				{
-					count: 4L
-					id: "6881D81F0E3CF9DC"
-					item: { count: 1, id: "minecraft:soul_sand" }
-					type: "item"
-				}
-				{
-					id: "20DA82068CC27F71"
-					item: { count: 1, id: "minecraft:diamond" }
-					type: "item"
-				}
-				{
-					id: "4D1D4DF4AE382EF5"
-					item: { count: 1, id: "minecraft:copper_ingot" }
-					type: "item"
-				}
-				{
-					id: "68B346594C63FC5E"
-					item: { count: 1, id: "alltheores:silver_ingot" }
-					type: "item"
-				}
-				{
-					id: "594F7571F053C9EB"
-					item: { components: { "occultism:spirit_name": "Fircresryn" }, count: 1, id: "occultism:book_of_binding_bound_djinni" }
+					id: "3E04DC4A0E760083"
+					item: { count: 1, id: "occultism:chalk_light_gray_impure" }
 					type: "item"
 				}
 			]
-			x: 9.5d
-			y: 5.5d
+			x: 8.0d
+			y: 8.0d
 		}
 		{
-			dependencies: ["1DE0F289821F55D1"]
+			dependencies: ["38A1295878B68F83"]
 			icon: {
 				id: "occultism:chalk_red_impure"
 			}
@@ -624,11 +593,12 @@
 					type: "item"
 				}
 			]
-			x: 14.0d
+			x: 20.0d
 			y: 8.0d
 		}
 		{
-			dependencies: ["08B1A64B01A8A604"]
+			dependencies: ["0D18BBB04693885A"]
+			hide_dependent_lines: true
 			id: "666EA8B8F13EB292"
 			rewards: [
 				{
@@ -644,17 +614,17 @@
 				}
 			]
 			shape: "hexagon"
-			size: 2.0d
+			size: 1.0d
 			tasks: [{
 				id: "1E44A3F521ED5DFC"
 				item: { count: 1, id: "occultism:soul_gem" }
 				type: "item"
 			}]
-			x: 7.0d
-			y: 5.5d
+			x: 14.0d
+			y: 3.0d
 		}
 		{
-			dependencies: ["1DE0F289821F55D1"]
+			dependencies: ["39647A2473F6F7D7"]
 			id: "2A5004EB99AE4F96"
 			rewards: [
 				{
@@ -666,7 +636,7 @@
 				{
 					id: "66AF59413C4ADCF3"
 					type: "xp"
-					xp: 50
+					xp: 100
 				}
 			]
 			tasks: [{
@@ -674,37 +644,11 @@
 				item: { count: 1, id: "occultism:otherworld_goggles" }
 				type: "item"
 			}]
-			x: 11.0d
-			y: 8.0d
+			x: 11.5d
+			y: 5.0d
 		}
 		{
-			dependencies: ["2A5004EB99AE4F96"]
-			id: "686AEC3EF1140D15"
-			rewards: [
-				{
-					exclude_from_claim_all: true
-					id: "0905ED561E579042"
-					table_id: 487623848494439020L
-					type: "loot"
-				}
-				{
-					id: "26FF1D11583ADA23"
-					type: "xp"
-					xp: 50
-				}
-			]
-			shape: "square"
-			size: 1.25d
-			tasks: [{
-				id: "73EA231C66874BB0"
-				item: { count: 1, id: "occultism:infused_pickaxe" }
-				type: "item"
-			}]
-			x: 9.5d
-			y: 9.5d
-		}
-		{
-			dependencies: ["686AEC3EF1140D15"]
+			dependencies: ["2A3683BF7E50EF83"]
 			id: "33106E24A3B5DDD8"
 			min_width: 450
 			rewards: [{
@@ -717,8 +661,8 @@
 				item: { count: 1, id: "occultism:iesnium_ore" }
 				type: "item"
 			}]
-			x: 11.0d
-			y: 11.0d
+			x: 17.0d
+			y: 4.0d
 		}
 		{
 			dependencies: ["33106E24A3B5DDD8"]
@@ -741,54 +685,14 @@
 				item: { count: 1, id: "occultism:iesnium_pickaxe" }
 				type: "item"
 			}]
-			x: 12.5d
-			y: 12.5d
-		}
-		{
-			dependencies: [
-				"57282D7E31EE61EE"
-				"145C8235BCCB9BA8"
-			]
-			icon: {
-				components: {
-					"occultism:spirit_name": "Merrymdor"
-				}
-				id: "occultism:book_of_binding_bound_marid"
-			}
-			id: "676BC41C19BEF1FC"
-			progression_mode: "linear"
-			rewards: [
-				{
-					exclude_from_claim_all: true
-					id: "4381289734981296"
-					table_id: 5564196992594175882L
-					type: "loot"
-				}
-				{
-					id: "29200B3A1B0AC9D1"
-					type: "xp"
-					xp: 100
-				}
-			]
-			shape: "square"
-			size: 1.25d
-			tasks: [
-				{
-					id: "5E80B6869FE42D9F"
-					item: { count: 1, id: "occultism:iesnium_block" }
-					type: "item"
-				}
-				{
-					id: "73801C9489E0E797"
-					item: { components: { "occultism:spirit_name": "Einvonddrin" }, count: 1, id: "occultism:book_of_binding_bound_marid" }
-					type: "item"
-				}
-			]
-			x: 15.5d
-			y: 9.5d
+			x: 20.0d
+			y: 3.5d
 		}
 		{
 			dependencies: ["57282D7E31EE61EE"]
+			icon: {
+				id: "occultism:dimensional_mineshaft"
+			}
 			id: "172D2A634E849562"
 			min_width: 350
 			rewards: [{
@@ -805,13 +709,13 @@
 					type: "item"
 				}
 				{
-					id: "51F776CF868BABEF"
-					item: { components: { "ftbfiltersystem:filter": "or(item_tag(occultism:miners/ores))" }, count: 1, id: "ftbfiltersystem:smart_filter" }
+					id: "53DE943DF951696B"
+					item: { components: { "ftbfiltersystem:filter": "ftbfiltersystem:item_tag(occultism:miners/ores)" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 					type: "item"
 				}
 			]
-			x: 12.5d
-			y: 9.5d
+			x: 22.5d
+			y: 3.5d
 		}
 		{
 			dependencies: ["1DE0F289821F55D1"]
@@ -847,11 +751,12 @@
 					type: "item"
 				}
 			]
-			x: 15.5d
-			y: 5.5d
+			x: 8.0d
+			y: 10.5d
 		}
 		{
 			dependencies: ["6CC5FE34778F0DFA"]
+			hide_dependent_lines: true
 			id: "42F50CE7FE715583"
 			min_width: 300
 			rewards: [
@@ -874,11 +779,12 @@
 				item: { components: { "ftbfiltersystem:filter": "or(item(occultism:storage_stabilizer_tier1)item(occultism:storage_stabilizer_tier2)item(occultism:storage_stabilizer_tier3)item(occultism:storage_stabilizer_tier4))" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 				type: "item"
 			}]
-			x: 18.0d
-			y: 5.5d
+			x: 8.0d
+			y: 14.0d
 		}
 		{
-			dependencies: ["3D41D0092D94636B"]
+			dependencies: ["4C873491F6F0FFAF"]
+			hide_dependency_lines: false
 			id: "78ECC28DD4BA9696"
 			rewards: [{
 				id: "755329C134364BB8"
@@ -890,12 +796,13 @@
 				item: { count: 1, id: "occultism:divination_rod" }
 				type: "item"
 			}]
-			x: 6.0d
-			y: -1.5d
+			x: 8.0d
+			y: 1.0d
 		}
 		{
 			dependencies: ["6CC5FE34778F0DFA"]
 			id: "5831B3192C0E8C56"
+			optional: true
 			rewards: [
 				{
 					exclude_from_claim_all: true
@@ -921,11 +828,11 @@
 					type: "item"
 				}
 			]
-			x: 16.5d
-			y: 7.0d
+			x: 6.5d
+			y: 11.5d
 		}
 		{
-			dependencies: ["08B1A64B01A8A604"]
+			dependencies: ["5ACE97EE75813006"]
 			icon: {
 				components: {
 					"ftbquests:icon": "occultism:textures/gui/book/familiar_headless_ratman.png"
@@ -933,6 +840,7 @@
 				id: "ftbquests:custom_icon"
 			}
 			id: "7F59941D62E672B0"
+			optional: true
 			rewards: [{
 				id: "1FEDC70622D3F66B"
 				type: "xp"
@@ -942,8 +850,8 @@
 				id: "6C3887D42B6B2122"
 				type: "checkmark"
 			}]
-			x: 8.5d
-			y: 7.0d
+			x: 10.5d
+			y: 1.0d
 		}
 		{
 			id: "6CCDEEDA2C99DA66"
@@ -960,8 +868,894 @@
 					type: "checkmark"
 				}
 			]
-			x: 2.0d
-			y: -1.5d
+			x: 0.5d
+			y: 0.5d
+		}
+		{
+			dependencies: ["1DE0F289821F55D1"]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_craft"
+			}
+			id: "39647A2473F6F7D7"
+			min_width: 300
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [{
+				id: "610306AAA51D5967"
+				type: "checkmark"
+			}]
+			x: 10.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["5ACE97EE75813006"]
+			hide_dependency_lines: true
+			id: "4DF0D7B85065ADC9"
+			tasks: [{
+				id: "630455630821CAB0"
+				item: { count: 1, id: "occultism:butcher_knife" }
+				type: "item"
+			}]
+			x: 1.0d
+			y: 6.0d
+		}
+		{
+			dependencies: ["39647A2473F6F7D7"]
+			icon: {
+				id: "occultism:chalk_lime_impure"
+			}
+			id: "30C5B597610F4AFB"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "3B1B9DB617500BAA"
+					table_id: 487623848494439020L
+					type: "loot"
+				}
+				{
+					id: "1ACB00A8A96B37B0"
+					type: "xp"
+					xp: 50
+				}
+			]
+			tasks: [
+				{
+					id: "308ADBEA527AF653"
+					item: { count: 1, id: "occultism:research_fragment_dust" }
+					type: "item"
+				}
+				{
+					id: "0C8EA5B6F92B41B7"
+					item: { count: 1, id: "occultism:chalk_lime_impure" }
+					type: "item"
+				}
+			]
+			x: 12.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["30C5B597610F4AFB"]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_possess"
+			}
+			id: "0BD6365534BF04D5"
+			min_width: 300
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [{
+				id: "5E0DC5327BAE3754"
+				type: "checkmark"
+			}]
+			x: 14.0d
+			y: 9.0d
+		}
+		{
+			dependencies: ["0BD6365534BF04D5"]
+			icon: {
+				id: "occultism:chalk_orange_impure"
+			}
+			id: "74130EB1E4B8586D"
+			tasks: [
+				{
+					id: "56B5E2D58E61A670"
+					item: { count: 1, id: "occultism:cursed_honey" }
+					type: "item"
+				}
+				{
+					id: "7CC5188C1D471B63"
+					item: { count: 1, id: "occultism:chalk_orange_impure" }
+					type: "item"
+				}
+			]
+			x: 16.0d
+			y: 9.5d
+		}
+		{
+			dependencies: [
+				"6FEED25FFAC4101F"
+				"74130EB1E4B8586D"
+			]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_summon"
+			}
+			id: "38A1295878B68F83"
+			min_width: 300
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [{
+				id: "45B6CDFD71466E08"
+				type: "checkmark"
+			}]
+			x: 18.0d
+			y: 7.0d
+		}
+		{
+			dependencies: ["30C5B597610F4AFB"]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_craft"
+			}
+			id: "0D18BBB04693885A"
+			min_width: 300
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [{
+				id: "798E453B4C59964C"
+				type: "checkmark"
+			}]
+			x: 14.0d
+			y: 7.0d
+		}
+		{
+			dependencies: ["0D18BBB04693885A"]
+			icon: {
+				id: "occultism:chalk_gray_impure"
+			}
+			id: "6FEED25FFAC4101F"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "373390521D12FAFF"
+					table_id: 487623848494439020L
+					type: "loot"
+				}
+				{
+					id: "172458963B35A871"
+					type: "xp"
+					xp: 50
+				}
+			]
+			tasks: [
+				{
+					id: "6BCAF5C014C9B8CD"
+					item: { count: 1, id: "occultism:gray_paste" }
+					type: "item"
+				}
+				{
+					id: "4A9046ADC251E85F"
+					item: { count: 1, id: "occultism:chalk_gray_impure" }
+					type: "item"
+				}
+			]
+			x: 16.0d
+			y: 6.5d
+		}
+		{
+			dependencies: ["39647A2473F6F7D7"]
+			icon: {
+				id: "occultism:chalk_green_impure"
+			}
+			id: "11A0593C0E2E6A35"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "71825C8D99ADBB2A"
+					table_id: 487623848494439020L
+					type: "loot"
+				}
+				{
+					id: "40665ED40AD50F96"
+					type: "xp"
+					xp: 50
+				}
+			]
+			tasks: [
+				{
+					id: "3469624E1932FA86"
+					item: { count: 1, id: "occultism:nature_paste" }
+					type: "item"
+				}
+				{
+					id: "28577F9A1DE33F02"
+					item: { count: 1, id: "occultism:chalk_green_impure" }
+					type: "item"
+				}
+			]
+			x: 11.5d
+			y: 11.0d
+		}
+		{
+			dependencies: [
+				"2A5004EB99AE4F96"
+				"0D18BBB04693885A"
+			]
+			id: "2A3683BF7E50EF83"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "76340CDC577FD688"
+					table_id: 487623848494439020L
+					type: "loot"
+				}
+				{
+					id: "53894207A33668FB"
+					type: "xp"
+					xp: 50
+				}
+			]
+			tasks: [{
+				id: "02718432862B0267"
+				item: { count: 1, id: "occultism:infused_pickaxe" }
+				type: "item"
+			}]
+			x: 14.0d
+			y: 4.5d
+		}
+		{
+			dependencies: ["0D18BBB04693885A"]
+			id: "5AE80FF518B1BBA6"
+			optional: true
+			rewards: [{
+				id: "0C4945F14A4E9AD2"
+				type: "xp"
+				xp: 75
+			}]
+			tasks: [{
+				id: "12713B611A3AA745"
+				item: { count: 1, id: "occultism:ritual_satchel_t1" }
+				type: "item"
+			}]
+			x: 15.0d
+			y: 5.5d
+		}
+		{
+			dependencies: ["0D18BBB04693885A"]
+			icon: {
+				components: {
+					"ftbquests:icon": "occultism:block/chalk_glyph/0"
+				}
+				id: "ftbquests:custom_icon"
+			}
+			id: "61999669BDE127F9"
+			optional: true
+			tasks: [{
+				id: "2448345116BDC7C6"
+				type: "checkmark"
+			}]
+			x: 13.0d
+			y: 5.5d
+		}
+		{
+			dependencies: ["145C8235BCCB9BA8"]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_craft"
+			}
+			id: "2960FFE0C53DFEB1"
+			min_width: 300
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [{
+				id: "30DBC2F3438C0884"
+				type: "checkmark"
+			}]
+			x: 22.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["2960FFE0C53DFEB1"]
+			icon: {
+				id: "occultism:chalk_black_impure"
+			}
+			id: "367E891A50991436"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "6FE0A14BDB35C40C"
+					table_id: 487623848494439020L
+					type: "loot"
+				}
+				{
+					id: "1D1E44C1ED4E349E"
+					type: "xp"
+					xp: 50
+				}
+			]
+			tasks: [
+				{
+					id: "43AD1E4B8B90C32B"
+					item: { count: 1, id: "occultism:witherite_dust" }
+					type: "item"
+				}
+				{
+					id: "7C5A8F34E6CE5B45"
+					item: { count: 1, id: "occultism:chalk_black_impure" }
+					type: "item"
+				}
+			]
+			x: 24.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["2960FFE0C53DFEB1"]
+			id: "4CE571F942461909"
+			optional: true
+			rewards: [{
+				id: "4EBE9A3D181D1F8D"
+				type: "xp"
+				xp: 100
+			}]
+			tasks: [{
+				id: "002AC613F837D5B5"
+				item: { count: 1, id: "occultism:ritual_satchel_t2" }
+				type: "item"
+			}]
+			x: 21.0d
+			y: 6.0d
+		}
+		{
+			dependencies: ["2960FFE0C53DFEB1"]
+			icon: {
+				components: {
+					"ftbquests:icon": "occultism:block/chalk_glyph/7"
+				}
+				id: "ftbquests:custom_icon"
+			}
+			id: "1848F431D0380DA9"
+			optional: true
+			tasks: [{
+				id: "7DA8A385C843AD5F"
+				type: "checkmark"
+			}]
+			x: 23.0d
+			y: 6.0d
+		}
+		{
+			dependencies: [
+				"74130EB1E4B8586D"
+				"6FEED25FFAC4101F"
+			]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_possess"
+			}
+			id: "429B5A81DF6C43FE"
+			min_width: 300
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [{
+				id: "0FB5D8A7798D9F3F"
+				item: { count: 1, id: "occultism:ritual_dummy/possess_hoglin" }
+				type: "item"
+			}]
+			x: 18.0d
+			y: 9.0d
+		}
+		{
+			dependencies: ["429B5A81DF6C43FE"]
+			icon: {
+				id: "occultism:chalk_pink_impure"
+			}
+			id: "2E68E1D96B25336D"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "5B284E8F9D2E2E51"
+					table_id: 487623848494439020L
+					type: "loot"
+				}
+				{
+					id: "50619186D8DC7176"
+					type: "xp"
+					xp: 50
+				}
+			]
+			tasks: [
+				{
+					count: 3L
+					id: "411F787B683CA921"
+					item: { count: 1, id: "occultism:demonic_meat" }
+					type: "item"
+				}
+				{
+					id: "714891B19615AC21"
+					item: { count: 1, id: "occultism:chalk_pink_impure" }
+					type: "item"
+				}
+			]
+			x: 18.0d
+			y: 11.0d
+		}
+		{
+			dependencies: [
+				"11A0593C0E2E6A35"
+				"2E68E1D96B25336D"
+				"1EB887F8072439A3"
+			]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_misc"
+			}
+			id: "67884BFA27870CCE"
+			min_width: 300
+			shape: "gear"
+			size: 1.5d
+			tasks: [{
+				id: "1BEBE185FBB4969A"
+				type: "checkmark"
+			}]
+			x: 18.0d
+			y: 13.0d
+		}
+		{
+			dependencies: ["367E891A50991436"]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_summon"
+			}
+			id: "53DEA3DFEDC4809E"
+			min_width: 300
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [{
+				id: "72376A8345BC8171"
+				type: "checkmark"
+			}]
+			x: 26.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["53DEA3DFEDC4809E"]
+			icon: {
+				id: "occultism:chalk_blue_impure"
+			}
+			id: "03250A0202C25E80"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "327F077402F22592"
+					table_id: 487623848494439020L
+					type: "loot"
+				}
+				{
+					id: "64999ED05425EAEB"
+					type: "xp"
+					xp: 50
+				}
+			]
+			tasks: [
+				{
+					id: "7BFF993075EFB7B9"
+					item: { count: 1, id: "occultism:marid_essence" }
+					type: "item"
+				}
+				{
+					id: "5CE28B53187E9128"
+					item: { count: 1, id: "occultism:chalk_blue_impure" }
+					type: "item"
+				}
+			]
+			x: 28.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["03250A0202C25E80"]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_summon"
+			}
+			id: "2AD68066C1948C90"
+			min_width: 300
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [{
+				id: "75AC4550E656F013"
+				type: "checkmark"
+			}]
+			x: 29.5d
+			y: 9.5d
+		}
+		{
+			dependencies: ["03250A0202C25E80"]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_possess"
+			}
+			id: "56EC79AF11B0869E"
+			min_width: 300
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [{
+				id: "3A9125CA2A2E8613"
+				type: "checkmark"
+			}]
+			x: 31.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["03250A0202C25E80"]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_craft"
+			}
+			id: "2CF96A264EB5522C"
+			min_width: 300
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [{
+				id: "4E920BF03DC031D0"
+				type: "checkmark"
+			}]
+			x: 29.5d
+			y: 6.5d
+		}
+		{
+			dependencies: ["2AD68066C1948C90"]
+			icon: {
+				id: "occultism:chalk_light_blue_impure"
+			}
+			id: "1EB887F8072439A3"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "639F0D08BE538FE3"
+					table_id: 487623848494439020L
+					type: "loot"
+				}
+				{
+					id: "7E5E9C1DCC125331"
+					type: "xp"
+					xp: 50
+				}
+			]
+			tasks: [
+				{
+					id: "021F29CA7E51BA5F"
+					item: { count: 1, id: "occultism:crushed_ice" }
+					type: "item"
+				}
+				{
+					id: "09AF3B0519418345"
+					item: { count: 1, id: "occultism:crushed_packed_ice" }
+					type: "item"
+				}
+				{
+					id: "5C2F8463520C2BDF"
+					item: { count: 1, id: "occultism:crushed_blue_ice" }
+					type: "item"
+				}
+				{
+					id: "0B04FCA28ECB05DB"
+					item: { count: 1, id: "occultism:chalk_light_blue_impure" }
+					type: "item"
+				}
+			]
+			x: 25.5d
+			y: 11.0d
+		}
+		{
+			dependencies: [
+				"2CF96A264EB5522C"
+				"2AD68066C1948C90"
+			]
+			icon: {
+				id: "occultism:chalk_magenta_impure"
+			}
+			id: "3543563DF036D461"
+			tasks: [
+				{
+					id: "0B0C632E633B60C8"
+					item: { count: 1, id: "occultism:dragonyst_dust" }
+					type: "item"
+				}
+				{
+					id: "2935D5987F62BD6F"
+					item: { count: 1, id: "occultism:chalk_magenta_impure" }
+					type: "item"
+				}
+			]
+			x: 31.0d
+			y: 5.0d
+		}
+		{
+			dependencies: ["2AD68066C1948C90"]
+			icon: {
+				id: "occultism:chalk_cyan_impure"
+			}
+			id: "00A6020BC979947F"
+			tasks: [
+				{
+					id: "453BB853EA9182B1"
+					item: { count: 1, id: "occultism:echo_dust" }
+					type: "item"
+				}
+				{
+					id: "674E6AB8F52A57A0"
+					item: { count: 1, id: "occultism:chalk_cyan_impure" }
+					type: "item"
+				}
+			]
+			x: 31.0d
+			y: 11.0d
+		}
+		{
+			dependencies: ["56EC79AF11B0869E"]
+			icon: {
+				id: "occultism:chalk_brown_impure"
+			}
+			id: "7BCD4A425CF6199B"
+			tasks: [
+				{
+					id: "2BD7510CD96A57ED"
+					item: { count: 1, id: "occultism:cruelty_essence" }
+					type: "item"
+				}
+				{
+					id: "2A59204579B09A8B"
+					item: { count: 1, id: "occultism:chalk_brown_impure" }
+					type: "item"
+				}
+			]
+			x: 33.5d
+			y: 8.0d
+		}
+		{
+			dependencies: [
+				"3543563DF036D461"
+				"7BCD4A425CF6199B"
+				"00A6020BC979947F"
+			]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_misc"
+			}
+			id: "0A25276925EB0CBA"
+			min_width: 300
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "516706F4DCD89A14"
+					table_id: 4196188979167302596L
+					type: "loot"
+				}
+				{
+					id: "7BC9E8E58C40E3CC"
+					type: "xp_levels"
+					xp_levels: 1
+				}
+			]
+			shape: "gear"
+			size: 2.0d
+			tasks: [
+				{
+					id: "313C481463E421F7"
+					item: { count: 1, id: "occultism:chalk_white_impure" }
+					type: "item"
+				}
+				{
+					id: "0DD67B59254DDB95"
+					item: { count: 1, id: "occultism:chalk_light_gray_impure" }
+					type: "item"
+				}
+				{
+					id: "002EA4824248BCD2"
+					item: { count: 1, id: "occultism:chalk_gray_impure" }
+					type: "item"
+				}
+				{
+					id: "1F19833D693F324F"
+					item: { count: 1, id: "occultism:chalk_black_impure" }
+					type: "item"
+				}
+				{
+					id: "0F58A0EAC35E51BB"
+					item: { count: 1, id: "occultism:chalk_brown_impure" }
+					type: "item"
+				}
+				{
+					id: "46E0A7B9A053277D"
+					item: { count: 1, id: "occultism:chalk_red_impure" }
+					type: "item"
+				}
+				{
+					id: "0A4A298A7AA69522"
+					item: { count: 1, id: "occultism:chalk_orange_impure" }
+					type: "item"
+				}
+				{
+					id: "068263DD30A6961D"
+					item: { count: 1, id: "occultism:chalk_yellow_impure" }
+					type: "item"
+				}
+				{
+					id: "0F0619C13F633AC3"
+					item: { count: 1, id: "occultism:chalk_lime_impure" }
+					type: "item"
+				}
+				{
+					id: "279C3E75AA687B08"
+					item: { count: 1, id: "occultism:chalk_green_impure" }
+					type: "item"
+				}
+				{
+					id: "4CDB7E20D683AD29"
+					item: { count: 1, id: "occultism:chalk_green_impure" }
+					type: "item"
+				}
+				{
+					id: "6F7BE78E7C2F1AEC"
+					item: { count: 1, id: "occultism:chalk_cyan_impure" }
+					type: "item"
+				}
+				{
+					id: "0A6AE6AC767FFE65"
+					item: { count: 1, id: "occultism:chalk_light_blue_impure" }
+					type: "item"
+				}
+				{
+					id: "4F9EB45160D4E2A9"
+					item: { count: 1, id: "occultism:chalk_blue_impure" }
+					type: "item"
+				}
+				{
+					id: "5D0C4878FBCE6213"
+					item: { count: 1, id: "occultism:chalk_purple_impure" }
+					type: "item"
+				}
+				{
+					id: "6D5EAFADDF110214"
+					item: { count: 1, id: "occultism:chalk_magenta_impure" }
+					type: "item"
+				}
+				{
+					id: "232F31CB4D1351E3"
+					item: { count: 1, id: "occultism:chalk_pink_impure" }
+					type: "item"
+				}
+			]
+			x: 36.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["0A25276925EB0CBA"]
+			id: "690B89D23134B624"
+			require_sequential_tasks: false
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "40582796F09FEC70"
+					table_id: 4196188979167302596L
+					type: "loot"
+				}
+				{
+					id: "364D9D1E440B9756"
+					type: "xp_levels"
+					xp_levels: 1
+				}
+			]
+			tasks: [{
+				id: "687E54A17D6F09AB"
+				item: { count: 1, id: "occultism:chalk_rainbow" }
+				type: "item"
+			}]
+			x: 38.5d
+			y: 8.0d
+		}
+		{
+			dependencies: ["690B89D23134B624"]
+			id: "54378277B8D28B1D"
+			optional: true
+			tasks: [{
+				id: "4A935B03FA1DD7C3"
+				item: { count: 1, id: "occultism:chalk_void" }
+				type: "item"
+			}]
+			x: 41.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["2CF96A264EB5522C"]
+			id: "1BDB369FD243D4C6"
+			min_width: 300
+			shape: "gear"
+			size: 1.25d
+			tasks: [{
+				id: "0210448E8118E45C"
+				item: { count: 1, id: "occultism:iesnium_anvil" }
+				type: "item"
+			}]
+			x: 28.0d
+			y: 5.0d
+		}
+		{
+			dependencies: ["2960FFE0C53DFEB1"]
+			hide_dependent_lines: true
+			id: "6FFFAE334DFAAAAB"
+			rewards: [{
+				id: "5EDBE01DE9B25580"
+				type: "xp"
+				xp: 100
+			}]
+			tasks: [{
+				id: "10037D5225C2D20E"
+				item: { count: 1, id: "occultism:iesnium_sacrificial_bowl" }
+				type: "item"
+			}]
+			x: 22.0d
+			y: 5.0d
+		}
+		{
+			dependencies: [
+				"0A25276925EB0CBA"
+				"666EA8B8F13EB292"
+			]
+			id: "2FD22502E6481269"
+			tasks: [{
+				id: "3F319A5CD7E4E884"
+				item: { count: 1, id: "occultism:trinity_gem" }
+				type: "item"
+			}]
+			x: 38.0d
+			y: 5.0d
+		}
+		{
+			dependencies: [
+				"0A25276925EB0CBA"
+				"6FFFAE334DFAAAAB"
+			]
+			id: "08697EB269B011FD"
+			tasks: [{
+				id: "05A43D4098C30ED1"
+				item: { count: 1, id: "occultism:eldritch_chalice" }
+				type: "item"
+			}]
+			x: 38.0d
+			y: 11.0d
+		}
+		{
+			dependencies: [
+				"2FD22502E6481269"
+				"690B89D23134B624"
+				"08697EB269B011FD"
+				"42F50CE7FE715583"
+			]
+			hide_details_until_startable: true
+			icon: {
+				components: {
+					"ftbquests:icon": "occultism:textures/gui/book/infusion.png"
+				}
+				id: "ftbquests:custom_icon"
+			}
+			id: "29C83B00AC4AFC23"
+			min_width: 300
+			rewards: [{
+				id: "1CA2FF5D585D03DF"
+				type: "xp_levels"
+				xp_levels: 1
+			}]
+			shape: "rsquare"
+			size: 2.5d
+			tasks: [{
+				id: "2B54A5BE4392F79C"
+				type: "checkmark"
+			}]
+			x: 44.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["4C873491F6F0FFAF"]
+			icon: {
+				id: "minecraft:book"
+			}
+			id: "5ACE97EE75813006"
+			min_width: 300
+			tasks: [{
+				id: "348A7E3E3A3D324E"
+				type: "checkmark"
+			}]
+			x: 10.5d
+			y: 3.0d
 		}
 	]
 }


### PR DESCRIPTION
Thanks to TheBedrockMaster for helping me with this.
Please keep in mind that this isn't perfect, and (I don't know of any, I did try to catch them) there may be small spelling errors.
List of changes:
- Rearranged 90% of the existing quests to make the flow more natural/readable
- Renamed a few quests (mainly to add Tools of the Trade: to the beginning of tool quests)
- Deleted some quests and merged their requirements/text/rewards into new quests
- Changed dependencies of certain quests to better fit in with added quests
- Added more requirements to certain quests to better assist players in understanding the mod
- Changed descriptions of several of the existing quests to better assist players in understanding the mod
Added quests:
- The Basics of Rituals
- Tools of the Trade: Butcher's Knife
- Eziveus' Spectral Compulsion
- Lime Chalk
- Green Chalk
- Strigeor's Higher Binding
- Ihagan's Enthrallment
- Chalk Repair
- Tools of the Trade: Ritual Satchel
- Gray Chalk
- Orange Chalk
- Abras' Open Conjure
- Abras' Open Commanding Conjure
- Pink Chalk
- Red Chalk
- Sevira's Permanent Confinement
- Tools of the Trade: Artisanal Ritual Satchel
- Iesnium Sacrificial Bowl
- Repairing Items
- Black Chalk
- Abras' Fortified Conjure
- Blue Chalk
- Uphyxes' Inverted Tower
- Xeovrenth Adjure
- Fatmas' Incentivized Attraction
- Iesnium Anvil
- Magenta Chalk
- Brown Chalk
- Cyan Chalk
- Light Blue Chalk
- Osorin's Unbound Calling
- Ronaza's Contact
- Trinity Gem
- Rainbow Chalk
- Eldritch Chalice
- Void Chalk (optional)
- What's next?
