### PR TITLE
Occultism Questline Rework

### DIFF
--- a/config/ftbquests/quests/chapters/occultism.snbt
+++ b/config/ftbquests/quests/chapters/occultism.snbt
@@ -15,8 +15,8 @@
 			order: -1
 			rotation: 0.0d
 			width: 5.0d
-			x: 12.5d
-			y: 0.0d
+			x: 3.0d
+			y: 8.0d
 		}
 		{
 			color: 16711680
@@ -24,8 +24,8 @@
 			image: "occultism:textures/gui/book/robe.png"
 			rotation: 0.0d
 			width: 1.0d
-			x: 11.0d
-			y: 2.0d
+			x: 1.3571428571428399d
+			y: 10.285714285714242d
 		}
 		{
 			color: 16711680
@@ -33,8 +33,8 @@
 			image: "occultism:textures/gui/book/robe.png"
 			rotation: 0.0d
 			width: 1.0d
-			x: 13.95d
-			y: 2.0d
+			x: 4.642857142857125d
+			y: 10.285714285714242d
 		}
 		{
 			color: 16711680
@@ -42,8 +42,8 @@
 			image: "occultism:textures/gui/book/robe.png"
 			rotation: 0.0d
 			width: 1.0d
-			x: 15.0d
-			y: -0.5d
+			x: 5.5d
+			y: 7.5d
 		}
 		{
 			color: 16711680
@@ -51,8 +51,8 @@
 			image: "occultism:textures/gui/book/robe.png"
 			rotation: 0.0d
 			width: 1.0d
-			x: 10.0d
-			y: -0.5d
+			x: 0.5d
+			y: 7.5d
 		}
 		{
 			color: 16711680
@@ -60,8 +60,8 @@
 			image: "occultism:textures/gui/book/robe.png"
 			rotation: 0.0d
 			width: 1.0d
-			x: 12.5d
-			y: -2.5d
+			x: 3.0d
+			y: 5.5d
 		}
 		{
 			color: 255
@@ -69,8 +69,8 @@
 			image: "ftbquests:tasks/input_only"
 			rotation: 45.0d
 			width: 2.0d
-			x: 12.5d
-			y: 0.0d
+			x: 3.0d
+			y: 8.0d
 		}
 		{
 			color: 255
@@ -79,8 +79,8 @@
 			order: -1
 			rotation: -30.0d
 			width: 2.0d
-			x: 9.5d
-			y: 5.5d
+			x: 14.0d
+			y: 3.0d
 		}
 		{
 			color: 16711680
@@ -89,24 +89,24 @@
 			order: -1
 			rotation: 90.0d
 			width: 2.0d
-			x: 15.5d
-			y: 5.5d
+			x: 8.0d
+			y: 10.5d
 		}
 		{
 			height: 1.0d
 			image: "occultism:textures/gui/book/familiar_shub_niggurath.png"
 			rotation: 0.0d
 			width: 1.0d
-			x: 13.5d
-			y: 5.0d
+			x: 9.0d
+			y: 7.0d
 		}
 		{
 			height: 1.0d
 			image: "occultism:textures/gui/book/otherworld_bird.png"
 			rotation: 0.0d
 			width: 1.0d
-			x: 11.5d
-			y: 5.0d
+			x: 7.0d
+			y: 7.0d
 		}
 		{
 			alpha: 150
@@ -114,24 +114,24 @@
 			image: "occultism:block/stable_wormhole_frame"
 			rotation: 0.0d
 			width: 2.0d
-			x: 12.5d
-			y: 9.5d
+			x: 22.5d
+			y: 3.5d
 		}
 		{
 			height: 2.0d
 			image: "occultism:item/divination_rod/divination_rod_animation"
 			rotation: -45.0d
 			width: 2.0d
-			x: 12.5d
-			y: 14.0d
+			x: 18.0d
+			y: 15.5d
 		}
 		{
 			height: 0.5d
 			image: "occultism:block/chalk_glyph/0"
 			rotation: 0.0d
 			width: 0.5d
-			x: 10.5d
-			y: 1.0d
+			x: 1.0d
+			y: 9.0d
 		}
 		{
 			color: 6111187
@@ -139,8 +139,8 @@
 			image: "occultism:block/chalk_glyph/11"
 			rotation: 0.0d
 			width: 0.5d
-			x: 14.5d
-			y: 1.0d
+			x: 5.0d
+			y: 9.0d
 		}
 		{
 			color: 16711680
@@ -148,8 +148,8 @@
 			image: "occultism:block/chalk_glyph/12"
 			rotation: 0.0d
 			width: 0.5d
-			x: 14.0d
-			y: -1.5d
+			x: 4.5d
+			y: 6.5d
 		}
 		{
 			color: 16766720
@@ -157,32 +157,32 @@
 			image: "occultism:block/chalk_glyph/4"
 			rotation: 0.0d
 			width: 0.5d
-			x: 11.0d
-			y: -1.5d
+			x: 1.5d
+			y: 6.5d
 		}
 		{
 			height: 3.0d
 			image: "occultism:textures/gui/book/familiar_beholder.png"
 			rotation: 0.0d
 			width: 3.0d
-			x: 16.5d
-			y: 12.5d
+			x: 23.071428571428527d
+			y: 13.678571428571423d
 		}
 		{
 			height: 3.0d
 			image: "occultism:textures/gui/book/familiar_headless_ratman.png"
 			rotation: 0.0d
 			width: 3.0d
-			x: 8.5d
-			y: 12.5d
+			x: 13.5d
+			y: 13.5d
 		}
 		{
 			height: 3.0d
 			image: "occultism:textures/gui/book/infusion.png"
 			rotation: 0.0d
 			width: 3.0d
-			x: 0.0d
-			y: 0.0d
+			x: 2.0d
+			y: 3.0d
 		}
 		{
 			alpha: 100
@@ -191,7 +191,7 @@
 			rotation: 45.0d
 			width: 1.25d
 			x: 8.0d
-			y: 0.0d
+			y: 3.0d
 		}
 		{
 			alpha: 150
@@ -201,15 +201,15 @@
 			rotation: 45.0d
 			width: 1.5d
 			x: 8.0d
-			y: 0.0d
+			y: 3.0d
 		}
 		{
 			height: 9.0d
 			image: "atm:textures/questpics/occultism/maridlogo.png"
 			rotation: 0.0d
 			width: 6.0d
-			x: 1.0d
-			y: 7.0d
+			x: -3.0d
+			y: 8.0d
 		}
 		{
 			color: 16766720
@@ -217,32 +217,42 @@
 			image: "occultism:block/chalk_glyph/8"
 			rotation: 0.0d
 			width: 0.5d
-			x: 12.5d
-			y: 2.5d
+			x: 3.0d
+			y: 10.5d
 		}
 		{
 			height: 0.3d
 			image: "allthetweaks:item/atm_star"
 			rotation: 0.0d
 			width: 0.3d
-			x: 7.0d
-			y: 4.4d
+			x: 13.5d
+			y: 2.5d
 		}
 		{
 			height: 3.0d
 			image: "atm:textures/questpics/occultism/occultism_title.png"
 			rotation: 0.0d
 			width: 8.4d
-			x: 13.0d
-			y: -4.0d
+			x: 17.0d
+			y: 0.0d
 		}
 		{
 			height: 3.0d
 			image: "atm:textures/questpics/occultism/occultism_logo.png"
 			rotation: 0.0d
 			width: 3.0d
-			x: 12.5d
-			y: 6.5d
+			x: 8.0d
+			y: 8.0d
+		}
+		{
+			color: 255
+			height: 2.0d
+			image: "occultism:textures/gui/book/summoning.png"
+			order: -1
+			rotation: -30.0d
+			width: 2.0d
+			x: 38.0d
+			y: 5.0d
 		}
 	]
 	order_index: 6
@@ -269,8 +279,8 @@
 				item: { count: 1, id: "occultism:datura_seeds" }
 				type: "item"
 			}]
-			x: 0.0d
-			y: 0.0d
+			x: 2.0d
+			y: 3.0d
 		}
 		{
 			dependencies: ["5316DF321B45D2CA"]
@@ -286,11 +296,11 @@
 				item: { count: 1, id: "occultism:dictionary_of_spirits" }
 				type: "item"
 			}]
-			x: 2.0d
-			y: 0.0d
+			x: 4.0d
+			y: 2.0d
 		}
 		{
-			dependencies: ["6C1BBA559963B3DF"]
+			dependencies: ["5316DF321B45D2CA"]
 			id: "47358ADC1470C82A"
 			rewards: [{
 				id: "3BB86ECD39545201"
@@ -303,10 +313,13 @@
 				type: "item"
 			}]
 			x: 4.0d
-			y: 0.0d
+			y: 4.0d
 		}
 		{
-			dependencies: ["47358ADC1470C82A"]
+			dependencies: [
+				"47358ADC1470C82A"
+				"6C1BBA559963B3DF"
+			]
 			icon: {
 				components: {
 					"ftbquests:icon": "occultism:block/spirit_fire_0"
@@ -339,7 +352,7 @@
 				type: "item"
 			}]
 			x: 6.0d
-			y: 0.0d
+			y: 3.0d
 		}
 		{
 			dependencies: ["3D41D0092D94636B"]
@@ -379,11 +392,10 @@
 				}
 			]
 			x: 8.0d
-			y: 0.0d
+			y: 3.0d
 		}
 		{
-			dependencies: ["4C873491F6F0FFAF"]
-			hide_dependency_lines: true
+			dependencies: ["4DF0D7B85065ADC9"]
 			id: "6581D4AF1A6DE230"
 			shape: "diamond"
 			tasks: [
@@ -400,11 +412,11 @@
 					type: "item"
 				}
 			]
-			x: 13.5d
-			y: -1.0d
+			x: 2.0d
+			y: 7.0d
 		}
 		{
-			dependencies: ["4C873491F6F0FFAF"]
+			dependencies: ["5ACE97EE75813006"]
 			hide_dependency_lines: true
 			id: "1B5177A774FCEF64"
 			min_width: 350
@@ -426,11 +438,11 @@
 					type: "item"
 				}
 			]
-			x: 11.5d
-			y: 1.0d
+			x: 2.0d
+			y: 9.0d
 		}
 		{
-			dependencies: ["4C873491F6F0FFAF"]
+			dependencies: ["5ACE97EE75813006"]
 			hide_dependency_lines: true
 			id: "7F09F8F98C13F11B"
 			shape: "diamond"
@@ -447,11 +459,11 @@
 					type: "item"
 				}
 			]
-			x: 13.5d
-			y: 1.0d
+			x: 4.0d
+			y: 9.0d
 		}
 		{
-			dependencies: ["4C873491F6F0FFAF"]
+			dependencies: ["5ACE97EE75813006"]
 			hide_dependency_lines: true
 			id: "0B3EA604C5172D98"
 			shape: "diamond"
@@ -467,8 +479,8 @@
 					type: "item"
 				}
 			]
-			x: 11.5d
-			y: -1.0d
+			x: 4.0d
+			y: 7.0d
 		}
 		{
 			dependencies: [
@@ -478,10 +490,7 @@
 				"1B5177A774FCEF64"
 			]
 			icon: {
-				components: {
-					"ftbquests:icon": "occultism:block/chalk_glyph/5"
-				}
-				id: "ftbquests:custom_icon"
+				id: "occultism:ritual_dummy/custom_ritual_summon"
 			}
 			id: "4F35D04721DFC9FF"
 			min_width: 300
@@ -519,10 +528,11 @@
 					type: "item"
 				}
 			]
-			x: 12.5d
-			y: 0.0d
+			x: 3.0d
+			y: 8.0d
 		}
 		{
+			dependencies: ["4F35D04721DFC9FF"]
 			id: "1DE0F289821F55D1"
 			rewards: [{
 				id: "1B9CD287CB41E0E8"
@@ -542,58 +552,17 @@
 					item: { count: 1, id: "occultism:chalk_purple_impure" }
 					type: "item"
 				}
-			]
-			x: 12.5d
-			y: 6.5d
-		}
-		{
-			dependencies: ["1DE0F289821F55D1"]
-			icon: {
-				components: {
-					"occultism:spirit_name": "Crosorryn"
-				}
-				id: "occultism:book_of_binding_bound_djinni"
-			}
-			id: "08B1A64B01A8A604"
-			rewards: [{
-				id: "3EE821F59A85DDED"
-				type: "xp"
-				xp: 100
-			}]
-			shape: "diamond"
-			tasks: [
 				{
-					count: 4L
-					id: "6881D81F0E3CF9DC"
-					item: { count: 1, id: "minecraft:soul_sand" }
-					type: "item"
-				}
-				{
-					id: "20DA82068CC27F71"
-					item: { count: 1, id: "minecraft:diamond" }
-					type: "item"
-				}
-				{
-					id: "4D1D4DF4AE382EF5"
-					item: { count: 1, id: "minecraft:copper_ingot" }
-					type: "item"
-				}
-				{
-					id: "68B346594C63FC5E"
-					item: { count: 1, id: "alltheores:silver_ingot" }
-					type: "item"
-				}
-				{
-					id: "594F7571F053C9EB"
-					item: { components: { "occultism:spirit_name": "Fircresryn" }, count: 1, id: "occultism:book_of_binding_bound_djinni" }
+					id: "3E04DC4A0E760083"
+					item: { count: 1, id: "occultism:chalk_light_gray_impure" }
 					type: "item"
 				}
 			]
-			x: 9.5d
-			y: 5.5d
+			x: 8.0d
+			y: 8.0d
 		}
 		{
-			dependencies: ["1DE0F289821F55D1"]
+			dependencies: ["38A1295878B68F83"]
 			icon: {
 				id: "occultism:chalk_red_impure"
 			}
@@ -624,11 +593,12 @@
 					type: "item"
 				}
 			]
-			x: 14.0d
+			x: 20.0d
 			y: 8.0d
 		}
 		{
-			dependencies: ["08B1A64B01A8A604"]
+			dependencies: ["0D18BBB04693885A"]
+			hide_dependent_lines: true
 			id: "666EA8B8F13EB292"
 			rewards: [
 				{
@@ -644,17 +614,17 @@
 				}
 			]
 			shape: "hexagon"
-			size: 2.0d
+			size: 1.0d
 			tasks: [{
 				id: "1E44A3F521ED5DFC"
 				item: { count: 1, id: "occultism:soul_gem" }
 				type: "item"
 			}]
-			x: 7.0d
-			y: 5.5d
+			x: 14.0d
+			y: 3.0d
 		}
 		{
-			dependencies: ["1DE0F289821F55D1"]
+			dependencies: ["39647A2473F6F7D7"]
 			id: "2A5004EB99AE4F96"
 			rewards: [
 				{
@@ -666,7 +636,7 @@
 				{
 					id: "66AF59413C4ADCF3"
 					type: "xp"
-					xp: 50
+					xp: 100
 				}
 			]
 			tasks: [{
@@ -674,37 +644,11 @@
 				item: { count: 1, id: "occultism:otherworld_goggles" }
 				type: "item"
 			}]
-			x: 11.0d
-			y: 8.0d
+			x: 11.5d
+			y: 5.0d
 		}
 		{
-			dependencies: ["2A5004EB99AE4F96"]
-			id: "686AEC3EF1140D15"
-			rewards: [
-				{
-					exclude_from_claim_all: true
-					id: "0905ED561E579042"
-					table_id: 487623848494439020L
-					type: "loot"
-				}
-				{
-					id: "26FF1D11583ADA23"
-					type: "xp"
-					xp: 50
-				}
-			]
-			shape: "square"
-			size: 1.25d
-			tasks: [{
-				id: "73EA231C66874BB0"
-				item: { count: 1, id: "occultism:infused_pickaxe" }
-				type: "item"
-			}]
-			x: 9.5d
-			y: 9.5d
-		}
-		{
-			dependencies: ["686AEC3EF1140D15"]
+			dependencies: ["2A3683BF7E50EF83"]
 			id: "33106E24A3B5DDD8"
 			min_width: 450
 			rewards: [{
@@ -717,8 +661,8 @@
 				item: { count: 1, id: "occultism:iesnium_ore" }
 				type: "item"
 			}]
-			x: 11.0d
-			y: 11.0d
+			x: 17.0d
+			y: 4.0d
 		}
 		{
 			dependencies: ["33106E24A3B5DDD8"]
@@ -741,54 +685,14 @@
 				item: { count: 1, id: "occultism:iesnium_pickaxe" }
 				type: "item"
 			}]
-			x: 12.5d
-			y: 12.5d
-		}
-		{
-			dependencies: [
-				"57282D7E31EE61EE"
-				"145C8235BCCB9BA8"
-			]
-			icon: {
-				components: {
-					"occultism:spirit_name": "Merrymdor"
-				}
-				id: "occultism:book_of_binding_bound_marid"
-			}
-			id: "676BC41C19BEF1FC"
-			progression_mode: "linear"
-			rewards: [
-				{
-					exclude_from_claim_all: true
-					id: "4381289734981296"
-					table_id: 5564196992594175882L
-					type: "loot"
-				}
-				{
-					id: "29200B3A1B0AC9D1"
-					type: "xp"
-					xp: 100
-				}
-			]
-			shape: "square"
-			size: 1.25d
-			tasks: [
-				{
-					id: "5E80B6869FE42D9F"
-					item: { count: 1, id: "occultism:iesnium_block" }
-					type: "item"
-				}
-				{
-					id: "73801C9489E0E797"
-					item: { components: { "occultism:spirit_name": "Einvonddrin" }, count: 1, id: "occultism:book_of_binding_bound_marid" }
-					type: "item"
-				}
-			]
-			x: 15.5d
-			y: 9.5d
+			x: 20.0d
+			y: 3.5d
 		}
 		{
 			dependencies: ["57282D7E31EE61EE"]
+			icon: {
+				id: "occultism:dimensional_mineshaft"
+			}
 			id: "172D2A634E849562"
 			min_width: 350
 			rewards: [{
@@ -805,13 +709,13 @@
 					type: "item"
 				}
 				{
-					id: "51F776CF868BABEF"
-					item: { components: { "ftbfiltersystem:filter": "or(item_tag(occultism:miners/ores))" }, count: 1, id: "ftbfiltersystem:smart_filter" }
+					id: "53DE943DF951696B"
+					item: { components: { "ftbfiltersystem:filter": "ftbfiltersystem:item_tag(occultism:miners/ores)" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 					type: "item"
 				}
 			]
-			x: 12.5d
-			y: 9.5d
+			x: 22.5d
+			y: 3.5d
 		}
 		{
 			dependencies: ["1DE0F289821F55D1"]
@@ -847,11 +751,12 @@
 					type: "item"
 				}
 			]
-			x: 15.5d
-			y: 5.5d
+			x: 8.0d
+			y: 10.5d
 		}
 		{
 			dependencies: ["6CC5FE34778F0DFA"]
+			hide_dependent_lines: true
 			id: "42F50CE7FE715583"
 			min_width: 300
 			rewards: [
@@ -874,11 +779,12 @@
 				item: { components: { "ftbfiltersystem:filter": "or(item(occultism:storage_stabilizer_tier1)item(occultism:storage_stabilizer_tier2)item(occultism:storage_stabilizer_tier3)item(occultism:storage_stabilizer_tier4))" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 				type: "item"
 			}]
-			x: 18.0d
-			y: 5.5d
+			x: 8.0d
+			y: 14.0d
 		}
 		{
-			dependencies: ["3D41D0092D94636B"]
+			dependencies: ["4C873491F6F0FFAF"]
+			hide_dependency_lines: false
 			id: "78ECC28DD4BA9696"
 			rewards: [{
 				id: "755329C134364BB8"
@@ -890,12 +796,13 @@
 				item: { count: 1, id: "occultism:divination_rod" }
 				type: "item"
 			}]
-			x: 6.0d
-			y: -1.5d
+			x: 8.0d
+			y: 1.0d
 		}
 		{
 			dependencies: ["6CC5FE34778F0DFA"]
 			id: "5831B3192C0E8C56"
+			optional: true
 			rewards: [
 				{
 					exclude_from_claim_all: true
@@ -921,11 +828,11 @@
 					type: "item"
 				}
 			]
-			x: 16.5d
-			y: 7.0d
+			x: 6.5d
+			y: 11.5d
 		}
 		{
-			dependencies: ["08B1A64B01A8A604"]
+			dependencies: ["5ACE97EE75813006"]
 			icon: {
 				components: {
 					"ftbquests:icon": "occultism:textures/gui/book/familiar_headless_ratman.png"
@@ -933,6 +840,7 @@
 				id: "ftbquests:custom_icon"
 			}
 			id: "7F59941D62E672B0"
+			optional: true
 			rewards: [{
 				id: "1FEDC70622D3F66B"
 				type: "xp"
@@ -942,8 +850,8 @@
 				id: "6C3887D42B6B2122"
 				type: "checkmark"
 			}]
-			x: 8.5d
-			y: 7.0d
+			x: 10.5d
+			y: 1.0d
 		}
 		{
 			id: "6CCDEEDA2C99DA66"
@@ -960,8 +868,894 @@
 					type: "checkmark"
 				}
 			]
-			x: 2.0d
-			y: -1.5d
+			x: 0.5d
+			y: 0.5d
+		}
+		{
+			dependencies: ["1DE0F289821F55D1"]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_craft"
+			}
+			id: "39647A2473F6F7D7"
+			min_width: 300
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [{
+				id: "610306AAA51D5967"
+				type: "checkmark"
+			}]
+			x: 10.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["5ACE97EE75813006"]
+			hide_dependency_lines: true
+			id: "4DF0D7B85065ADC9"
+			tasks: [{
+				id: "630455630821CAB0"
+				item: { count: 1, id: "occultism:butcher_knife" }
+				type: "item"
+			}]
+			x: 1.0d
+			y: 6.0d
+		}
+		{
+			dependencies: ["39647A2473F6F7D7"]
+			icon: {
+				id: "occultism:chalk_lime_impure"
+			}
+			id: "30C5B597610F4AFB"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "3B1B9DB617500BAA"
+					table_id: 487623848494439020L
+					type: "loot"
+				}
+				{
+					id: "1ACB00A8A96B37B0"
+					type: "xp"
+					xp: 50
+				}
+			]
+			tasks: [
+				{
+					id: "308ADBEA527AF653"
+					item: { count: 1, id: "occultism:research_fragment_dust" }
+					type: "item"
+				}
+				{
+					id: "0C8EA5B6F92B41B7"
+					item: { count: 1, id: "occultism:chalk_lime_impure" }
+					type: "item"
+				}
+			]
+			x: 12.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["30C5B597610F4AFB"]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_possess"
+			}
+			id: "0BD6365534BF04D5"
+			min_width: 300
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [{
+				id: "5E0DC5327BAE3754"
+				type: "checkmark"
+			}]
+			x: 14.0d
+			y: 9.0d
+		}
+		{
+			dependencies: ["0BD6365534BF04D5"]
+			icon: {
+				id: "occultism:chalk_orange_impure"
+			}
+			id: "74130EB1E4B8586D"
+			tasks: [
+				{
+					id: "56B5E2D58E61A670"
+					item: { count: 1, id: "occultism:cursed_honey" }
+					type: "item"
+				}
+				{
+					id: "7CC5188C1D471B63"
+					item: { count: 1, id: "occultism:chalk_orange_impure" }
+					type: "item"
+				}
+			]
+			x: 16.0d
+			y: 9.5d
+		}
+		{
+			dependencies: [
+				"6FEED25FFAC4101F"
+				"74130EB1E4B8586D"
+			]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_summon"
+			}
+			id: "38A1295878B68F83"
+			min_width: 300
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [{
+				id: "45B6CDFD71466E08"
+				type: "checkmark"
+			}]
+			x: 18.0d
+			y: 7.0d
+		}
+		{
+			dependencies: ["30C5B597610F4AFB"]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_craft"
+			}
+			id: "0D18BBB04693885A"
+			min_width: 300
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [{
+				id: "798E453B4C59964C"
+				type: "checkmark"
+			}]
+			x: 14.0d
+			y: 7.0d
+		}
+		{
+			dependencies: ["0D18BBB04693885A"]
+			icon: {
+				id: "occultism:chalk_gray_impure"
+			}
+			id: "6FEED25FFAC4101F"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "373390521D12FAFF"
+					table_id: 487623848494439020L
+					type: "loot"
+				}
+				{
+					id: "172458963B35A871"
+					type: "xp"
+					xp: 50
+				}
+			]
+			tasks: [
+				{
+					id: "6BCAF5C014C9B8CD"
+					item: { count: 1, id: "occultism:gray_paste" }
+					type: "item"
+				}
+				{
+					id: "4A9046ADC251E85F"
+					item: { count: 1, id: "occultism:chalk_gray_impure" }
+					type: "item"
+				}
+			]
+			x: 16.0d
+			y: 6.5d
+		}
+		{
+			dependencies: ["39647A2473F6F7D7"]
+			icon: {
+				id: "occultism:chalk_green_impure"
+			}
+			id: "11A0593C0E2E6A35"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "71825C8D99ADBB2A"
+					table_id: 487623848494439020L
+					type: "loot"
+				}
+				{
+					id: "40665ED40AD50F96"
+					type: "xp"
+					xp: 50
+				}
+			]
+			tasks: [
+				{
+					id: "3469624E1932FA86"
+					item: { count: 1, id: "occultism:nature_paste" }
+					type: "item"
+				}
+				{
+					id: "28577F9A1DE33F02"
+					item: { count: 1, id: "occultism:chalk_green_impure" }
+					type: "item"
+				}
+			]
+			x: 11.5d
+			y: 11.0d
+		}
+		{
+			dependencies: [
+				"2A5004EB99AE4F96"
+				"0D18BBB04693885A"
+			]
+			id: "2A3683BF7E50EF83"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "76340CDC577FD688"
+					table_id: 487623848494439020L
+					type: "loot"
+				}
+				{
+					id: "53894207A33668FB"
+					type: "xp"
+					xp: 50
+				}
+			]
+			tasks: [{
+				id: "02718432862B0267"
+				item: { count: 1, id: "occultism:infused_pickaxe" }
+				type: "item"
+			}]
+			x: 14.0d
+			y: 4.5d
+		}
+		{
+			dependencies: ["0D18BBB04693885A"]
+			id: "5AE80FF518B1BBA6"
+			optional: true
+			rewards: [{
+				id: "0C4945F14A4E9AD2"
+				type: "xp"
+				xp: 75
+			}]
+			tasks: [{
+				id: "12713B611A3AA745"
+				item: { count: 1, id: "occultism:ritual_satchel_t1" }
+				type: "item"
+			}]
+			x: 15.0d
+			y: 5.5d
+		}
+		{
+			dependencies: ["0D18BBB04693885A"]
+			icon: {
+				components: {
+					"ftbquests:icon": "occultism:block/chalk_glyph/0"
+				}
+				id: "ftbquests:custom_icon"
+			}
+			id: "61999669BDE127F9"
+			optional: true
+			tasks: [{
+				id: "2448345116BDC7C6"
+				type: "checkmark"
+			}]
+			x: 13.0d
+			y: 5.5d
+		}
+		{
+			dependencies: ["145C8235BCCB9BA8"]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_craft"
+			}
+			id: "2960FFE0C53DFEB1"
+			min_width: 300
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [{
+				id: "30DBC2F3438C0884"
+				type: "checkmark"
+			}]
+			x: 22.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["2960FFE0C53DFEB1"]
+			icon: {
+				id: "occultism:chalk_black_impure"
+			}
+			id: "367E891A50991436"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "6FE0A14BDB35C40C"
+					table_id: 487623848494439020L
+					type: "loot"
+				}
+				{
+					id: "1D1E44C1ED4E349E"
+					type: "xp"
+					xp: 50
+				}
+			]
+			tasks: [
+				{
+					id: "43AD1E4B8B90C32B"
+					item: { count: 1, id: "occultism:witherite_dust" }
+					type: "item"
+				}
+				{
+					id: "7C5A8F34E6CE5B45"
+					item: { count: 1, id: "occultism:chalk_black_impure" }
+					type: "item"
+				}
+			]
+			x: 24.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["2960FFE0C53DFEB1"]
+			id: "4CE571F942461909"
+			optional: true
+			rewards: [{
+				id: "4EBE9A3D181D1F8D"
+				type: "xp"
+				xp: 100
+			}]
+			tasks: [{
+				id: "002AC613F837D5B5"
+				item: { count: 1, id: "occultism:ritual_satchel_t2" }
+				type: "item"
+			}]
+			x: 21.0d
+			y: 6.0d
+		}
+		{
+			dependencies: ["2960FFE0C53DFEB1"]
+			icon: {
+				components: {
+					"ftbquests:icon": "occultism:block/chalk_glyph/7"
+				}
+				id: "ftbquests:custom_icon"
+			}
+			id: "1848F431D0380DA9"
+			optional: true
+			tasks: [{
+				id: "7DA8A385C843AD5F"
+				type: "checkmark"
+			}]
+			x: 23.0d
+			y: 6.0d
+		}
+		{
+			dependencies: [
+				"74130EB1E4B8586D"
+				"6FEED25FFAC4101F"
+			]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_possess"
+			}
+			id: "429B5A81DF6C43FE"
+			min_width: 300
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [{
+				id: "0FB5D8A7798D9F3F"
+				item: { count: 1, id: "occultism:ritual_dummy/possess_hoglin" }
+				type: "item"
+			}]
+			x: 18.0d
+			y: 9.0d
+		}
+		{
+			dependencies: ["429B5A81DF6C43FE"]
+			icon: {
+				id: "occultism:chalk_pink_impure"
+			}
+			id: "2E68E1D96B25336D"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "5B284E8F9D2E2E51"
+					table_id: 487623848494439020L
+					type: "loot"
+				}
+				{
+					id: "50619186D8DC7176"
+					type: "xp"
+					xp: 50
+				}
+			]
+			tasks: [
+				{
+					count: 3L
+					id: "411F787B683CA921"
+					item: { count: 1, id: "occultism:demonic_meat" }
+					type: "item"
+				}
+				{
+					id: "714891B19615AC21"
+					item: { count: 1, id: "occultism:chalk_pink_impure" }
+					type: "item"
+				}
+			]
+			x: 18.0d
+			y: 11.0d
+		}
+		{
+			dependencies: [
+				"11A0593C0E2E6A35"
+				"2E68E1D96B25336D"
+				"1EB887F8072439A3"
+			]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_misc"
+			}
+			id: "67884BFA27870CCE"
+			min_width: 300
+			shape: "gear"
+			size: 1.5d
+			tasks: [{
+				id: "1BEBE185FBB4969A"
+				type: "checkmark"
+			}]
+			x: 18.0d
+			y: 13.0d
+		}
+		{
+			dependencies: ["367E891A50991436"]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_summon"
+			}
+			id: "53DEA3DFEDC4809E"
+			min_width: 300
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [{
+				id: "72376A8345BC8171"
+				type: "checkmark"
+			}]
+			x: 26.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["53DEA3DFEDC4809E"]
+			icon: {
+				id: "occultism:chalk_blue_impure"
+			}
+			id: "03250A0202C25E80"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "327F077402F22592"
+					table_id: 487623848494439020L
+					type: "loot"
+				}
+				{
+					id: "64999ED05425EAEB"
+					type: "xp"
+					xp: 50
+				}
+			]
+			tasks: [
+				{
+					id: "7BFF993075EFB7B9"
+					item: { count: 1, id: "occultism:marid_essence" }
+					type: "item"
+				}
+				{
+					id: "5CE28B53187E9128"
+					item: { count: 1, id: "occultism:chalk_blue_impure" }
+					type: "item"
+				}
+			]
+			x: 28.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["03250A0202C25E80"]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_summon"
+			}
+			id: "2AD68066C1948C90"
+			min_width: 300
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [{
+				id: "75AC4550E656F013"
+				type: "checkmark"
+			}]
+			x: 29.5d
+			y: 9.5d
+		}
+		{
+			dependencies: ["03250A0202C25E80"]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_possess"
+			}
+			id: "56EC79AF11B0869E"
+			min_width: 300
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [{
+				id: "3A9125CA2A2E8613"
+				type: "checkmark"
+			}]
+			x: 31.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["03250A0202C25E80"]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_craft"
+			}
+			id: "2CF96A264EB5522C"
+			min_width: 300
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [{
+				id: "4E920BF03DC031D0"
+				type: "checkmark"
+			}]
+			x: 29.5d
+			y: 6.5d
+		}
+		{
+			dependencies: ["2AD68066C1948C90"]
+			icon: {
+				id: "occultism:chalk_light_blue_impure"
+			}
+			id: "1EB887F8072439A3"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "639F0D08BE538FE3"
+					table_id: 487623848494439020L
+					type: "loot"
+				}
+				{
+					id: "7E5E9C1DCC125331"
+					type: "xp"
+					xp: 50
+				}
+			]
+			tasks: [
+				{
+					id: "021F29CA7E51BA5F"
+					item: { count: 1, id: "occultism:crushed_ice" }
+					type: "item"
+				}
+				{
+					id: "09AF3B0519418345"
+					item: { count: 1, id: "occultism:crushed_packed_ice" }
+					type: "item"
+				}
+				{
+					id: "5C2F8463520C2BDF"
+					item: { count: 1, id: "occultism:crushed_blue_ice" }
+					type: "item"
+				}
+				{
+					id: "0B04FCA28ECB05DB"
+					item: { count: 1, id: "occultism:chalk_light_blue_impure" }
+					type: "item"
+				}
+			]
+			x: 25.5d
+			y: 11.0d
+		}
+		{
+			dependencies: [
+				"2CF96A264EB5522C"
+				"2AD68066C1948C90"
+			]
+			icon: {
+				id: "occultism:chalk_magenta_impure"
+			}
+			id: "3543563DF036D461"
+			tasks: [
+				{
+					id: "0B0C632E633B60C8"
+					item: { count: 1, id: "occultism:dragonyst_dust" }
+					type: "item"
+				}
+				{
+					id: "2935D5987F62BD6F"
+					item: { count: 1, id: "occultism:chalk_magenta_impure" }
+					type: "item"
+				}
+			]
+			x: 31.0d
+			y: 5.0d
+		}
+		{
+			dependencies: ["2AD68066C1948C90"]
+			icon: {
+				id: "occultism:chalk_cyan_impure"
+			}
+			id: "00A6020BC979947F"
+			tasks: [
+				{
+					id: "453BB853EA9182B1"
+					item: { count: 1, id: "occultism:echo_dust" }
+					type: "item"
+				}
+				{
+					id: "674E6AB8F52A57A0"
+					item: { count: 1, id: "occultism:chalk_cyan_impure" }
+					type: "item"
+				}
+			]
+			x: 31.0d
+			y: 11.0d
+		}
+		{
+			dependencies: ["56EC79AF11B0869E"]
+			icon: {
+				id: "occultism:chalk_brown_impure"
+			}
+			id: "7BCD4A425CF6199B"
+			tasks: [
+				{
+					id: "2BD7510CD96A57ED"
+					item: { count: 1, id: "occultism:cruelty_essence" }
+					type: "item"
+				}
+				{
+					id: "2A59204579B09A8B"
+					item: { count: 1, id: "occultism:chalk_brown_impure" }
+					type: "item"
+				}
+			]
+			x: 33.5d
+			y: 8.0d
+		}
+		{
+			dependencies: [
+				"3543563DF036D461"
+				"7BCD4A425CF6199B"
+				"00A6020BC979947F"
+			]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_misc"
+			}
+			id: "0A25276925EB0CBA"
+			min_width: 300
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "516706F4DCD89A14"
+					table_id: 4196188979167302596L
+					type: "loot"
+				}
+				{
+					id: "7BC9E8E58C40E3CC"
+					type: "xp_levels"
+					xp_levels: 1
+				}
+			]
+			shape: "gear"
+			size: 2.0d
+			tasks: [
+				{
+					id: "313C481463E421F7"
+					item: { count: 1, id: "occultism:chalk_white_impure" }
+					type: "item"
+				}
+				{
+					id: "0DD67B59254DDB95"
+					item: { count: 1, id: "occultism:chalk_light_gray_impure" }
+					type: "item"
+				}
+				{
+					id: "002EA4824248BCD2"
+					item: { count: 1, id: "occultism:chalk_gray_impure" }
+					type: "item"
+				}
+				{
+					id: "1F19833D693F324F"
+					item: { count: 1, id: "occultism:chalk_black_impure" }
+					type: "item"
+				}
+				{
+					id: "0F58A0EAC35E51BB"
+					item: { count: 1, id: "occultism:chalk_brown_impure" }
+					type: "item"
+				}
+				{
+					id: "46E0A7B9A053277D"
+					item: { count: 1, id: "occultism:chalk_red_impure" }
+					type: "item"
+				}
+				{
+					id: "0A4A298A7AA69522"
+					item: { count: 1, id: "occultism:chalk_orange_impure" }
+					type: "item"
+				}
+				{
+					id: "068263DD30A6961D"
+					item: { count: 1, id: "occultism:chalk_yellow_impure" }
+					type: "item"
+				}
+				{
+					id: "0F0619C13F633AC3"
+					item: { count: 1, id: "occultism:chalk_lime_impure" }
+					type: "item"
+				}
+				{
+					id: "279C3E75AA687B08"
+					item: { count: 1, id: "occultism:chalk_green_impure" }
+					type: "item"
+				}
+				{
+					id: "4CDB7E20D683AD29"
+					item: { count: 1, id: "occultism:chalk_green_impure" }
+					type: "item"
+				}
+				{
+					id: "6F7BE78E7C2F1AEC"
+					item: { count: 1, id: "occultism:chalk_cyan_impure" }
+					type: "item"
+				}
+				{
+					id: "0A6AE6AC767FFE65"
+					item: { count: 1, id: "occultism:chalk_light_blue_impure" }
+					type: "item"
+				}
+				{
+					id: "4F9EB45160D4E2A9"
+					item: { count: 1, id: "occultism:chalk_blue_impure" }
+					type: "item"
+				}
+				{
+					id: "5D0C4878FBCE6213"
+					item: { count: 1, id: "occultism:chalk_purple_impure" }
+					type: "item"
+				}
+				{
+					id: "6D5EAFADDF110214"
+					item: { count: 1, id: "occultism:chalk_magenta_impure" }
+					type: "item"
+				}
+				{
+					id: "232F31CB4D1351E3"
+					item: { count: 1, id: "occultism:chalk_pink_impure" }
+					type: "item"
+				}
+			]
+			x: 36.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["0A25276925EB0CBA"]
+			id: "690B89D23134B624"
+			require_sequential_tasks: false
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "40582796F09FEC70"
+					table_id: 4196188979167302596L
+					type: "loot"
+				}
+				{
+					id: "364D9D1E440B9756"
+					type: "xp_levels"
+					xp_levels: 1
+				}
+			]
+			tasks: [{
+				id: "687E54A17D6F09AB"
+				item: { count: 1, id: "occultism:chalk_rainbow" }
+				type: "item"
+			}]
+			x: 38.5d
+			y: 8.0d
+		}
+		{
+			dependencies: ["690B89D23134B624"]
+			id: "54378277B8D28B1D"
+			optional: true
+			tasks: [{
+				id: "4A935B03FA1DD7C3"
+				item: { count: 1, id: "occultism:chalk_void" }
+				type: "item"
+			}]
+			x: 41.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["2CF96A264EB5522C"]
+			id: "1BDB369FD243D4C6"
+			min_width: 300
+			shape: "gear"
+			size: 1.25d
+			tasks: [{
+				id: "0210448E8118E45C"
+				item: { count: 1, id: "occultism:iesnium_anvil" }
+				type: "item"
+			}]
+			x: 28.0d
+			y: 5.0d
+		}
+		{
+			dependencies: ["2960FFE0C53DFEB1"]
+			hide_dependent_lines: true
+			id: "6FFFAE334DFAAAAB"
+			rewards: [{
+				id: "5EDBE01DE9B25580"
+				type: "xp"
+				xp: 100
+			}]
+			tasks: [{
+				id: "10037D5225C2D20E"
+				item: { count: 1, id: "occultism:iesnium_sacrificial_bowl" }
+				type: "item"
+			}]
+			x: 22.0d
+			y: 5.0d
+		}
+		{
+			dependencies: [
+				"0A25276925EB0CBA"
+				"666EA8B8F13EB292"
+			]
+			id: "2FD22502E6481269"
+			tasks: [{
+				id: "3F319A5CD7E4E884"
+				item: { count: 1, id: "occultism:trinity_gem" }
+				type: "item"
+			}]
+			x: 38.0d
+			y: 5.0d
+		}
+		{
+			dependencies: [
+				"0A25276925EB0CBA"
+				"6FFFAE334DFAAAAB"
+			]
+			id: "08697EB269B011FD"
+			tasks: [{
+				id: "05A43D4098C30ED1"
+				item: { count: 1, id: "occultism:eldritch_chalice" }
+				type: "item"
+			}]
+			x: 38.0d
+			y: 11.0d
+		}
+		{
+			dependencies: [
+				"2FD22502E6481269"
+				"690B89D23134B624"
+				"08697EB269B011FD"
+				"42F50CE7FE715583"
+			]
+			hide_details_until_startable: true
+			icon: {
+				components: {
+					"ftbquests:icon": "occultism:textures/gui/book/infusion.png"
+				}
+				id: "ftbquests:custom_icon"
+			}
+			id: "29C83B00AC4AFC23"
+			min_width: 300
+			rewards: [{
+				id: "1CA2FF5D585D03DF"
+				type: "xp_levels"
+				xp_levels: 1
+			}]
+			shape: "rsquare"
+			size: 2.5d
+			tasks: [{
+				id: "2B54A5BE4392F79C"
+				type: "checkmark"
+			}]
+			x: 44.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["4C873491F6F0FFAF"]
+			icon: {
+				id: "minecraft:book"
+			}
+			id: "5ACE97EE75813006"
+			min_width: 300
+			tasks: [{
+				id: "348A7E3E3A3D324E"
+				type: "checkmark"
+			}]
+			x: 10.5d
+			y: 3.0d
 		}
 	]
 }

--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -116,7 +116,7 @@
 	quest.00A17728A387B426.quest_desc: ["Wood Nests are used to lure Carpenter Bees and the Blue Banded Bee.\\n\\nDark Oak Nests lures 3 different bees.\\n\\nThese can be placed in any Overworld Biome."]
 	quest.00A17728A387B426.quest_subtitle: "Can be used in any Overworld biome"
 	quest.00A17728A387B426.title: "Wood Nests"
-	quest.00A6020BC979947F.quest_desc: ["With your freshly summoned &9Marid Crusher&r, you can break down an echo shard and an Iesnium ingot, which combine with a glow ink sac to create Cyan Chalk."]
+	quest.00A6020BC979947F.quest_desc: ["With your freshly summoned &9Marid Crusher&r, you can break down an Echo Shard and an Iesnium Ingot, which when combined with a Glow Ink Sac creates Cyan Chalk."]
 	quest.00A6020BC979947F.title: "&3Cyan Chalk"
 	quest.00A91BD731486644.quest_subtitle: "Ceylon Ebony + Sour Cherry"
 	quest.00AC7CC291A3E590.quest_desc: ["You've probably (definitely) seen structures around the world with what looks like Beacons coming out of them. They're made of cobblestone, have 4 legs supporting them, kinda high in the air! \\n\\nHopefully you know it but they're called &8Dark Temples&r and they have an &aEnviromental Accumulator&r which we need. \\n\\nYou'll have to wait for Thunderstorm to happen to fill your Weather Container. Then, you can make your &3Lightning Bomb&r!"]
@@ -333,7 +333,7 @@
 	]
 	quest.030AC1AF8F735550.quest_desc: ["To get liquids into the Tank you'll need some sort of Pipes.\\n\\nThe Hydro Pump can automatically put Water into them at a slow rate, but also for free!"]
 	quest.030AC1AF8F735550.title: "Pipes"
-	quest.03250A0202C25E80.quest_desc: ["After you've successfully slain the &9unbound Marid&r demon that you summoned with &4Abras' Fortified Conjure&r, you can use the &9Marid Essence&r that it drops to craft the \"highest\" Colored Chalk, Blue Chalk."]
+	quest.03250A0202C25E80.quest_desc: ["After you've successfully slain the &9Unbound Marid&r Demon that you summoned with &4Abras' Fortified Conjure&r, you can use the &9Marid Essence&r that it drops to craft the \"highest\" colored Chalk, Blue Chalk."]
 	quest.03250A0202C25E80.title: "&9Blue Chalk"
 	quest.032B654201E71618.quest_desc: ["These &cTrack Kits&r are for using entities with your &7Carts&r (Entities aka Mobs). \\n\\nThe &cEmbarking Kit&r will pick up any Mobs nearby and put them in a &7Cart&r. \\nThe &cDisembarking Kit&r unloads Mobs from the &7Carts&r. \\nThe &cDumping Kit&r will drop the mobs in the &7Carts&r below the &6tracks&r its on."]
 	quest.032B654201E71618.title: "&cTrack Kits&r for moving entities"
@@ -1041,7 +1041,7 @@
 	quest.0A21773B773F34F8.quest_desc: ["Color is one of the most important parts of making a Build more lively! \\n\\nIt gives it life, personality, and color! \\n\\nStart with the Dyes!"]
 	quest.0A21773B773F34F8.title: "Colored Blocks"
 	quest.0A25276925EB0CBA.quest_desc: [
-		"Once you've gathered every single Colored Chalk and Foundation Chalk, you can perform the second &dDemon-less&r type ritual, &dRonaza's Contact&r. This is ultimate ritual, using everything you've learned so far!"
+		"Once you've gathered every single colored Chalk and Foundation Chalk, you can perform the second &dDemon-less&r type ritual, &dRonaza's Contact&r. This is the ultimate ritual, using everything you've learned so far!"
 		""
 		"It has limited uses, but everything created with this ritual is super powerful!"
 	]
@@ -1182,15 +1182,15 @@
 	quest.0BCCDE24D378F260.quest_subtitle: "Tier: &d3"
 	quest.0BCCDE24D378F260.title: "&dAdvanced Machine Frame"
 	quest.0BD6365534BF04D5.quest_desc: [
-		"With our lime chalk in hand, it's time to delve into &5Possesion Rituals&r. These rituals are slightly different from the others because they all require a live sacrifice, usually small mobs such as chickens, bees, bats, etc. However, as rituals get more complicated, they will require larger and larger sacrifices. "
+		"With Lime Chalk, it's time to delve into &5Possesion Rituals&r. These rituals are slightly different from the others because they all require a live sacrifice, usually small mobs such as Chickens, Bees, Bats, etc. However, as rituals get more complicated, they will require larger and larger sacrifices. "
 		""
 		"Even if you've placed all of the items needed and the Book of Binding into the Golden Sacrificial Bowl, the Ritual will not begin until you kill the sacrifice on top of the runes."
 		""
-		"We reccomend that you make some sort of mob capture item such as an empty soul gem, jar, Mob Imprisonment Tool, or Quantum Catcher!"
+		"It is recommended that you make some sort of mob capture item such as an Empty Soul Gem, Jar, Mob Imprisonment Tool, or Quantum Catcher!"
 		""
-		"The first tier of &5Possession rituals&r is &eHeidryn's Lure&r, which is only used to get mundane items like skeleton skulls and end stone. Because of this, we're skipping right to the second tier ritual, &aIhagan's Enthrallment&r. "
+		"The first tier of &5Possession rituals&r is &eHeidryn's Lure&r, which is only used to get mundane items like Skeleton Skulls and End Stone. Because of this, you can skip straight to the second tier of ritual, &aIhagan's Enthrallment&r. "
 	]
-	quest.0BD6365534BF04D5.quest_subtitle: "Who ya gonna call?"
+	quest.0BD6365534BF04D5.quest_subtitle: "Who you gonna call?"
 	quest.0BD6365534BF04D5.title: "&aIhagan's Enthrallment"
 	quest.0BD908937BC6E97B.quest_subtitle: "Kapok + Rosewood"
 	quest.0BE2E7C9454058C3.quest_desc: [
@@ -1296,8 +1296,8 @@
 	quest.0CF6D11016BAF3D0.quest_subtitle: "Complex Naquadah"
 	quest.0D01524F249E25D7.quest_subtitle: "Who turned off the lights?"
 	quest.0D01524F249E25D7.title: "&8Dark Xychorium Gems"
-	quest.0D18BBB04693885A.quest_desc: ["Strigeor's Higher Binding is the second tier of &6Infusion Rituals&r. It's used for a TON of different things, but the main things we'll need are the Infused Pickaxe and Gray Paste."]
-	quest.0D18BBB04693885A.quest_subtitle: "The \"everything\" ritual"
+	quest.0D18BBB04693885A.quest_desc: ["Strigeor's Higher Binding is the second tier of &6Infusion Rituals&r. It's used for many different things, but the main things we'll need are the Infused Pickaxe and Gray Paste."]
+	quest.0D18BBB04693885A.quest_subtitle: "The \"Everything\" Ritual"
 	quest.0D18BBB04693885A.title: "&aStrigeor's Higher Binding"
 	quest.0D19FB62C2C1D9F7.quest_desc: ["Once you've got at least 200 &4Mahou&r you might want to make a Boundary of Life Drain. \\n\\nFor every Mob that dies in that boundary, you get 10 &4Mahou&r back, but this is a SLOW process."]
 	quest.0D19FB62C2C1D9F7.title: "Boundary of Life Drain"
@@ -1733,7 +1733,7 @@
 	quest.1194FF35ADAA9957.quest_subtitle: "Sharks with Laser beams?"
 	quest.119FF09D481F9178.quest_desc: ["What good would a tech mod be without barrels and tanks. They could be useful, but functions the same as other items of the same."]
 	quest.119FF09D481F9178.title: "Tanks and Barrels"
-	quest.11A0593C0E2E6A35.quest_desc: ["Using &eEziveus' Spectral Compulsion&r, we can imbue a myriad of different nature blocks to form some &2Nature Paste&r. Combine this paste with some impure white chalk to create Green Chalk."]
+	quest.11A0593C0E2E6A35.quest_desc: ["Using &eEziveus' Spectral Compulsion&r, we can imbue a myriad of different nature blocks to form some &2Nature Paste&r. Combine this Paste with some Impure White Chalk to create Green Chalk."]
 	quest.11A0593C0E2E6A35.title: "&2Green Chalk"
 	quest.11AAA1DCB452DFFC.quest_subtitle: "For"
 	quest.11B0B93D725ABE43.quest_desc: ["Silent Gear gear can be repaired using a &9Repair Kit&r.\\n\\nTo repair an item, place the Repair Kit into a crafting grid, then place the materials needed to repair the tool in with it. This will \"fill\" the Repair Kit.\\n\\nTo repair the tool, combine the filled Repair Kit with the tool you'd like to repair in a crafting grid."]
@@ -2063,7 +2063,7 @@
 	quest.145C8235BCCB9BA8.quest_desc: [
 		"If we want to collect all of the Chalks, we'll need to summon and kill aa not-so friendly &cAfrit&r."
 		""
-		"Even though this isn't a &5Possession Ritual&r, you'll need a live sacrifice for this ritual. In this instance, we'll be sacrificing a cow. Sorry Betsy!"
+		"Even though this isn't a &5Possession Ritual&r, you'll need a live sacrifice for this ritual. In this instance, we'll be sacrificing a Cow. Sorry Betsy!"
 	]
 	quest.145C8235BCCB9BA8.title: "&cRed Chalk"
 	quest.145E7D1A88B83DDD.quest_desc: ["Where'd you go?"]
@@ -2459,11 +2459,11 @@
 	quest.1834B5C1F8435D7A.quest_subtitle: "Fluids"
 	quest.1843C79133DFB024.quest_desc: ["The most powerful and efficient Generator, the Netherstar Generator. Take a guess what it uses to make Energy!"]
 	quest.1848F431D0380DA9.quest_desc: [
-		"Similar to the Chalk Repairing function of &aStrigeor's Higher Binding&r, &cSevira's Permanent Confinement&r can be used to repair items using the power of an Afrit demon."
+		"Similar to the Chalk Repairing function of &aStrigeor's Higher Binding&r, &cSevira's Permanent Confinement&r can be used to repair items using the power of an Afrit Demon."
 		""
-		"This ritual can repair just about anything, so &edemon miners&r, tools, and armor can all be restored to their original durability! "
+		"This ritual can repair just about anything, so &eDemon Miners&r, tools, and armor can all be restored to their original durability! "
 		""
-		"All items that are repaired using this ritual retain their original properties (affixes, enchantments, etc.), so don't worry about your precious level 10 enchantments!"
+		"All items that are repaired using this ritual retain their original properties (affixes, enchantments, etc), so don't worry about your precious enchantments!"
 	]
 	quest.1848F431D0380DA9.quest_subtitle: "Free(ish) durability!"
 	quest.1848F431D0380DA9.title: "Repairing Items"
@@ -2759,15 +2759,15 @@
 	quest.1BD5B25B80EC0F97.quest_desc: ["Also makes those magnetic iron rods for just some energy - save your redstone!"]
 	quest.1BD5B25B80EC0F97.quest_subtitle: "Magnetizing!"
 	quest.1BDB369FD243D4C6.quest_desc: [
-		"Arguably the most useful item that you can create in the Occultism modpack, the &bIesnium Anvil&r is a super-powerful version of the anvil."
+		"Arguably the most useful item that you can create in Occultism, the &bIesnium Anvil&r is a super-powerful version of the Anvil."
 		""
 		"Created using &9Uphyxes' Inverted Tower&r, it:"
 		""
-		"- Is unbreakable"
-		"- Increases the maximum level of all enchants for anything combined on it by one level"
-		"- Costs 1/2 as much xp as the estimate says (rounded down, so if it says 25, it'll cost 12)"
-		"- Has a smaller xp-requirement increase for repeated edits on the same item"
-		"- Increases the maximum xp level at which you can edit items (the point at which it says \"Too Expensive!\")"
+		"- Is unbreakable."
+		"- Increases the maximum level of all enchants for anything combined on it by one level."
+		"- Costs half as much xp as the estimate says (rounded down, so if it says 25, it'll cost 12)."
+		"- Has a smaller experience requirement increase for repeated edits on the same item."
+		"- Increases the maximum xp level at which you can edit items (the point at which it says \"Too Expensive!\")."
 	]
 	quest.1BE26A00A420DAE3.quest_desc: ["In this mod, you'll need &aFlux Cores&r and &aFlux Blocks&r to craft the core parts of your network. Make a few of each!"]
 	quest.1BE26A00A420DAE3.title: "The 'Core' Crafting Materials"
@@ -2945,7 +2945,7 @@
 	quest.1DCFC67A8E3DCA2C.quest_desc: ["Similar to the Alchemy Catalyst, when placed under a Mana Pool, the &9Conjuration Catalyst&r unlocks the abillity to use conjuration recipes. "]
 	quest.1DDA5ADA11DF868F.quest_desc: ["Now we can upgrade our Multiblock structures Tiers! EBF's, VF's, Crackers, LFD, and more! They can process faster, and they can process &dLuV&r tier materials! Lets Go!"]
 	quest.1DDA5ADA11DF868F.quest_subtitle: "LuV Energy Hatch at Last!"
-	quest.1DE0F289821F55D1.quest_desc: ["Now that we have a Foliot Crusher, we can &muse&r politely ask it to crush down some &eEnd Stone&r, &9Obsidian&r, &7Calcite&r for us. We'll use these to make some new Chalk!"]
+	quest.1DE0F289821F55D1.quest_desc: ["Now that we have a Foliot Crusher, we can &muse&r politely ask it to crush down some &eEnd Stone&r, &9Obsidian&r and &7Calcite&r for us. We'll use these to make some new Chalk!"]
 	quest.1DE0F289821F55D1.title: "&aChalking It Up"
 	quest.1DE8B0C9A7195720.quest_desc: [
 		"Once you've finished placing in all of the required blocks to build the Reactor, it should give off red particles to show that it is complete.\\n\\nRight clicking anywhere on the Reactor will open up the &aInterface&r. This will have all of the information you need to run the Reactor properly, as well as two buttons to turn on and off the Reactor.\\n\\nOn the left, you have 2 tanks: One for &bCoolant&r and one for &3Fissile Fuel&r. On the right, you have one for &8Nuclear Waste&r, and one for &bHeated Coolant&r, which will most likely be &bSteam&r.\\n\\nThe &cTemperature&r bar will show you how hot the Reactor is. After a certain temp, the Reactor will start taking &4Damage&r, which will eventually cause the Reactor to explode.\\n\\nTo adjust the &cBurn Rate&r of the Fissile Fuel and see more statistics, click on the (I) tab on the left side. Here, you can adjust the Rate Limit, which controls how much fuel the Reactor burns per tick.\\n"
@@ -3021,7 +3021,7 @@
 	quest.1EABF2E7AE7B8F22.title: "&8Netherite&r"
 	quest.1EB04FE105ACA4BE.quest_desc: ["When a &9Warden&r dies it has a chance to drop a &9Heart of the Deep&r. \\n\\nThis can be used for the &6&lATM Star&r, or to activate the Portal in the Ancient City! \\n\\nThere can't be anything in the Portal to activate it, that includes &9Sculk&r!"]
 	quest.1EB04FE105ACA4BE.title: "&9Heart of the Deep"
-	quest.1EB887F8072439A3.quest_desc: ["After using &9Fatma's Incentivized Attraction&r to summon a &9Marid Crusher&r, you can turn ice, packed ice, and blue ice into their crushed forms, and use these to create Light Blue Chalk."]
+	quest.1EB887F8072439A3.quest_desc: ["After using &9Fatma's Incentivized Attraction&r to summon a &9Marid Crusher&r, you can turn Ice, Packed Ice, and Blue Ice into their crushed forms, and use these to create Light Blue Chalk."]
 	quest.1EB887F8072439A3.title: "&bLight Blue Chalk"
 	quest.1EBD5E4410A6DF34.quest_subtitle: "Feed a Ghostly Bee a Soulium Dagger"
 	quest.1EBD5E4410A6DF34.title: "Soulium Bee"
@@ -4055,11 +4055,11 @@
 	quest.2951B1D7080C5EF9.title: "Every Thorn has its Rose"
 	quest.295C77EEC89000FC.quest_subtitle: "Generates Source from Mob Deaths and Animal Breeding"
 	quest.2960FFE0C53DFEB1.quest_desc: [
-		"&cSevira's Permanent Confinement&r is the third tier of &6Infusion Rituals&r. It's mainly used to create the next level of foundation chalk, Black Chalk."
+		"&cSevira's Permanent Confinement&r is the third tier of &6Infusion Rituals&r. It's mainly used to create the next level of foundation Chalk, Black Chalk."
 		""
 		"It's also used to create a couple of items that can speed up ritual making and performing by a significant amount."
 	]
-	quest.2960FFE0C53DFEB1.quest_subtitle: "The \"even more everything\" ritual"
+	quest.2960FFE0C53DFEB1.quest_subtitle: "The \"Even More Everything\" Ritual"
 	quest.2960FFE0C53DFEB1.title: "&cSevira's Permanent Confinement"
 	quest.29706E3681616E41.quest_subtitle: "That's a Lot of Different Dusts!"
 	quest.2982D38BD5EE6349.quest_subtitle: "Feed a Shroombee Warped Fungus"
@@ -4085,13 +4085,13 @@
 	]
 	quest.29C78845B488EDF8.title: "&5Purple Sempiternal Sanctum"
 	quest.29C83B00AC4AFC23.quest_desc: [
-		"Now that you've completed the Occultism questline, you may be asking yourself, what's next? Well, there are so many more things to explore in Occultism! "
+		"Now that you've come this far, you may be asking yourself, what's next? Well, there are so many more things to explore in Occultism! "
 		""
-		"You can see a comprehensive list of every single ritual and item in your &6Dictionary of Spirits&r, try going through all the rituals' outcomes to see if you can find something that piques your interest!"
+		"You can see a comprehensive list of every single ritual and item in your &6Dictionary of Spirits&r, you could try going through all the rituals' outcomes to see if you can find something that piques your interest!"
 		""
-		"If you haven't already, you could lie out and decorate three separate ritual areas, one for summons, one for possessions, and one for infusions."
+		"If you haven't already, you could lay out and decorate three separate ritual areas, one for Summons, one for Possessions, and one for Infusions."
 		""
-		"With any mod, there's always new ways to use each and every seemingly mundane feature to maximize your experience with the modpack. Happy ritual crafting!"
+		"There's always new ways to use each and every seemingly mundane feature to maximize your experience with the modpack. Happy ritual crafting!"
 	]
 	quest.29C83B00AC4AFC23.title: "What's Next?"
 	quest.29C9F8719DA63D8D.quest_desc: ["The &2&lBuzzsaw&r works similar to the &4&lMining Drill&r, just for &2Trees&r! \\n\\nIt requires &2Bio-Diesel&r as Fuel, which I won't explain how to get here either! \\n\\nAnd some sort of &8Sawblade&r. Which you can attach via the Top Slot in the &6Engineer's Workbench&r. \\n\\nSimply break Logs on a &2Tree&r and every Log, Leaf, and Birds Nest will come down with it! You can hold Shift to not break everything attached. \\n\\nThe &2&lBuzzsaw&r also does 10 Damage! Dang, why even use a Sword? Oh yeah &8Saws&r have Durability and it needs &2Bio-Diesel&r. \\n\\nThe &2&lBuzzsaw&r can hold 1 &8Blade&r or &8Disk&r and 2 Upgrades."]
@@ -4596,7 +4596,7 @@
 	]
 	quest.2E596B5A4EA2ABF4.title: "&3S'Mog&r"
 	quest.2E5EF984B9CE0CB9.quest_desc: ["The all in one, big battery, big range ore/fluid finder"]
-	quest.2E68E1D96B25336D.quest_desc: ["After fighting through a few Demon possessed zombie piglins summoned by &6Abras' Open Commanding Conjure&r, you can use the Demonic Meat dropped by them to craft some Pink Chalk."]
+	quest.2E68E1D96B25336D.quest_desc: ["After fighting through a few Demon Possessed Zombified Piglins summoned by &6Abras' Open Commanding Conjure&r, you can use the Demonic Meat dropped by them to craft some Pink Chalk."]
 	quest.2E68E1D96B25336D.title: "&dPink Chalk"
 	quest.2E6D11A5F5626A6C.quest_subtitle: "Tier: &f2"
 	quest.2E6F1C8718EB8C66.title: "&4Blood&r Upgrade Orb"
@@ -4741,7 +4741,7 @@
 	quest.2FB62AE3C62CA052.quest_subtitle: "&f4.5&r &4Damage&r"
 	quest.2FC15D3916DBF4E4.quest_subtitle: "More Filtering Options"
 	quest.2FC15D3916DBF4E4.title: "&eAdvanced Void Upgrade"
-	quest.2FD22502E6481269.quest_desc: ["Using &dRonaza's Contact&r, you can upgrade your soul gem to create a trinity gem. It's basically just a beefed up version of the soul gem that can capture larger enemies, although it still can't contain most bosses."]
+	quest.2FD22502E6481269.quest_desc: ["Using &dRonaza's Contact&r, you can upgrade your Soul Gem to create a Trinity Gem. It's basically just a beefed up version of the Soul Gem that can capture larger enemies, although it still can't contain most bosses."]
 	quest.2FDACD6F153D5B64.quest_desc: ["Processing Sheldonite and purifying it will allow you to get the highest return on Platinum Group Sludge. This Sludge contains resources you need to progress."]
 	quest.2FDACD6F153D5B64.quest_subtitle: "My Friend Sheldon went to a club on nite."
 	quest.2FE4B7B70D90A455.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks.\\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission.\\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
@@ -4829,7 +4829,7 @@
 		"{image:atm:textures/questpics/bumblezone/bumble_cell.png width:200 height:100 align:center}"
 	]
 	quest.30C12E249F7E2D52.title: "Cell Maze"
-	quest.30C5B597610F4AFB.quest_desc: ["The first and most important item to make using Eziveus' Spectral Compulsion is the Research Fragment Dust. This is used in combination with some crushed emeralds to create lime chalk!"]
+	quest.30C5B597610F4AFB.quest_desc: ["The first and most important item to make using Eziveus' Spectral Compulsion is the Research Fragment Dust. This is used in combination with some crushed Emeralds to create Lime Chalk!"]
 	quest.30C5B597610F4AFB.title: "&aLime Chalk"
 	quest.30CD69FC601F26B5.quest_desc: ["Now just 1 more processing step before you can finally craft the Naquadah Alloy Frame&l"]
 	quest.30CD69FC601F26B5.quest_subtitle: "Naq Alloy Time!"
@@ -5393,7 +5393,7 @@
 	quest.3663E93E169EF8E3.title: "&2Uranium Hexafluoride"
 	quest.3673893C88EB5EDE.quest_desc: ["Use 3 other crystals to craft this crystal."]
 	quest.3673893C88EB5EDE.quest_subtitle: "Weathering the Storm"
-	quest.367E891A50991436.quest_desc: ["Using &cSevira's Permanent Confinement&r, we can combine several different wither materials and some netherite to create three Witherite Dust. With these, we can create ourselfs the highest form of Foundation Chalk, Black Chalk."]
+	quest.367E891A50991436.quest_desc: ["Using &cSevira's Permanent Confinement&r, we can combine several different Wither materials and some Netherite to create three Witherite Dust. With these, we can create ourselfs the highest form of Foundation Chalk, Black Chalk."]
 	quest.367E891A50991436.title: "Black Chalk"
 	quest.36836AD948F96B9F.quest_desc: [
 		"The simplest of the simplest of &e&lPipes&r, the &eItem Pipe&r. \\n\\nIt will move Items from one Inventory to another. Could be from one Chest to another, could be a Farm to a System, or even a Quarry to a Smelter. \\n\\nVery simple just connect the &ePipes&r to what you want moved, and use your Wrench to configure which side it Pulls from. "
@@ -5577,7 +5577,7 @@
 		""
 		"&cAfrit Demons&r are Demons of &cFire&r. They are more advanced Demons, which some are friends and some are... not. It all depends on how strongly the ritual can control the &cAfrit&r. "
 		""
-		"Because we don't have access to red chalk yet, all we can summon is an &9unbound&r demon, meaning it cannot be controlled and will be violent."
+		"Because we don't have access to Red Chalk yet, all we can summon is an &9Unbound&r Demon, meaning it cannot be controlled and will be violent."
 	]
 	quest.38A1295878B68F83.quest_subtitle: "Hot Demons!"
 	quest.38A1295878B68F83.title: "&6Abras' Open Conjure"
@@ -5639,7 +5639,7 @@
 		""
 		"The first tier of &6Infusion Rituals&r is &eEziveus' Spectral Compulsion&r. We'll be using this ritual to create several items that you'll need throughout this mod."
 		""
-		"We reccomend creating this ritual in a separate area from your first one, because the three main types of rituals build off each previous tier."
+		"It is recommended to create this ritual in a separate area from your first one, because the three main types of rituals build off each previous tier."
 	]
 	quest.39647A2473F6F7D7.quest_subtitle: "Put some Demon Dust™ on it!"
 	quest.39647A2473F6F7D7.title: "&eEziveus' Spectral Compulsion"
@@ -6661,13 +6661,13 @@
 	quest.429785E8F64929CE.quest_desc: ["In order to get to the Starlight Dimension you'll need to find Portal Ruins in the Overworld. \\n\\nThere you will find a Gatekeeper, Right Click to initiate a conversation and challenge them to a duel! Careful, they are very tough. \\n\\nOnce you win the duel you'll be gifted a few Items, the Orb of Prophecy being one. Right Click the Portal with the Orb to activate it! Then, walk in to get to the..."]
 	quest.429785E8F64929CE.title: "The Gatekeeper and The Gate"
 	quest.429B5A81DF6C43FE.quest_desc: [
-		"&6Abras' Open Commanding Conjure&r is used to bring an &cAfrit&r demon into a pig. Because this ritual is performed without the use of red chalk, it's only powerful enough to summon an &9unbound&r demon."
+		"&6Abras' Open Commanding Conjure&r is used to bring an &cAfrit&r demon into a Pig. Because this ritual is performed without the use of Red Chalk, it's only powerful enough to summon an &9unbound&r demon."
 		""
-		"In particular, this ritual will create an &cAfrit&r-possessed zombified piglin, which will drop some demonic meat, which is used to craft pink chalk"
+		"In particular, this ritual will create an &cAfrit&r-possessed Zombified Piglin, which will drop some Demonic Meat, which is used to craft Pink Chalk"
 		""
-		"&l&4WARNING: YOU MAY HAVE TO DO THIS ONE MULTIPLE TIMES TO GET ENOUGH DEMONIC MEAT! "
+		"&4WARNING: YOU MAY HAVE TO DO THIS ONE MULTIPLE TIMES TO GET ENOUGH DEMONIC MEAT."
 	]
-	quest.429B5A81DF6C43FE.quest_subtitle: "How... fleshy..."
+	quest.429B5A81DF6C43FE.quest_subtitle: "How... Fleshy..."
 	quest.429B5A81DF6C43FE.title: "&6Abras' Open Commanding Conjure"
 	quest.42AAEC41F2BC2474.quest_desc: ["{image:atm:textures/questpics/basicarmor/armor_glacite.png width:100 height:150 align:center}"]
 	quest.42AAEC41F2BC2474.title: "&bGlacite&r"
@@ -7697,9 +7697,9 @@
 		""
 		"&aOak Saplings&r convert to &9Oak Saplings&r but they are not the same. When grown, these will look exactly like a regular Oak tree. However, under the effects of the &bThird Eye&r, you will be able to harvest the Otherworld variant."
 		""
-		"If you have trouble collecting the logs (if they turn into regular Oak logs even with &bThird Eye&r), try collecting them from the top."
+		"If you have trouble collecting the logs (if they turn into regular Oak Logs even with &bThird Eye&r), try collecting them from the top."
 		""
-		"&eDiamonds&r will turn into &dSpirit Attuned Gems&r which are used in several recipes we'll need later down the road."
+		"&eDiamonds&r will turn into &dSpirit Attuned Gems&r which are used in several recipes we'll need later on."
 	]
 	quest.4C873491F6F0FFAF.title: "&dSpiritfire&r Conversions"
 	quest.4C8C56F960D92E9D.quest_subtitle: "&f51 &cAttack Damage"
@@ -7726,9 +7726,9 @@
 	quest.4CE571F942461909.quest_desc: [
 		"The Ritual Satchel is nice, but it takes a long time to place all the blocks. Now that you can perform the &cSevira's Permenant Confinement&r ritual, you can create the Artisanal Ritual Satchel!"
 		""
-		"The Artisanal Ritual Satchel functions nearly identically to the regular Ritual satchel, except it instantly places all the nessecary items for the ritual, and has the added ability to right-click on a golden bowl to erase all the chalk runes and collect all the other items (skulls, candles, and crystals) and return them to the satchel. "
+		"The Artisanal Ritual Satchel functions nearly identically to the regular Ritual Satchel, except it instantly places all the nessecary items for the ritual, and has the added ability to right-click on Golden Bowl to erase all the Chalk Runes and collect all the other items (Skulls, Candles, and Crystals) and return them to the Satchel."
 		""
-		"No, it doesn't restore the durability of the chalk."
+		"No, it doesn't restore the durability of the Chalk."
 	]
 	quest.4CE571F942461909.title: "Tools of the Trade: Artisanal Ritual Satchel"
 	quest.4CE6CABCB2334C0E.quest_desc: ["We have used a bunch of chromium already. But we again need to call on this highly resistive and high hardness metal, except in its liquid form."]
@@ -8032,19 +8032,19 @@
 	quest.4F1FFC02F4EAA2E6.title: "Tier: &4Nitro"
 	quest.4F2BBB75E5B5EAD8.title: "Salts Vein"
 	quest.4F35D04721DFC9FF.quest_desc: [
-		"The first type of Ritual we'll be performing is the &9Summoning Ritual&r. These rituals are used to summon different types of useful Demons to assist you in crushing, smelting, and tons of other things as you get to higher tiers of rituals."
+		"The first type of ritual we'll be performing is the &9Summoning Ritual&r. These rituals are used to summon different types of useful Demons to assist you in crushing, smelting, and more as you get to higher tiers of rituals."
 		""
-		"For our first Ritual, we want to summon a &aFoliot Crusher&r Demon. This Demon will crush items for us, which is something we'll need to make some of the higher level Chalks!"
+		"For our first ritual, we want to summon a &aFoliot Crusher&r Demon. This Demon will crush items for us, which is something we'll need to make some of the higher level Chalks!"
 		""
-		"To start with, combine your Unbound Book with your &aDictionary of Spirits&r in a crafting table. This will bind a Demon to the book, which is what we'll need for the Ritual."
+		"To start with, combine your Unbound Book with your &aDictionary of Spirits&r in a crafting grid. This will bind a Demon to the Book, which is what we'll need for the ritual."
 		""
-		"Speaking of your Dictionary of Spirits, it's time to open it up! On the left, click on the &dPentacles&r tab and click on &bAviar's Circle&r. You might have to advance through it by reading a little bit. There is also a way to click \\\"Mark All As Read\\\" so it unlocks everything in the book."
+		"Speaking about your Dictionary of Spirits, it's time to open it up! On the left, click on the &dPentacles&r tab and click on &bAviar's Circle&r. You might have to advance through it by reading a little bit. There is also a way to click \\\"Mark All As Read\\\" so it unlocks everything in the Book."
 		""
-		"This is what we're going to use to summon our new Friend. On the right side, you can click the eye in the bottom-left corner of the image to build an outline of the Ritual for you in the world. This is super helpful!"
+		"This is what we're going to use to summon our new friend. On the right side, you can click the eye in the bottom-left corner of the image to build an outline of the ritual for you in the world. This is super helpful!"
 		""
-		"Once you've completed the multi-block Ritual, place down 4 (or more for future rituals) Sacrificial Bowls anywhere within 8 block horizontal radius from the center Sacrificial Bowl and use the required items on them. Once you place your Bound Book in the Golden Sacrificial Bowl, the Ritual will start!"
+		"Once you've completed the multi-block ritual, place down 4 (or more for future rituals) Sacrificial Bowls anywhere within 8 block horizontal radius from the center Sacrificial Bowl and use the required items on them. Once you place your Bound Book in the Golden Sacrificial Bowl, the ritual will start!"
 		""
-		"This is what the Ritual will look like."
+		"This is what the ritual will look like."
 		""
 		"{image:atm:textures/questpics/occultism/aviarcircle_v2.png width:200 height:200 align:1}"
 	]
@@ -8546,11 +8546,11 @@
 	]
 	quest.53DD784E75965947.title: "The Beyond"
 	quest.53DEA3DFEDC4809E.quest_desc: [
-		"Don't worry, this is the last of the Abras series of rituals. It is used to summon a &9Marid&r demon, but even though it uses Red Chalk, it's not powerful enough to &9bind&r the demon. This means that, unfortunately, you're going to have to fight it."
+		"Don't worry, this is the last of the Abras series of rituals. It is used to summon a &9Marid&r demon, but even though it uses Red Chalk, it's not powerful enough to &9bind&r the Demon. This means that, unfortunately, you're going to have to fight it."
 		""
-		"By the way, this ritual uses a trident as a sacrifice, which is confusing because most sacrifices are living creatures. So instead of killing a mob on top of the completed ritual circle, you simply throw the trident at the center bowl to start the ritual."
+		"This ritual uses a Trident as a sacrifice, which is confusing because most sacrifices are living creatures. So instead of killing a mob on top of the completed ritual circle, you simply throw the Trident at the center bowl to start the ritual."
 	]
-	quest.53DEA3DFEDC4809E.quest_subtitle: "Is it a bird? Is it a plane? No, it's an unbound &9Marid&r!"
+	quest.53DEA3DFEDC4809E.quest_subtitle: "Is it a Bird? Is it a Plane? No, it's an unbound &9Marid&r!"
 	quest.53DEA3DFEDC4809E.title: "&4Abras' Fortified Conjure"
 	quest.53E2BEA626B35BFC.quest_desc: ["Quite expensive recipe but most definitely worth it! \\n\\nUsing the &6Spectral &4Eye&r will give you the &4Spectral Vision Effect&r. This Effect gives &eGlowing&r to every Mob within a 100 Block radius in every direction! \\n\\nPerfect for finding structures underground, or Bastions in the &c&lNether&r, or even finding your friends hidden Axolotl farm!"]
 	quest.53E2BEA626B35BFC.quest_subtitle: "Very popular in ATM6!"
@@ -8836,7 +8836,7 @@
 	quest.56DA46DC82F6665D.quest_desc: ["The Wilden Chimera is a Boss added by Ars Nouveau and is needed for progressing through it. \\n\\nHe needs to be summoned through a ritual then fought!"]
 	quest.56DA46DC82F6665D.title: "Kill The Wilden Chimera"
 	quest.56E30438AE512475.quest_desc: ["Let's get these flames burning! \\n\\nThe Preheater is a very simple addition to the &l&4Improved Blast Furnace&r. \\n\\nSimply place them on the Left and Right of the &l&4Improved Blast Furnace&r. Then, connect power to the top of it and it will start speeding up the &l&4Improved Blast Furnace&r."]
-	quest.56EC79AF11B0869E.quest_desc: ["&9Xeovrenth Adjure&r is the maximum tier of &5Possession Rituals&r. It only has two uses: creating Cruelty Essence, the main ingredient in Brown Chalk, and creating an Iesnium Golem, which is basically just an Iron golem that's immortal and does more damage."]
+	quest.56EC79AF11B0869E.quest_desc: ["&9Xeovrenth Adjure&r is the maximum tier of &5Possession Rituals&r. It only has two uses: creating Cruelty Essence, the main ingredient in Brown Chalk, and creating an Iesnium Golem, which is basically just an Iron Golem that's immortal and does more damage."]
 	quest.56EC79AF11B0869E.quest_subtitle: "Maximum Possession"
 	quest.56EC79AF11B0869E.title: "&9Xeovrenth Adjure"
 	quest.56FB82DEB944F758.quest_desc: ["Works like the &aMace of Distortion&r, except it causes an AoE explosion instead."]
@@ -9207,25 +9207,25 @@
 	quest.5AC1BE754210429E.quest_desc: ["If you want to create a team for you and your friends, use the command &a/ftbteams party create (name of team)&r to create the team!"]
 	quest.5AC497F76A086A5C.title: "&l&9Overworld Bounty:&r&e Witches"
 	quest.5ACE97EE75813006.quest_desc: [
-		"This quest is your main source of information on &dRituals&r. Here's the basics:"
+		"This is the main source of information on &dRituals&r. Here's the basics:"
 		""
-		"&lTiers of Rituals:&r"
+		"&lTiers of Rituals&r:"
 		""
-		"Rituals have (basically) four tiers based on how powerful the demon that you're invoking is. The first tier is &eFoliot&r, then &aDijini&r, &cAfrit&r, and &9Marid&r. Some rituals fall into in-between tiers, such as the &6Unbound Afrit&r tier."
+		"Rituals have (basically) four tiers based on how powerful the Demon that you're invoking is. The first tier is &eFoliot&r, then &aDijini&r, &cAfrit&r, and &9Marid&r. Some rituals fall into in-between tiers, such as the &6Unbound Afrit&r tier."
 		""
-		"T&lypes of Rituals:&r"
+		"T&lypes of Rituals&r:"
 		""
-		"There are five main types of rituals, but we'll only need four for progression. The main three are &9Summoning Rituals&r, &5Possession Rituals&r, and &6Infusion Rituals&r. Each one will be explained the first time that they appear in this questbook. The fourth type of ritual is a sort of &dDemon-less&r &dRitual&r, meaning that it uses bits and pieces from all three types to preform a special action without the direct usage of a demon. "
+		"There are five main types of rituals, but we'll only need four for progression. The main three are &9Summoning Rituals&r, &5Possession Rituals&r, and &6Infusion Rituals&r. Each one will be explained the first time that they appear in these quests. The fourth type of ritual is a sort of &dDemon-less&r &dRitual&r, meaning that it uses bits and pieces from all three types to preform a special action without the direct usage of a Demon."
 		""
 		"The fifth type, &eFamiliar Rituals&r, are not needed for progression. But they can still be summon some useful friends to help you out!"
 		""
-		"&lChalks:&r"
+		"&lChalks&r:"
 		""
-		"There are two types of chalks: Foundation Chalks, and Colored Chalks."
+		"There are two types of Chalks: Foundation Chalks, and Colored Chalks."
 		""
-		"Foundation chalks are used in every single ritual, and each tier higher gets a shade darker, starting with white chalk and ending with black chalk. "
+		"Foundation chalks are used in every single ritual, and each tier higher gets a shade darker, starting with White Chalk and ending with Black Chalk. "
 		""
-		"Colored Chalks are the most commonly used, but the color of the chalk doesn't directly corelate to its power the same as Foundation Chalks."
+		"Colored Chalks are the most commonly used, but the color of the Chalk doesn't directly corelate to its power the same as Foundation Chalks."
 	]
 	quest.5ACE97EE75813006.title: "The Basics of Rituals"
 	quest.5AD09CCEEDC0B50F.quest_desc: ["Now these are super helpful, you should definitely check them out! \\n\\nThe actual Light Source is the Feral Flare Lantern. It will place invisible Light Sources around 20 Blocks or more around it. \\n\\nThe Mega Torch is different: it doesn't emit Light but it does Block all Hostile Mob spawns with 64 Blocks of it! Useful for those using Night Vision. \\n\\nThe Dread Lamp does the opposite, it blocks Passive Mob spawns in the same area."]
@@ -9239,13 +9239,13 @@
 	quest.5AD80D3242DD3F60.quest_desc: ["One of the hardest materials to get in the mod!\\n\\nThis is also used to create the &6ATM Star&r!"]
 	quest.5AD80D3242DD3F60.title: "&dInsanite Block"
 	quest.5AE80FF518B1BBA6.quest_desc: [
-		"Tired of lugging around chalks, candles, skulls, and crystals? Just make a ritual satchel!"
+		"Tired of lugging around Chalks, Candles, Skulls, and Crystals? Just make a Ritual Satchel!"
 		""
-		"By sneak + right-clicking with the ritual satchel in your hand, you can fill it with all the materials you need to draw a ritual circle."
+		"By sneak + right-clicking with the Ritual Satchel in your hand, you can fill it with all the materials you need to draw a ritual circle."
 		""
-		"Once you've loaded up the satchel, simply right-click any preview block to begin (slowly) automatically placing all the runes for the selected ritual. "
+		"Once you've loaded up the Satchel, simply right-click any preview block to begin (slowly) automatically placing all the runes for the selected ritual. "
 		""
-		"If a piece of chalk inside the bag falls under 40% durability, the enchantment glint on this item will dissapear to signal that it may be time to repair or replace some of your chalks."
+		"If a piece of chalk inside the bag falls under 40% durability, the enchantment glint on this item will dissapear to signal that it may be time to repair or replace some of your Chalks."
 	]
 	quest.5AE80FF518B1BBA6.quest_subtitle: "Pocket Ritual!"
 	quest.5AE80FF518B1BBA6.title: "Tools of the Trade: Ritual Satchel"
@@ -9961,13 +9961,13 @@
 	quest.618F1434757C8E69.quest_desc: ["&lGenerator's Galore&r adds very simple Generators. The most basic ones act like Furnaces with &3Augment&r: Generator. They'll take Fuel and make it into Energy! \\n \\nYes you have to start with &6Copper Generator&r."]
 	quest.618F1434757C8E69.title: "&6Copper Generator&r"
 	quest.61999669BDE127F9.quest_desc: [
-		"If you haven't noticed already, making and re-making rituals over and over again is very taxing on the durability of your chalks. "
+		"If you haven't noticed already, making and re-making rituals over and over again is very taxing on the durability of your Chalks. "
 		""
-		"If you're worried about your chalk breaking, but don't feel like doing the entire ritual to create a new chalk over again, then this ritual is for you!"
+		"If you're worried about your Chalk breaking, but don't feel like doing the entire ritual to create a new chalk over again, then this ritual is for you!"
 		""
-		"Using the power of a &aDijinni&r, you can repair any color of chalk to it's maximum!"
+		"Using the power of a &aDijinni&r, you can repair any color of Chalk to it's maximum!"
 		""
-		"Alternatively, you could use something like the &aEternal Stella&r from the Forbidden Arcanus mod to permenantly preserve your chalks!"
+		"Alternatively, you could use something like the &aEternal Stella&r from the Forbidden Arcanus mod to permenantly preserve your Chalks!"
 	]
 	quest.61999669BDE127F9.quest_subtitle: "You break it, &mwe&r Demons fix it!"
 	quest.61999669BDE127F9.title: "Chalk Repair"
@@ -10526,9 +10526,9 @@
 	quest.6786C701B7C4980B.quest_desc: ["The Gravistar is another very important component for our high tier machines were going to be making."]
 	quest.6786C701B7C4980B.quest_subtitle: "Stars have Lots of Gravity"
 	quest.67884BFA27870CCE.quest_desc: [
-		"&dOsorin's Unbound Calling&r is the second tier of &dDemon-less rituals&r. The first tier isn't useful for progression at all, it's only used for reviving familiars and turning vexes into allays. "
+		"&dOsorin's Unbound Calling&r is the second tier of &dDemon-less rituals&r. The first tier isn't useful for progression at all, it's only used for reviving Familiars and turning Vexes into Allays. "
 		""
-		"This ritual is used to create a ton of rare-ish blocks, items, and materials that you might not be able to (or it's hard to) get normally."
+		"This ritual is used to create a ton of rare-ish blocks, items, and materials that you might not be able to (or it's hard to) get otherwise."
 	]
 	quest.67884BFA27870CCE.quest_subtitle: "For the less trial-chamber-inclined of us"
 	quest.67884BFA27870CCE.title: "&dOsorin's Unbound Calling"
@@ -10718,7 +10718,7 @@
 	quest.690B89D23134B624.quest_desc: [
 		"Grab your chalks, draw your &dRonaza's Contact&r ritual, and get ready to create the ULTIMATE CHALK!"
 		""
-		"Instead of having to lug around a full set of 16 chalks, you can use the rainbow chalk to paint a color-changing rune that counts as any of them! "
+		"Instead of having to lug around a full set of 16 chalks, you can use the Rainbow Chalk to paint a color-changing Rune that counts as any of them! "
 	]
 	quest.690B89D23134B624.title: "&cR&6a&ei&an&9b&5o&dw&r Chalk"
 	quest.690CFF61CE787D43.quest_desc: ["Plastic is the main resource of &bIndustrial Foregoing&r, you now have access to some very useful machines!"]
@@ -11056,10 +11056,7 @@
 		"If you aren't sure what items have NBT data on them, you can always check out the quest \"NBT and You\" in the Storage questline for more info on NBT!"
 	]
 	quest.6CC5FE34778F0DFA.title: "&c&mDemonir&r &dMagical Storage&r!"
-	quest.6CCDEEDA2C99DA66.quest_desc: [
-		"This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks. \\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission. \\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."
-		"Hi I'm in editing mode right now editing this :)"
-	]
+	quest.6CCDEEDA2C99DA66.quest_desc: "This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks.\\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission.\\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."
 	quest.6CD1720B76F47806.quest_desc: ["This generator will burn Bio Fuel into energy. It produces around 140FE/t."]
 	quest.6CD7A3760C6D87E6.title: "Block of Diamond 4X"
 	quest.6CD7D99AA102A5C3.quest_desc: ["&n&f&lLogistics&r: \\nA system of moving, managing, and storing items or resources. \\n\\nIn Modded Minecraft it's quite the same, moving items! With Modded you will need items and by the thousands, heck if you want the &6&lStar&r it gets in the millions! So you'll need to move items from factories, machines, farms, and especially chests. That's what &l&fLogistics&r is for."]
@@ -11407,7 +11404,7 @@
 	]
 	quest.6FD65139CD50A8C0.quest_desc: ["Is that even possible?\\n\\nIf you wish to automate this process you can use &eProductive Bees&r or &aMystical Agriculture&r. Or I guess you could automate it, with...explosions."]
 	quest.6FD65139CD50A8C0.quest_subtitle: "Tired of blowing stuff up?"
-	quest.6FEED25FFAC4101F.quest_desc: ["Using &aStrigeor's Higher Binding&r, you can create Gray Paste. Smear this on a piece of impure white chalk to create Gray Chalk."]
+	quest.6FEED25FFAC4101F.quest_desc: ["Using &aStrigeor's Higher Binding&r, you can create Gray Paste. Smear this on a piece of Impure White Chalk to create Gray Chalk."]
 	quest.6FEED25FFAC4101F.title: "&8Gray Chalk"
 	quest.6FF04DD735346BED.quest_desc: ["Turns Latex into Dry Rubber."]
 	quest.6FF116239EACA390.title: "End Stone 5X"
@@ -11420,7 +11417,7 @@
 		""
 		"When using this in place of a Golden Ritual Bowl, it greatly reduces how long it takes to perform a ritual, taking it down to one fourth of its original time!"
 	]
-	quest.6FFFAE334DFAAAAB.quest_subtitle: "Super-speed rituals!"
+	quest.6FFFAE334DFAAAAB.quest_subtitle: "Super-speed Rituals!"
 	quest.700F3FF7C23D0C0F.quest_desc: ["The &5Ender Cell&r will store power for a channel in your &7Ender Network&r. To increase the power capacity of the network, right click on the Ender Cell to open up the interface, then add either a &aBattery&r or an &9Energy Cell&r to increase the overall capacity."]
 	quest.70112194DFFD15D3.title: "&5Tyr Armor"
 	quest.7026E46FD8B3A81D.quest_desc: ["The &9Hydra&r is the infamous multi-headed beast from Greek Mythology.\\n\\nRanged attacks aren't as effective, meaning you'll need to get up close and personal.\\n\\nOnce defeated, you'll be able to find the next boss in the &2Dark Forest&r."]
@@ -11912,7 +11909,7 @@
 	quest.74015945716FD10A.quest_subtitle: "A configurable hopper"
 	quest.7408CCF998D9CD37.quest_desc: ["A Craftable &eSpell Book&r... yeah it's not easy to craft. \\n\\nHardest to get would be the Ruined Book, which you can find in &9Ancient City&r Chests. &4Blood Vials&r can be obtained from either putting a Mob (or even yourself) into a Cauldron above a Campfire or an Alchemical Cauldron. &5Bottle O' Lightning&r comes from using a Bottle on a Charged Creeper. \\n\\nOnce you do all that you can craft the Ancient Codex. Its 12 &3Spell&r Slots is very helpful!"]
 	quest.7408CCF998D9CD37.title: "Ancient Codex"
-	quest.74130EB1E4B8586D.quest_desc: ["Using &aIhagan's Enthrallment&r, you can sacrifice an allay, bat, bee, or parrot to summon the &6Possessed Bee&r. Upon defeating it, it will drop cursed honey, the main ingredient for making orange chalk!"]
+	quest.74130EB1E4B8586D.quest_desc: ["Using &aIhagan's Enthrallment&r, you can sacrifice an Allay, Bat, Bee, or Parrot to summon a &6Possessed Bee&r. Upon defeating one, it will drop Cursed Honey, the main ingredient for making Orange Chalk!"]
 	quest.74130EB1E4B8586D.title: "&6Orange Chalk"
 	quest.7413BB136EF9D6C5.quest_desc: ["The Mechanical Drying Basin uses energy to dry"]
 	quest.74200A48498DD7F8.quest_desc: ["Generates power from the sun!"]
@@ -12667,7 +12664,7 @@
 	quest.7BC616DDB5933479.quest_desc: ["This one can be created with a &5Blood Vial&r and normal ingrediants for Scrolls. \\nYou will need to make sure it is Level 10 and &6Legendary&r which you can upgrade it to."]
 	quest.7BC616DDB5933479.title: "&4Wither Skull Scroll"
 	quest.7BC8F50A89A3BE1A.quest_desc: ["These are just used to Connect &cLaser Nodes&r to each other and to Connectors. Not too important I just wanted to keep with the theme of Wrenches. \\n\\nIt does work as a Wrench for other Configs!"]
-	quest.7BCD4A425CF6199B.quest_desc: ["After slaying the Goat of Mercy summoned from &9Xeovrenth Adjure&r, you'll find yourself one Cruelty Essence richer. Combine this with some cocao beans to create Brown Chalk."]
+	quest.7BCD4A425CF6199B.quest_desc: ["After slaying the Goat of Mercy summoned from &9Xeovrenth Adjure&r, you'll find yourself one Cruelty Essence richer. Combine this with some Cocao Beans to create Brown Chalk."]
 	quest.7BCD4A425CF6199B.title: "&#4E2C00Brown Chalk"
 	quest.7BCE96070C36D547.quest_subtitle: "&f7.5 &cAttack Damage"
 	quest.7BFC24607189B6D0.quest_desc: ["Makes you swim faster."]

--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -116,6 +116,8 @@
 	quest.00A17728A387B426.quest_desc: ["Wood Nests are used to lure Carpenter Bees and the Blue Banded Bee.\\n\\nDark Oak Nests lures 3 different bees.\\n\\nThese can be placed in any Overworld Biome."]
 	quest.00A17728A387B426.quest_subtitle: "Can be used in any Overworld biome"
 	quest.00A17728A387B426.title: "Wood Nests"
+	quest.00A6020BC979947F.quest_desc: ["With your freshly summoned &9Marid Crusher&r, you can break down an echo shard and an Iesnium ingot, which combine with a glow ink sac to create Cyan Chalk."]
+	quest.00A6020BC979947F.title: "&3Cyan Chalk"
 	quest.00A91BD731486644.quest_subtitle: "Ceylon Ebony + Sour Cherry"
 	quest.00AC7CC291A3E590.quest_desc: ["You've probably (definitely) seen structures around the world with what looks like Beacons coming out of them. They're made of cobblestone, have 4 legs supporting them, kinda high in the air! \\n\\nHopefully you know it but they're called &8Dark Temples&r and they have an &aEnviromental Accumulator&r which we need. \\n\\nYou'll have to wait for Thunderstorm to happen to fill your Weather Container. Then, you can make your &3Lightning Bomb&r!"]
 	quest.00AC7CC291A3E590.title: "&3Lightning Bomb"
@@ -331,6 +333,8 @@
 	]
 	quest.030AC1AF8F735550.quest_desc: ["To get liquids into the Tank you'll need some sort of Pipes.\\n\\nThe Hydro Pump can automatically put Water into them at a slow rate, but also for free!"]
 	quest.030AC1AF8F735550.title: "Pipes"
+	quest.03250A0202C25E80.quest_desc: ["After you've successfully slain the &9unbound Marid&r demon that you summoned with &4Abras' Fortified Conjure&r, you can use the &9Marid Essence&r that it drops to craft the \"highest\" Colored Chalk, Blue Chalk."]
+	quest.03250A0202C25E80.title: "&9Blue Chalk"
 	quest.032B654201E71618.quest_desc: ["These &cTrack Kits&r are for using entities with your &7Carts&r (Entities aka Mobs). \\n\\nThe &cEmbarking Kit&r will pick up any Mobs nearby and put them in a &7Cart&r. \\nThe &cDisembarking Kit&r unloads Mobs from the &7Carts&r. \\nThe &cDumping Kit&r will drop the mobs in the &7Carts&r below the &6tracks&r its on."]
 	quest.032B654201E71618.title: "&cTrack Kits&r for moving entities"
 	quest.033BF8D12E32A5E5.quest_desc: ["Take that Ruthenium Dust and get to mixing! "]
@@ -856,6 +860,11 @@
 	quest.0854AD352218E1C3.quest_desc: ["Don't you hate when you have all this power but no Heating? \\n\\nNow you can change that with the Caloric Flux Emitter! Shift Right Click with it to bind it to a Machine. Then place it down and power it to send Heat. \\n\\nCan't be set to multiple Machines!"]
 	quest.0854AD352218E1C3.quest_subtitle: "How?"
 	quest.0854AD352218E1C3.title: "Wireless Heat"
+	quest.08697EB269B011FD.quest_desc: [
+		"With &dRonaza's Contact&r, you can upgrade your &bIesnium Sacrificial Bowl&r to the Eldritch Chalice. When used in a ritual, reduces the time it takes to complete... entirely. "
+		""
+		"Yes, the Eldritch Chalice makes it so that all rituals complete instantly!"
+	]
 	quest.087726194EED4BDF.quest_desc: ["Hold a Shield in your off hand and the Scroll of Strengthening in your main and hold right click."]
 	quest.087726194EED4BDF.title: "Strong Shield"
 	quest.088D685775ED92EE.quest_desc: [
@@ -890,14 +899,6 @@
 	quest.089D22E6B361EBA4.quest_desc: ["Preparing components for the Micro Universe Drill Ship."]
 	quest.089D22E6B361EBA4.quest_subtitle: "Thrusters to Full!"
 	quest.08AC2D81A1004984.title: "&6Allthemodium &5Alloy &3Trident"
-	quest.08B1A64B01A8A604.quest_desc: [
-		"While there are other methods to move Demons around, you can create an &dEmpty Soul Gem&r to capture a Demon and place it somewhere else."
-		""
-		"To make this, we'll need to do a more advanced Ritual called &aStrigeor's Higher Binding&r. For this, you'll need &a8 Sacrificial Bowls&r as well as the items required for this quest."
-		""
-		"Remember, you can always use the multi-block preview by finding the Pentacle in the &bDictionary of Spirits&r to help you build the structure."
-	]
-	quest.08B1A64B01A8A604.title: "&bCapturing &dDemons"
 	quest.08B60D8A25008CCC.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks. \\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission. \\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
 	quest.08C66BCA3AAE765B.quest_desc: ["This one adds Non-&2&lMinecraft&r Blocks so I'd rather not discuss it."]
 	quest.08C66BCA3AAE765B.title: "&b&lMacaw's Roofs"
@@ -1039,6 +1040,13 @@
 	quest.0A207A437AF153AA.title: "&2Phantom Armor"
 	quest.0A21773B773F34F8.quest_desc: ["Color is one of the most important parts of making a Build more lively! \\n\\nIt gives it life, personality, and color! \\n\\nStart with the Dyes!"]
 	quest.0A21773B773F34F8.title: "Colored Blocks"
+	quest.0A25276925EB0CBA.quest_desc: [
+		"Once you've gathered every single Colored Chalk and Foundation Chalk, you can perform the second &dDemon-less&r type ritual, &dRonaza's Contact&r. This is ultimate ritual, using everything you've learned so far!"
+		""
+		"It has limited uses, but everything created with this ritual is super powerful!"
+	]
+	quest.0A25276925EB0CBA.quest_subtitle: "With this sacred treasure I summon..."
+	quest.0A25276925EB0CBA.title: "&dRonaza's Contact"
 	quest.0A2675CF16B6443B.quest_desc: [
 		"Extruders force ingots into various shapes with the use of the extruder mold"
 		""
@@ -1124,7 +1132,11 @@
 	quest.0B2B8247DA280E90.quest_desc: ["This rune increases the total capacity of the Altar by 20% for each Capacity rune."]
 	quest.0B37355262121DD5.quest_desc: ["The &aInfusion Altar&r is how you make all of the seeds. Place down the Altar first and it'll show you where to place the Pedestals after.\\n\\nIn order for the Infusing to start, the Alter requires a &4Redstone signal&r."]
 	quest.0B37355262121DD5.quest_subtitle: "Creating Seeds"
-	quest.0B3EA604C5172D98.quest_desc: ["For us to specify which &c&mDemon&r &9Friend&r we want to summon, we'll need to make a specific &bBook of Binding&r.\\n\\nTo make this, you'll need to purify some Black Dye in &dSpiritfire&r to get Purified Ink. With this, we're going to make our first Book of Binding which will summon a &aFoliot&r Demon."]
+	quest.0B3EA604C5172D98.quest_desc: [
+		"For us to specify which &c&mDemon&r &9Friend&r we want to summon, we'll need to make a specific &bBook of Binding&r.\\n\\nTo make this, you'll need to purify some Black Dye in &dSpiritfire&r to get Purified Ink. With this, we're going to make our first Book of Binding which will summon a &aFoliot&r Demon."
+		""
+		"Alternatively, you can make an Empty Book of Binding, which can be dyed later to fit whatever tier of ritual you need."
+	]
 	quest.0B3EA604C5172D98.title: "&bBooks of &dBinding"
 	quest.0B485DB737A036E9.quest_desc: ["Machine Settings Copier allows players to copy settings between machines."]
 	quest.0B6772E52FE97284.quest_subtitle: "&f11&r &4Damage&r"
@@ -1169,6 +1181,17 @@
 	quest.0BCC79C1D002F532.title: "Infinite &9Water&r!!!"
 	quest.0BCCDE24D378F260.quest_subtitle: "Tier: &d3"
 	quest.0BCCDE24D378F260.title: "&dAdvanced Machine Frame"
+	quest.0BD6365534BF04D5.quest_desc: [
+		"With our lime chalk in hand, it's time to delve into &5Possesion Rituals&r. These rituals are slightly different from the others because they all require a live sacrifice, usually small mobs such as chickens, bees, bats, etc. However, as rituals get more complicated, they will require larger and larger sacrifices. "
+		""
+		"Even if you've placed all of the items needed and the Book of Binding into the Golden Sacrificial Bowl, the Ritual will not begin until you kill the sacrifice on top of the runes."
+		""
+		"We reccomend that you make some sort of mob capture item such as an empty soul gem, jar, Mob Imprisonment Tool, or Quantum Catcher!"
+		""
+		"The first tier of &5Possession rituals&r is &eHeidryn's Lure&r, which is only used to get mundane items like skeleton skulls and end stone. Because of this, we're skipping right to the second tier ritual, &aIhagan's Enthrallment&r. "
+	]
+	quest.0BD6365534BF04D5.quest_subtitle: "Who ya gonna call?"
+	quest.0BD6365534BF04D5.title: "&aIhagan's Enthrallment"
 	quest.0BD908937BC6E97B.quest_subtitle: "Kapok + Rosewood"
 	quest.0BE2E7C9454058C3.quest_desc: [
 		"Part of the beautiful &d&lFloral Meadow&r is a &dCherry Tree&r much older and bigger than the rest. \\n\\nThe &6B&8e&6e&8s&r have seemed to take a liking to these &dTrees&r and have set up mini &eHives&r next to them full of their young!"
@@ -1273,6 +1296,9 @@
 	quest.0CF6D11016BAF3D0.quest_subtitle: "Complex Naquadah"
 	quest.0D01524F249E25D7.quest_subtitle: "Who turned off the lights?"
 	quest.0D01524F249E25D7.title: "&8Dark Xychorium Gems"
+	quest.0D18BBB04693885A.quest_desc: ["Strigeor's Higher Binding is the second tier of &6Infusion Rituals&r. It's used for a TON of different things, but the main things we'll need are the Infused Pickaxe and Gray Paste."]
+	quest.0D18BBB04693885A.quest_subtitle: "The \"everything\" ritual"
+	quest.0D18BBB04693885A.title: "&aStrigeor's Higher Binding"
 	quest.0D19FB62C2C1D9F7.quest_desc: ["Once you've got at least 200 &4Mahou&r you might want to make a Boundary of Life Drain. \\n\\nFor every Mob that dies in that boundary, you get 10 &4Mahou&r back, but this is a SLOW process."]
 	quest.0D19FB62C2C1D9F7.title: "Boundary of Life Drain"
 	quest.0D1A6B32FEB51FAD.quest_desc: [
@@ -1707,6 +1733,8 @@
 	quest.1194FF35ADAA9957.quest_subtitle: "Sharks with Laser beams?"
 	quest.119FF09D481F9178.quest_desc: ["What good would a tech mod be without barrels and tanks. They could be useful, but functions the same as other items of the same."]
 	quest.119FF09D481F9178.title: "Tanks and Barrels"
+	quest.11A0593C0E2E6A35.quest_desc: ["Using &eEziveus' Spectral Compulsion&r, we can imbue a myriad of different nature blocks to form some &2Nature Paste&r. Combine this paste with some impure white chalk to create Green Chalk."]
+	quest.11A0593C0E2E6A35.title: "&2Green Chalk"
 	quest.11AAA1DCB452DFFC.quest_subtitle: "For"
 	quest.11B0B93D725ABE43.quest_desc: ["Silent Gear gear can be repaired using a &9Repair Kit&r.\\n\\nTo repair an item, place the Repair Kit into a crafting grid, then place the materials needed to repair the tool in with it. This will \"fill\" the Repair Kit.\\n\\nTo repair the tool, combine the filled Repair Kit with the tool you'd like to repair in a crafting grid."]
 	quest.11B0B93D725ABE43.quest_subtitle: "No Anvils required"
@@ -2033,16 +2061,11 @@
 	quest.1452D9CF827782B5.quest_subtitle: "16"
 	quest.1452D9CF827782B5.title: "&fArctic Gear"
 	quest.145C8235BCCB9BA8.quest_desc: [
-		"No, not that kind."
+		"If we want to collect all of the Chalks, we'll need to summon and kill aa not-so friendly &cAfrit&r."
 		""
-		"&cAfrit Demons&r are Demons of &cFire&r. They are more advanced Demons, which some are friends and some are....not."
-		""
-		"If we want to collect all of the Chalks, we'll need to summon a not-so friendly Ifrit. And kill it."
-		""
-		"This specific Ritual will need a live sacrifice. Once you've placed all of the items needed and the Book of Binding into the Golden Sacrificial Bowl, the Ritual will not start until you sacrifice the living creature nearby it. In this instance, we'll be sacrificing a cow. Sorry again, Betsy."
+		"Even though this isn't a &5Possession Ritual&r, you'll need a live sacrifice for this ritual. In this instance, we'll be sacrificing a cow. Sorry Betsy!"
 	]
-	quest.145C8235BCCB9BA8.quest_subtitle: "R.I.P. Betsy"
-	quest.145C8235BCCB9BA8.title: "&cHot Demons"
+	quest.145C8235BCCB9BA8.title: "&cRed Chalk"
 	quest.145E7D1A88B83DDD.quest_desc: ["Where'd you go?"]
 	quest.145E7D1A88B83DDD.quest_subtitle: "Scarf (Necklace)"
 	quest.145E7D1A88B83DDD.title: "&9Scarf of Invisibility&r"
@@ -2435,6 +2458,15 @@
 	]
 	quest.1834B5C1F8435D7A.quest_subtitle: "Fluids"
 	quest.1843C79133DFB024.quest_desc: ["The most powerful and efficient Generator, the Netherstar Generator. Take a guess what it uses to make Energy!"]
+	quest.1848F431D0380DA9.quest_desc: [
+		"Similar to the Chalk Repairing function of &aStrigeor's Higher Binding&r, &cSevira's Permanent Confinement&r can be used to repair items using the power of an Afrit demon."
+		""
+		"This ritual can repair just about anything, so &edemon miners&r, tools, and armor can all be restored to their original durability! "
+		""
+		"All items that are repaired using this ritual retain their original properties (affixes, enchantments, etc.), so don't worry about your precious level 10 enchantments!"
+	]
+	quest.1848F431D0380DA9.quest_subtitle: "Free(ish) durability!"
+	quest.1848F431D0380DA9.title: "Repairing Items"
 	quest.184F98BE0F6710E2.quest_desc: ["These 2 &cTrack Kits&r are for using &7Carts&r and Redstone.\\n\\nThe &cActivator Kit&r will activate whatever &7Cart&r goes over it. \\nThe &cDetector Kit&r will activate a redstone signal whenever a &7Cart&r passes over it. \\n\\nBoth are similar to their &2Vanilla&r counters for regular &6tracks&r."]
 	quest.184F98BE0F6710E2.title: "&cTrack Kits&r for using Redstone"
 	quest.185074907753AE77.quest_desc: ["If you are using Routers I hope you have some game knowledge. \\n\\nJust incase, to void an Item means to delete it. \\n\\nAny items that come into the Router, will be deleted forever! \\n\\nRecommend using Filters with this one..."]
@@ -2726,6 +2758,17 @@
 	quest.1BCE8D02CDD13838.quest_desc: ["Can Create \\\"Liquid\\\" Potions that can be bottled into Potions."]
 	quest.1BD5B25B80EC0F97.quest_desc: ["Also makes those magnetic iron rods for just some energy - save your redstone!"]
 	quest.1BD5B25B80EC0F97.quest_subtitle: "Magnetizing!"
+	quest.1BDB369FD243D4C6.quest_desc: [
+		"Arguably the most useful item that you can create in the Occultism modpack, the &bIesnium Anvil&r is a super-powerful version of the anvil."
+		""
+		"Created using &9Uphyxes' Inverted Tower&r, it:"
+		""
+		"- Is unbreakable"
+		"- Increases the maximum level of all enchants for anything combined on it by one level"
+		"- Costs 1/2 as much xp as the estimate says (rounded down, so if it says 25, it'll cost 12)"
+		"- Has a smaller xp-requirement increase for repeated edits on the same item"
+		"- Increases the maximum xp level at which you can edit items (the point at which it says \"Too Expensive!\")"
+	]
 	quest.1BE26A00A420DAE3.quest_desc: ["In this mod, you'll need &aFlux Cores&r and &aFlux Blocks&r to craft the core parts of your network. Make a few of each!"]
 	quest.1BE26A00A420DAE3.title: "The 'Core' Crafting Materials"
 	quest.1BE2CB4684AF7DFB.quest_subtitle: "Diamonds may be hidden in here"
@@ -2902,7 +2945,7 @@
 	quest.1DCFC67A8E3DCA2C.quest_desc: ["Similar to the Alchemy Catalyst, when placed under a Mana Pool, the &9Conjuration Catalyst&r unlocks the abillity to use conjuration recipes. "]
 	quest.1DDA5ADA11DF868F.quest_desc: ["Now we can upgrade our Multiblock structures Tiers! EBF's, VF's, Crackers, LFD, and more! They can process faster, and they can process &dLuV&r tier materials! Lets Go!"]
 	quest.1DDA5ADA11DF868F.quest_subtitle: "LuV Energy Hatch at Last!"
-	quest.1DE0F289821F55D1.quest_desc: ["Now that we have a Foliot Crusher, we can &muse&r politely ask it to crush down some &eEnd Stone&r and &9Obsidian&r for us. We'll use these to make some new Chalk!"]
+	quest.1DE0F289821F55D1.quest_desc: ["Now that we have a Foliot Crusher, we can &muse&r politely ask it to crush down some &eEnd Stone&r, &9Obsidian&r, &7Calcite&r for us. We'll use these to make some new Chalk!"]
 	quest.1DE0F289821F55D1.title: "&aChalking It Up"
 	quest.1DE8B0C9A7195720.quest_desc: [
 		"Once you've finished placing in all of the required blocks to build the Reactor, it should give off red particles to show that it is complete.\\n\\nRight clicking anywhere on the Reactor will open up the &aInterface&r. This will have all of the information you need to run the Reactor properly, as well as two buttons to turn on and off the Reactor.\\n\\nOn the left, you have 2 tanks: One for &bCoolant&r and one for &3Fissile Fuel&r. On the right, you have one for &8Nuclear Waste&r, and one for &bHeated Coolant&r, which will most likely be &bSteam&r.\\n\\nThe &cTemperature&r bar will show you how hot the Reactor is. After a certain temp, the Reactor will start taking &4Damage&r, which will eventually cause the Reactor to explode.\\n\\nTo adjust the &cBurn Rate&r of the Fissile Fuel and see more statistics, click on the (I) tab on the left side. Here, you can adjust the Rate Limit, which controls how much fuel the Reactor burns per tick.\\n"
@@ -2978,6 +3021,8 @@
 	quest.1EABF2E7AE7B8F22.title: "&8Netherite&r"
 	quest.1EB04FE105ACA4BE.quest_desc: ["When a &9Warden&r dies it has a chance to drop a &9Heart of the Deep&r. \\n\\nThis can be used for the &6&lATM Star&r, or to activate the Portal in the Ancient City! \\n\\nThere can't be anything in the Portal to activate it, that includes &9Sculk&r!"]
 	quest.1EB04FE105ACA4BE.title: "&9Heart of the Deep"
+	quest.1EB887F8072439A3.quest_desc: ["After using &9Fatma's Incentivized Attraction&r to summon a &9Marid Crusher&r, you can turn ice, packed ice, and blue ice into their crushed forms, and use these to create Light Blue Chalk."]
+	quest.1EB887F8072439A3.title: "&bLight Blue Chalk"
 	quest.1EBD5E4410A6DF34.quest_subtitle: "Feed a Ghostly Bee a Soulium Dagger"
 	quest.1EBD5E4410A6DF34.title: "Soulium Bee"
 	quest.1EBF234015B26F15.quest_desc: ["Basic Armor added by &a&lRoots Classic&r, you'll need a Ritual to get it though!"]
@@ -4009,6 +4054,13 @@
 	quest.2951B1D7080C5EF9.quest_desc: ["Using the &6Lamp of Cinders&r, you are able to break the Thorns in the Thornland Biome.\\n\\nGather some &cThorn Roses&r to continue on to the &2Final Plateau&r."]
 	quest.2951B1D7080C5EF9.title: "Every Thorn has its Rose"
 	quest.295C77EEC89000FC.quest_subtitle: "Generates Source from Mob Deaths and Animal Breeding"
+	quest.2960FFE0C53DFEB1.quest_desc: [
+		"&cSevira's Permanent Confinement&r is the third tier of &6Infusion Rituals&r. It's mainly used to create the next level of foundation chalk, Black Chalk."
+		""
+		"It's also used to create a couple of items that can speed up ritual making and performing by a significant amount."
+	]
+	quest.2960FFE0C53DFEB1.quest_subtitle: "The \"even more everything\" ritual"
+	quest.2960FFE0C53DFEB1.title: "&cSevira's Permanent Confinement"
 	quest.29706E3681616E41.quest_subtitle: "That's a Lot of Different Dusts!"
 	quest.2982D38BD5EE6349.quest_subtitle: "Feed a Shroombee Warped Fungus"
 	quest.2982D38BD5EE6349.title: "Warped Shroombee"
@@ -4032,6 +4084,16 @@
 		"{image:atm:textures/questpics/bumblezone/bumble_purple2.png width:200 height:100 align:center}"
 	]
 	quest.29C78845B488EDF8.title: "&5Purple Sempiternal Sanctum"
+	quest.29C83B00AC4AFC23.quest_desc: [
+		"Now that you've completed the Occultism questline, you may be asking yourself, what's next? Well, there are so many more things to explore in Occultism! "
+		""
+		"You can see a comprehensive list of every single ritual and item in your &6Dictionary of Spirits&r, try going through all the rituals' outcomes to see if you can find something that piques your interest!"
+		""
+		"If you haven't already, you could lie out and decorate three separate ritual areas, one for summons, one for possessions, and one for infusions."
+		""
+		"With any mod, there's always new ways to use each and every seemingly mundane feature to maximize your experience with the modpack. Happy ritual crafting!"
+	]
+	quest.29C83B00AC4AFC23.title: "What's Next?"
 	quest.29C9F8719DA63D8D.quest_desc: ["The &2&lBuzzsaw&r works similar to the &4&lMining Drill&r, just for &2Trees&r! \\n\\nIt requires &2Bio-Diesel&r as Fuel, which I won't explain how to get here either! \\n\\nAnd some sort of &8Sawblade&r. Which you can attach via the Top Slot in the &6Engineer's Workbench&r. \\n\\nSimply break Logs on a &2Tree&r and every Log, Leaf, and Birds Nest will come down with it! You can hold Shift to not break everything attached. \\n\\nThe &2&lBuzzsaw&r also does 10 Damage! Dang, why even use a Sword? Oh yeah &8Saws&r have Durability and it needs &2Bio-Diesel&r. \\n\\nThe &2&lBuzzsaw&r can hold 1 &8Blade&r or &8Disk&r and 2 Upgrades."]
 	quest.29C9F8719DA63D8D.title: "&2&lBuzzsaw"
 	quest.29CD5C0A253425D5.quest_desc: [
@@ -4113,6 +4175,12 @@
 		""
 		"There is an alternate recipe that uses Allyl Chloride and Hypochlorous Acid, if you so choose to go that route"
 	]
+	quest.2A3683BF7E50EF83.quest_desc: [
+		"Most of the items we've needed from the &3Otherworld&r so far just needed some Spiritfire. However, we will need to use the help of the &3Third Eye&r to find the Ore of the &3Otherworld&r."
+		""
+		"We'll also need a special pickaxe to be able to mine it. For this, we'll need to Infuse a Demon into a &dSpirit Attuned Pickaxe Head&r to create a pickaxe that can break this new kind of ore."
+	]
+	quest.2A3683BF7E50EF83.title: "Tools of the Trade: Infused Pickaxe"
 	quest.2A4FE9644F3B9DC1.quest_desc: ["Upgraded version of &2Prudentium&r."]
 	quest.2A4FE9644F3B9DC1.quest_subtitle: "26"
 	quest.2A4FE9644F3B9DC1.title: "&cTertium Armor"
@@ -4121,7 +4189,8 @@
 		""
 		"This is what the &dOtherworld Goggles&r are for! When equipped (even in your Curios slot), it gives the Third Eye effect!"
 	]
-	quest.2A5004EB99AE4F96.title: "Quit Eating That Fruit!"
+	quest.2A5004EB99AE4F96.quest_subtitle: "Quit eating that fruit!"
+	quest.2A5004EB99AE4F96.title: "Tools of the Trade: Spectral Goggles"
 	quest.2A50A687C40DB864.quest_desc: [
 		"&6&lHive Walls&r are the foundation of the &l&6Bumblezone&r. \\n\\nThey are massive walls of &6Honey Combs&r and &eWax&r that go from the floor to the roof. \\n\\nThey also hold &lProductive Bee&r Combs and holes in the &6&lWalls&r where Brood Blocks will spawn."
 		"{image:atm:textures/questpics/bumblezone/bumble_hivewall.png width:200 height:100 align:center}"
@@ -4174,6 +4243,13 @@
 		"{image:atm:textures/questpics/bumblezone/bumble_constructs.png width:200 height:100 align:center}"
 	]
 	quest.2AD13B965611DC86.title: "&7&lHowling Constructs"
+	quest.2AD68066C1948C90.quest_desc: [
+		"That first &eFoliot Crusher&r was cool, but what if I told you that you could summon a demon that gives you 6 dusts per raw ore it crushes?"
+		""
+		"The &9Marid Crusher&r does exactly that. To summon one, you'll need to use &9Fatma's Incentivized Attraction&r. "
+	]
+	quest.2AD68066C1948C90.quest_subtitle: "Maximum Summon"
+	quest.2AD68066C1948C90.title: "&9Fatma's Incentivized Attraction"
 	quest.2AD78E22988A92D3.quest_desc: ["I see you! \\n\\nWhen wearing &2Night Vision Goggles&r you get the ability to see in the dark! Not much else to them..."]
 	quest.2AD78E22988A92D3.quest_subtitle: "Head"
 	quest.2AD78E22988A92D3.title: "&2Night Vision Goggles"
@@ -4398,6 +4474,13 @@
 	quest.2CF11A70229000AB.title: "Getting Create-ive."
 	quest.2CF6EA138B53CE1B.quest_desc: ["&3Vibranium&r combined with &5Unobtainium&r!"]
 	quest.2CF6EA138B53CE1B.title: "&5Unobtainium&r - &3Vibranium&r Alloy Ingot"
+	quest.2CF96A264EB5522C.quest_desc: [
+		"&9Uphyxes' Inverted Tower&r is the maximum tier of &6Infusion Rituals&r. It doesn't have as many uses as the other three tiers, but it's still nessecary for the \"endgame\" of Occultism. "
+		""
+		"Mainly, it's used to create Dragonyst Dust, which is the main ingredient for Magenta Chalk."
+	]
+	quest.2CF96A264EB5522C.quest_subtitle: "Maximum Infusion"
+	quest.2CF96A264EB5522C.title: "&9Uphyxes' Inverted Tower"
 	quest.2CFEE04BA574921E.quest_desc: [
 		"This interface will place the designated block in the direction it is pointed. "
 		""
@@ -4513,6 +4596,8 @@
 	]
 	quest.2E596B5A4EA2ABF4.title: "&3S'Mog&r"
 	quest.2E5EF984B9CE0CB9.quest_desc: ["The all in one, big battery, big range ore/fluid finder"]
+	quest.2E68E1D96B25336D.quest_desc: ["After fighting through a few Demon possessed zombie piglins summoned by &6Abras' Open Commanding Conjure&r, you can use the Demonic Meat dropped by them to craft some Pink Chalk."]
+	quest.2E68E1D96B25336D.title: "&dPink Chalk"
 	quest.2E6D11A5F5626A6C.quest_subtitle: "Tier: &f2"
 	quest.2E6F1C8718EB8C66.title: "&4Blood&r Upgrade Orb"
 	quest.2E6F761585C1FB4D.quest_subtitle: "Ash + Silver Lime"
@@ -4656,6 +4741,7 @@
 	quest.2FB62AE3C62CA052.quest_subtitle: "&f4.5&r &4Damage&r"
 	quest.2FC15D3916DBF4E4.quest_subtitle: "More Filtering Options"
 	quest.2FC15D3916DBF4E4.title: "&eAdvanced Void Upgrade"
+	quest.2FD22502E6481269.quest_desc: ["Using &dRonaza's Contact&r, you can upgrade your soul gem to create a trinity gem. It's basically just a beefed up version of the soul gem that can capture larger enemies, although it still can't contain most bosses."]
 	quest.2FDACD6F153D5B64.quest_desc: ["Processing Sheldonite and purifying it will allow you to get the highest return on Platinum Group Sludge. This Sludge contains resources you need to progress."]
 	quest.2FDACD6F153D5B64.quest_subtitle: "My Friend Sheldon went to a club on nite."
 	quest.2FE4B7B70D90A455.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks.\\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission.\\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
@@ -4743,6 +4829,8 @@
 		"{image:atm:textures/questpics/bumblezone/bumble_cell.png width:200 height:100 align:center}"
 	]
 	quest.30C12E249F7E2D52.title: "Cell Maze"
+	quest.30C5B597610F4AFB.quest_desc: ["The first and most important item to make using Eziveus' Spectral Compulsion is the Research Fragment Dust. This is used in combination with some crushed emeralds to create lime chalk!"]
+	quest.30C5B597610F4AFB.title: "&aLime Chalk"
 	quest.30CD69FC601F26B5.quest_desc: ["Now just 1 more processing step before you can finally craft the Naquadah Alloy Frame&l"]
 	quest.30CD69FC601F26B5.quest_subtitle: "Naq Alloy Time!"
 	quest.30D97EABFE772604.quest_desc: ["Now we can push 64Amps from our substations at the ZPM tier!"]
@@ -5185,6 +5273,8 @@
 		"This takes a lot of Cyanite, so start stocking up! You might want to upgrade to a bigger reactor as well. "
 	]
 	quest.354086C858E10154.title: "Reprocessing our Waste"
+	quest.3543563DF036D461.quest_desc: ["To create Dragonyst Dust, you'll need to perform &9Uphyxes' Inverted Tower&r. However, to create Magenta Chalk, you'll also need some materials that you can only get through the &9Marid Crusher&r."]
+	quest.3543563DF036D461.title: "&#AD00C8Magenta Chalk"
 	quest.355244420EA47546.quest_desc: ["Fabricator is the Auto-Crafter. It will take items from the inventory below and make a set recipe.\\n\\nYou can lock recipes with CTRL Click. It will need to pipe out the created items though."]
 	quest.355244420EA47546.quest_subtitle: "Auto-Crafter"
 	quest.356102D5B5F3CA1E.quest_desc: ["An Alloy added by &6&lForbidden \\& Arcanus&r is &5Obsidiansteel&r. \\n\\nIt's created in the &l&bClibano&r, by combining Raw Iron and &5Obsidian&r. \\n\\nYou'll need an Artisan Relic in order to actually make the Alloy! \\n\\nAlso you'll get &6Copper&r as residue, which probably isn't supposed to happen..."]
@@ -5303,6 +5393,8 @@
 	quest.3663E93E169EF8E3.title: "&2Uranium Hexafluoride"
 	quest.3673893C88EB5EDE.quest_desc: ["Use 3 other crystals to craft this crystal."]
 	quest.3673893C88EB5EDE.quest_subtitle: "Weathering the Storm"
+	quest.367E891A50991436.quest_desc: ["Using &cSevira's Permanent Confinement&r, we can combine several different wither materials and some netherite to create three Witherite Dust. With these, we can create ourselfs the highest form of Foundation Chalk, Black Chalk."]
+	quest.367E891A50991436.title: "Black Chalk"
 	quest.36836AD948F96B9F.quest_desc: [
 		"The simplest of the simplest of &e&lPipes&r, the &eItem Pipe&r. \\n\\nIt will move Items from one Inventory to another. Could be from one Chest to another, could be a Farm to a System, or even a Quarry to a Smelter. \\n\\nVery simple just connect the &ePipes&r to what you want moved, and use your Wrench to configure which side it Pulls from. "
 		"{image:atm:textures/questpics/logistics/pipez_item.png width:200 height:50 align:center}"
@@ -5480,6 +5572,15 @@
 	quest.3889D0255074CE85.quest_desc: ["&bMacaw&r decided the furniture wasn't enough, he needed his Macaw home to have more than just natural lighting from his &b&lMacaw Windows&r. \\n\\nSo now we have &b&lMacaw's Lights and Lamps&r which adds all sorts of Light Sources. \\n\\nFrom Lamps to Lanterns to Chanderliers!"]
 	quest.3889D0255074CE85.title: "&l&bMacaw's Lights and Lamps&r"
 	quest.38954551309F42A7.quest_desc: ["Sender Module MK2 works similar to MK1 but with less restrictions. \\n\\nMK2 doesn't need direct line of sight or to be on same XYZ axis. \\n\\nWill have to be in the same Dimension though, unless you have..."]
+	quest.38A1295878B68F83.quest_desc: [
+		"No, not that kind."
+		""
+		"&cAfrit Demons&r are Demons of &cFire&r. They are more advanced Demons, which some are friends and some are... not. It all depends on how strongly the ritual can control the &cAfrit&r. "
+		""
+		"Because we don't have access to red chalk yet, all we can summon is an &9unbound&r demon, meaning it cannot be controlled and will be violent."
+	]
+	quest.38A1295878B68F83.quest_subtitle: "Hot Demons!"
+	quest.38A1295878B68F83.title: "&6Abras' Open Conjure"
 	quest.38A77DBAD24C4B53.quest_subtitle: "Tier: &63"
 	quest.38ADDF7FF4E4892D.quest_desc: ["The &7Glass Sword&r deals 40 hearts of damage, but only has 1 durability.\\n\\nYou can make it indestructible if you want to use it.\\n\\nThese are rarely found in loot chests in the &bAurora Palace&r."]
 	quest.38ADDF7FF4E4892D.title: "&7Glass Sword"
@@ -5533,6 +5634,15 @@
 	quest.39605F1FEB1A5A1C.title: "AllRightsReserved"
 	quest.39615B8E568E0380.quest_desc: ["Take the Yttrium Barrium Cuprate and make wires."]
 	quest.39615B8E568E0380.quest_subtitle: "Yit-Trium? is the Y silent?"
+	quest.39647A2473F6F7D7.quest_desc: [
+		"Our next step is a foray into &6Infusion Rituals&r. These rituals are used to imbue items with the magic of demons."
+		""
+		"The first tier of &6Infusion Rituals&r is &eEziveus' Spectral Compulsion&r. We'll be using this ritual to create several items that you'll need throughout this mod."
+		""
+		"We reccomend creating this ritual in a separate area from your first one, because the three main types of rituals build off each previous tier."
+	]
+	quest.39647A2473F6F7D7.quest_subtitle: "Put some Demon Dust™ on it!"
+	quest.39647A2473F6F7D7.title: "&eEziveus' Spectral Compulsion"
 	quest.396AA75774059D0B.quest_desc: ["You are too powerful."]
 	quest.396CEB9D05700927.quest_desc: ["To get into the &l&6Bumblezone&r you'll first need a &eBeehive&r. Normal &eBeehives&r and &eAdvanced Beehives&r it's not picky! \\n\\nThen you'll need to either throw an Enderpearl into it or have a Piston push you into it! \\n\\nAnd you'll get into the &eHive&r and enter the &l&6Bumblezone&r!"]
 	quest.396CEB9D05700927.quest_subtitle: "Unbeelievable"
@@ -6550,6 +6660,15 @@
 	quest.4295C863C9A81F28.quest_desc: ["The Telsa Coil is a very fun and &cEnergy&r hungry home defence! \\n\\nFirst, power it with &cEnergy&r from any of its Ports. Then, either give it a &4Redstone Signal&r to turn it on, or use a &6Engineer's Screwdriver&r to make it always on! \\n\\nOnce it is on it will be actively using &cEnergy&r and when a Mob comes near it, it will Stun them and hurt them! Hurting Mobs makes it take more &cEnergy&r though. \\n\\nYou can Shift Right Click with an &6Engineer's Screwdriver&r to set it to low power mode. It will take less &cEnery&r but also have less Range and deal less Damage!"]
 	quest.429785E8F64929CE.quest_desc: ["In order to get to the Starlight Dimension you'll need to find Portal Ruins in the Overworld. \\n\\nThere you will find a Gatekeeper, Right Click to initiate a conversation and challenge them to a duel! Careful, they are very tough. \\n\\nOnce you win the duel you'll be gifted a few Items, the Orb of Prophecy being one. Right Click the Portal with the Orb to activate it! Then, walk in to get to the..."]
 	quest.429785E8F64929CE.title: "The Gatekeeper and The Gate"
+	quest.429B5A81DF6C43FE.quest_desc: [
+		"&6Abras' Open Commanding Conjure&r is used to bring an &cAfrit&r demon into a pig. Because this ritual is performed without the use of red chalk, it's only powerful enough to summon an &9unbound&r demon."
+		""
+		"In particular, this ritual will create an &cAfrit&r-possessed zombified piglin, which will drop some demonic meat, which is used to craft pink chalk"
+		""
+		"&l&4WARNING: YOU MAY HAVE TO DO THIS ONE MULTIPLE TIMES TO GET ENOUGH DEMONIC MEAT! "
+	]
+	quest.429B5A81DF6C43FE.quest_subtitle: "How... fleshy..."
+	quest.429B5A81DF6C43FE.title: "&6Abras' Open Commanding Conjure"
 	quest.42AAEC41F2BC2474.quest_desc: ["{image:atm:textures/questpics/basicarmor/armor_glacite.png width:100 height:150 align:center}"]
 	quest.42AAEC41F2BC2474.title: "&bGlacite&r"
 	quest.42AF4EBDA5D6CC36.quest_desc: ["You can make &2Blastproof Alloy&r by combining the three strongest Metals available. &5Tungsten&r, &dTitanium&r, and &7Stainless Steel&r. Yes, stains matter apparently. \\n\\nWith these you can combine them to make the &2Casing&r."]
@@ -7578,6 +7697,8 @@
 		""
 		"&aOak Saplings&r convert to &9Oak Saplings&r but they are not the same. When grown, these will look exactly like a regular Oak tree. However, under the effects of the &bThird Eye&r, you will be able to harvest the Otherworld variant."
 		""
+		"If you have trouble collecting the logs (if they turn into regular Oak logs even with &bThird Eye&r), try collecting them from the top."
+		""
 		"&eDiamonds&r will turn into &dSpirit Attuned Gems&r which are used in several recipes we'll need later down the road."
 	]
 	quest.4C873491F6F0FFAF.title: "&dSpiritfire&r Conversions"
@@ -7602,6 +7723,14 @@
 	]
 	quest.4CD83943865018EA.quest_subtitle: "Importing Items!"
 	quest.4CD83943865018EA.title: "Exporter"
+	quest.4CE571F942461909.quest_desc: [
+		"The Ritual Satchel is nice, but it takes a long time to place all the blocks. Now that you can perform the &cSevira's Permenant Confinement&r ritual, you can create the Artisanal Ritual Satchel!"
+		""
+		"The Artisanal Ritual Satchel functions nearly identically to the regular Ritual satchel, except it instantly places all the nessecary items for the ritual, and has the added ability to right-click on a golden bowl to erase all the chalk runes and collect all the other items (skulls, candles, and crystals) and return them to the satchel. "
+		""
+		"No, it doesn't restore the durability of the chalk."
+	]
+	quest.4CE571F942461909.title: "Tools of the Trade: Artisanal Ritual Satchel"
 	quest.4CE6CABCB2334C0E.quest_desc: ["We have used a bunch of chromium already. But we again need to call on this highly resistive and high hardness metal, except in its liquid form."]
 	quest.4CE6CABCB2334C0E.quest_subtitle: "Liquid Chromium"
 	quest.4CE6EB54B12EF6C5.quest_subtitle: "&f10 &cAttack Damage"
@@ -7728,6 +7857,8 @@
 	]
 	quest.4DE719FC2E4C69AB.quest_subtitle: "And so it begins"
 	quest.4DE719FC2E4C69AB.title: "The Steam Age"
+	quest.4DF0D7B85065ADC9.quest_subtitle: "Hack and slash!"
+	quest.4DF0D7B85065ADC9.title: "Tools of the Trade: Butcher's Knife"
 	quest.4DF683461225690F.quest_desc: ["{image:atm:textures/questpics/basicarmor/armor_iron.png width:100 height:150 align:center}"]
 	quest.4DF683461225690F.title: "&7Iron&r"
 	quest.4DF7E2149F4BD8CC.quest_desc: ["To insert the desired potion, just right click with the &2Primed Pendant&r in hand to open its inventory."]
@@ -7901,6 +8032,8 @@
 	quest.4F1FFC02F4EAA2E6.title: "Tier: &4Nitro"
 	quest.4F2BBB75E5B5EAD8.title: "Salts Vein"
 	quest.4F35D04721DFC9FF.quest_desc: [
+		"The first type of Ritual we'll be performing is the &9Summoning Ritual&r. These rituals are used to summon different types of useful Demons to assist you in crushing, smelting, and tons of other things as you get to higher tiers of rituals."
+		""
 		"For our first Ritual, we want to summon a &aFoliot Crusher&r Demon. This Demon will crush items for us, which is something we'll need to make some of the higher level Chalks!"
 		""
 		"To start with, combine your Unbound Book with your &aDictionary of Spirits&r in a crafting table. This will bind a Demon to the book, which is what we'll need for the Ritual."
@@ -7915,6 +8048,7 @@
 		""
 		"{image:atm:textures/questpics/occultism/aviarcircle_v2.png width:200 height:200 align:1}"
 	]
+	quest.4F35D04721DFC9FF.quest_subtitle: "Aviar's Circle"
 	quest.4F35D04721DFC9FF.title: "&bOur First &dRitual"
 	quest.4F3B4990BE6C2A4A.quest_desc: [
 		"&7Scintlings&r are little innocent Slugs found everywhere in the &2&lUndergarden&r. \\n\\nThey act like Snow Golems as in they leave a trail wherever they walk. Just this one is more Gooey... \\n\\nOn death they drop Scintling Goo, but you can just farm it from their trails, so why kill them!"
@@ -8312,7 +8446,7 @@
 	quest.5311404799117060.quest_subtitle: "Tier: &b4"
 	quest.53154550397E9704.quest_desc: ["The &cNetherite Monstrosity&r lives up to his name, he's a beast of Netherite and lava and has 15000 Hearts. It has very basic attacks, if you get close he'll ground slam you, if you're farther he'll shoot lava at you which creates lava source blocks. He only has 1 stage, kinda boring. When killed he'll drop the Infernal Forge, Monstrous Horn, and maybe a music disc: vs Titans."]
 	quest.53154550397E9704.title: "&cNetherite Monstrosity&r"
-	quest.5316DF321B45D2CA.quest_desc: ["Welcome to &dOccultism&r!\\n\\nThis mod aimes to help the player in many different ways by enlisting the help of &c&mDemons&r &bSpirits&r! Don't worry, they are friendly. &oMostly&r.\\n\\nTo get started, you'll need to get some &aDemon's Fruit Seeds&r."]
+	quest.5316DF321B45D2CA.quest_desc: ["Welcome to &dOccultism&r!\\n\\nThis mod aimes to help the player in many different ways by enlisting the help of &c&mDemons&r &bSpirits&r! Don't worry, most of them are friendly. &oMost&r.\\n\\nTo get started, you'll need to get some &aDemon's Fruit Seeds&r."]
 	quest.5316DF321B45D2CA.title: "&dDreaming of &cDemons"
 	quest.531E3FF1F2865C67.quest_subtitle: "For Transferring Heat"
 	quest.532229D285CA4858.quest_desc: [
@@ -8411,6 +8545,13 @@
 		"Similar to the overworld->Nether, there is a block ratio of 1:50 for the End->Beyond"
 	]
 	quest.53DD784E75965947.title: "The Beyond"
+	quest.53DEA3DFEDC4809E.quest_desc: [
+		"Don't worry, this is the last of the Abras series of rituals. It is used to summon a &9Marid&r demon, but even though it uses Red Chalk, it's not powerful enough to &9bind&r the demon. This means that, unfortunately, you're going to have to fight it."
+		""
+		"By the way, this ritual uses a trident as a sacrifice, which is confusing because most sacrifices are living creatures. So instead of killing a mob on top of the completed ritual circle, you simply throw the trident at the center bowl to start the ritual."
+	]
+	quest.53DEA3DFEDC4809E.quest_subtitle: "Is it a bird? Is it a plane? No, it's an unbound &9Marid&r!"
+	quest.53DEA3DFEDC4809E.title: "&4Abras' Fortified Conjure"
 	quest.53E2BEA626B35BFC.quest_desc: ["Quite expensive recipe but most definitely worth it! \\n\\nUsing the &6Spectral &4Eye&r will give you the &4Spectral Vision Effect&r. This Effect gives &eGlowing&r to every Mob within a 100 Block radius in every direction! \\n\\nPerfect for finding structures underground, or Bastions in the &c&lNether&r, or even finding your friends hidden Axolotl farm!"]
 	quest.53E2BEA626B35BFC.quest_subtitle: "Very popular in ATM6!"
 	quest.53E2BEA626B35BFC.title: "&6Spectral &4Eye &7Amulet"
@@ -8453,6 +8594,11 @@
 	quest.542C6D76B579886C.quest_desc: ["Using our Enchanting Apparatus structure, we'll want to craft our first seed, the &5Magebloom Seed&r. \\n\\nThis will be used to create us some magical clothing!"]
 	quest.5436157FDFC9633E.quest_desc: ["With the Infused &dPatrick &aStar&r, 5 &6Star Fragments&r, &5Corrupti Dust&r, &cMundabitur Dust&r, and the Lens of the &4Killer&r we can rebuild &6&lATM Stars&r, 100% automated! \\n\\nNow these &5Creative&r Items will be a breeze to craft!"]
 	quest.5436157FDFC9633E.title: "Fully Automated &6&lATM Star"
+	quest.54378277B8D28B1D.quest_desc: [
+		"An \"upgrade\" to the Rainbow Chalk, for those who don't like the rapid color-switching runes ruining their tediously crafted aesthetic. "
+		""
+		"Has the same function as the Rainbow Chalk, except all the runes will show up as white."
+	]
 	quest.543F00603790AD3E.quest_desc: ["The (Log) Stripper strips Logs automatically using Axes put in the machine."]
 	quest.543F00603790AD3E.quest_subtitle: "Please don't"
 	quest.543F00603790AD3E.title: "Stripping"
@@ -8690,6 +8836,9 @@
 	quest.56DA46DC82F6665D.quest_desc: ["The Wilden Chimera is a Boss added by Ars Nouveau and is needed for progressing through it. \\n\\nHe needs to be summoned through a ritual then fought!"]
 	quest.56DA46DC82F6665D.title: "Kill The Wilden Chimera"
 	quest.56E30438AE512475.quest_desc: ["Let's get these flames burning! \\n\\nThe Preheater is a very simple addition to the &l&4Improved Blast Furnace&r. \\n\\nSimply place them on the Left and Right of the &l&4Improved Blast Furnace&r. Then, connect power to the top of it and it will start speeding up the &l&4Improved Blast Furnace&r."]
+	quest.56EC79AF11B0869E.quest_desc: ["&9Xeovrenth Adjure&r is the maximum tier of &5Possession Rituals&r. It only has two uses: creating Cruelty Essence, the main ingredient in Brown Chalk, and creating an Iesnium Golem, which is basically just an Iron golem that's immortal and does more damage."]
+	quest.56EC79AF11B0869E.quest_subtitle: "Maximum Possession"
+	quest.56EC79AF11B0869E.title: "&9Xeovrenth Adjure"
 	quest.56FB82DEB944F758.quest_desc: ["Works like the &aMace of Distortion&r, except it causes an AoE explosion instead."]
 	quest.570223A03231DF8C.quest_desc: ["Overhauled Endermen is a similar Mod to Overhauled Creepers! Just with Endermen of course! \\n\\nYou'll find all these Endermen in all different Biomes and each are unique in their own ways! Some have different attacks, some drop different Pearls, and they all look different!"]
 	quest.570223A03231DF8C.title: "Overhauled Endermen"
@@ -9057,6 +9206,28 @@
 	quest.5AAF6CA41209B365.title: "&3Vibranium Tools"
 	quest.5AC1BE754210429E.quest_desc: ["If you want to create a team for you and your friends, use the command &a/ftbteams party create (name of team)&r to create the team!"]
 	quest.5AC497F76A086A5C.title: "&l&9Overworld Bounty:&r&e Witches"
+	quest.5ACE97EE75813006.quest_desc: [
+		"This quest is your main source of information on &dRituals&r. Here's the basics:"
+		""
+		"&lTiers of Rituals:&r"
+		""
+		"Rituals have (basically) four tiers based on how powerful the demon that you're invoking is. The first tier is &eFoliot&r, then &aDijini&r, &cAfrit&r, and &9Marid&r. Some rituals fall into in-between tiers, such as the &6Unbound Afrit&r tier."
+		""
+		"T&lypes of Rituals:&r"
+		""
+		"There are five main types of rituals, but we'll only need four for progression. The main three are &9Summoning Rituals&r, &5Possession Rituals&r, and &6Infusion Rituals&r. Each one will be explained the first time that they appear in this questbook. The fourth type of ritual is a sort of &dDemon-less&r &dRitual&r, meaning that it uses bits and pieces from all three types to preform a special action without the direct usage of a demon. "
+		""
+		"The fifth type, &eFamiliar Rituals&r, are not needed for progression. But they can still be summon some useful friends to help you out!"
+		""
+		"&lChalks:&r"
+		""
+		"There are two types of chalks: Foundation Chalks, and Colored Chalks."
+		""
+		"Foundation chalks are used in every single ritual, and each tier higher gets a shade darker, starting with white chalk and ending with black chalk. "
+		""
+		"Colored Chalks are the most commonly used, but the color of the chalk doesn't directly corelate to its power the same as Foundation Chalks."
+	]
+	quest.5ACE97EE75813006.title: "The Basics of Rituals"
 	quest.5AD09CCEEDC0B50F.quest_desc: ["Now these are super helpful, you should definitely check them out! \\n\\nThe actual Light Source is the Feral Flare Lantern. It will place invisible Light Sources around 20 Blocks or more around it. \\n\\nThe Mega Torch is different: it doesn't emit Light but it does Block all Hostile Mob spawns with 64 Blocks of it! Useful for those using Night Vision. \\n\\nThe Dread Lamp does the opposite, it blocks Passive Mob spawns in the same area."]
 	quest.5AD09CCEEDC0B50F.title: "&l&eTorchmaster&r"
 	quest.5AD33290313151D6.quest_desc: [
@@ -9067,6 +9238,17 @@
 	quest.5AD33290313151D6.quest_subtitle: "Liquid Americium"
 	quest.5AD80D3242DD3F60.quest_desc: ["One of the hardest materials to get in the mod!\\n\\nThis is also used to create the &6ATM Star&r!"]
 	quest.5AD80D3242DD3F60.title: "&dInsanite Block"
+	quest.5AE80FF518B1BBA6.quest_desc: [
+		"Tired of lugging around chalks, candles, skulls, and crystals? Just make a ritual satchel!"
+		""
+		"By sneak + right-clicking with the ritual satchel in your hand, you can fill it with all the materials you need to draw a ritual circle."
+		""
+		"Once you've loaded up the satchel, simply right-click any preview block to begin (slowly) automatically placing all the runes for the selected ritual. "
+		""
+		"If a piece of chalk inside the bag falls under 40% durability, the enchantment glint on this item will dissapear to signal that it may be time to repair or replace some of your chalks."
+	]
+	quest.5AE80FF518B1BBA6.quest_subtitle: "Pocket Ritual!"
+	quest.5AE80FF518B1BBA6.title: "Tools of the Trade: Ritual Satchel"
 	quest.5AEE86EB39FD4087.quest_desc: ["The &3Vortex Tube&r seperates pressure into hot and cold air. The cold air goes to the blue side and the hot air goes to the red side."]
 	quest.5AEE86EB39FD4087.quest_subtitle: "Still not RF..."
 	quest.5AEE86EB39FD4087.title: "Heat Production"
@@ -9778,6 +9960,17 @@
 	quest.61847F47CCA225D9.title: "Silver Furnace"
 	quest.618F1434757C8E69.quest_desc: ["&lGenerator's Galore&r adds very simple Generators. The most basic ones act like Furnaces with &3Augment&r: Generator. They'll take Fuel and make it into Energy! \\n \\nYes you have to start with &6Copper Generator&r."]
 	quest.618F1434757C8E69.title: "&6Copper Generator&r"
+	quest.61999669BDE127F9.quest_desc: [
+		"If you haven't noticed already, making and re-making rituals over and over again is very taxing on the durability of your chalks. "
+		""
+		"If you're worried about your chalk breaking, but don't feel like doing the entire ritual to create a new chalk over again, then this ritual is for you!"
+		""
+		"Using the power of a &aDijinni&r, you can repair any color of chalk to it's maximum!"
+		""
+		"Alternatively, you could use something like the &aEternal Stella&r from the Forbidden Arcanus mod to permenantly preserve your chalks!"
+	]
+	quest.61999669BDE127F9.quest_subtitle: "You break it, &mwe&r Demons fix it!"
+	quest.61999669BDE127F9.title: "Chalk Repair"
 	quest.61A22707DBC83818.quest_desc: ["The Storage Access Point acts as a Storage Controller when linked to it, being able to be pushed into or pulled from. Basically a entry point for the Drawers."]
 	quest.61A8FAEC4FF18449.quest_desc: ["These can be used to charge items in your inventory, or can be used to increase the overall power capacity of an &7Ender Network&r channel."]
 	quest.61AD2207E770CD7F.quest_desc: ["Allows you to pickup items and experience from furthur away."]
@@ -10206,7 +10399,7 @@
 	quest.6648BC7D14233006.title: "&lAugments"
 	quest.665B4A8FF5277316.quest_desc: ["Makes gravity affect a Mana Burst, making it move in an arc. It also slightly increases the time before it starts to lose mana."]
 	quest.665C3A14C987E9C6.quest_subtitle: "&f5.5&r &4Damage&r"
-	quest.666EA8B8F13EB292.quest_desc: ["This item is used to capture Demons for transport or storage. It's also needed for the &6ATM Star&r."]
+	quest.666EA8B8F13EB292.quest_desc: ["This item is used to capture mobs for transport or storage. It's also needed for the &6ATM Star&r."]
 	quest.666EA8B8F13EB292.title: "&dEmpty Soul Gem"
 	quest.6674270897997BF7.quest_desc: ["Allows you to jump higher than usual and makes you springy, making for faster travel.\\n\\nYou can only have one level of these Upgrades in the Leggings at a time."]
 	quest.6674270897997BF7.quest_subtitle: "Max: 1"
@@ -10300,13 +10493,6 @@
 	quest.674F28BCA2E4A3C8.quest_desc: ["When moving items Routers can get pretty greedy, taking every single item they can get their grubby antennas on! \\n\\nWith Regulator Augment you can limit how much is moved."]
 	quest.6751F2651063B3A5.quest_desc: ["Blood Mushrooms can be found within their Bogs. \\n\\nThey are shaped like Dark Oak Trees and are mostly White with only some blocks having Blood spots on them!"]
 	quest.6754612E9AD4B9C0.title: "Reactor (Blazing)"
-	quest.676BC41C19BEF1FC.quest_desc: [
-		"That first Foliot Demon was cool, but what if I told you that you could summon a demon that gives you 6 dusts per raw ore it crushes?"
-		""
-		"The &5Marid Crusher&r does exactly that. To summon them, you'll need to use the &cFatma's Incentivized Attraction&r pentacle. This is an advanced ritual, requiring Red, White, and Gold Chalk as well as a lot of space."
-	]
-	quest.676BC41C19BEF1FC.quest_subtitle: "The Fastest Crushing On This Side of the Mississippi"
-	quest.676BC41C19BEF1FC.title: "The &5Marid Crusher"
 	quest.67704F7341EDCC49.title: "&bDiamond Backpack"
 	quest.677365A816994C8B.quest_desc: [
 		"The &9Player Transmitter&r will charge a player's items wirelessly. You must first bind this to a player using a &9Binding Card&r. This is the basic card which allows the transmitter to only work in the same dimension. You can upgrade this by using a &dBinding Card (Dimensional)&r instead. "
@@ -10339,6 +10525,13 @@
 	quest.6786B08C30D26037.quest_subtitle: "Spawns in a nest that has an Ashy Mining Bee"
 	quest.6786C701B7C4980B.quest_desc: ["The Gravistar is another very important component for our high tier machines were going to be making."]
 	quest.6786C701B7C4980B.quest_subtitle: "Stars have Lots of Gravity"
+	quest.67884BFA27870CCE.quest_desc: [
+		"&dOsorin's Unbound Calling&r is the second tier of &dDemon-less rituals&r. The first tier isn't useful for progression at all, it's only used for reviving familiars and turning vexes into allays. "
+		""
+		"This ritual is used to create a ton of rare-ish blocks, items, and materials that you might not be able to (or it's hard to) get normally."
+	]
+	quest.67884BFA27870CCE.quest_subtitle: "For the less trial-chamber-inclined of us"
+	quest.67884BFA27870CCE.title: "&dOsorin's Unbound Calling"
 	quest.678BA300CED48E5E.quest_desc: ["Lets make a bunch of these Yttrium Barium Cuprate Bolts, as we can utilize them to significantly reduce the cost of our IV Processors!"]
 	quest.678BA300CED48E5E.quest_subtitle: "Cost Reduction "
 	quest.67940C0774E73217.quest_desc: ["&eItem Router&r will &9Input &eItems&r and &6Output&r them to certain locations based on the Filtering set in its UI! \\n\\nThese can be set to &eBelts&r, Crates, or other Inventories."]
@@ -10446,12 +10639,6 @@
 	quest.6852BEFDD4DE4E4B.title: "&9Soul-Touched Deepshelf"
 	quest.6856A5572B239D10.quest_subtitle: "&f16&r &4Damage&r"
 	quest.685C4A646E092A82.title: "&6Awakened Supremium Armor"
-	quest.686AEC3EF1140D15.quest_desc: [
-		"Most of the items we've needed from the &3Otherworld&r so far just needed some Spiritfire. However, we will need to use the help of the &3Third Eye&r to find the Ore of the &3Otherworld&r."
-		""
-		"We'll also need a special pickaxe to be able to mine it. For this, we'll need to Infuse a Demon into a &dSpirit Attuned Pickaxe Head&r to create a pickaxe that can break this new kind of ore."
-	]
-	quest.686AEC3EF1140D15.title: "New Tools for New Ores"
 	quest.686B25F2E9D8CC97.quest_desc: ["At the time of writing this it's the end of July so I've got about 3 months until Halloween. But it's never to early to start getting Spooky! Just like Spirit Halloween we can get Spooky 3 months before it actually starts. This time by Right Clicking a Furnace with the Spook-alator! Once it's time to start getting ready for Thanksgiving Shift Right Click them to Un-Spook-Alate!"]
 	quest.686B25F2E9D8CC97.quest_subtitle: "\"This is Halloween\""
 	quest.686EB173C94301C0.quest_desc: ["&e&lIron's Spells&r &bIce Armor&r!"]
@@ -10528,6 +10715,12 @@
 	]
 	quest.6904EC449FBEE387.quest_subtitle: "Connecting The System"
 	quest.6904EC449FBEE387.title: "Cables"
+	quest.690B89D23134B624.quest_desc: [
+		"Grab your chalks, draw your &dRonaza's Contact&r ritual, and get ready to create the ULTIMATE CHALK!"
+		""
+		"Instead of having to lug around a full set of 16 chalks, you can use the rainbow chalk to paint a color-changing rune that counts as any of them! "
+	]
+	quest.690B89D23134B624.title: "&cR&6a&ei&an&9b&5o&dw&r Chalk"
 	quest.690CFF61CE787D43.quest_desc: ["Plastic is the main resource of &bIndustrial Foregoing&r, you now have access to some very useful machines!"]
 	quest.690DB8BEF80617E5.quest_desc: ["{image:atm:textures/questpics/basicarmor/armor_utherium.png width:100 height:150 align:center}"]
 	quest.690DB8BEF80617E5.title: "&cUtherium&r"
@@ -10863,7 +11056,10 @@
 		"If you aren't sure what items have NBT data on them, you can always check out the quest \"NBT and You\" in the Storage questline for more info on NBT!"
 	]
 	quest.6CC5FE34778F0DFA.title: "&c&mDemonir&r &dMagical Storage&r!"
-	quest.6CCDEEDA2C99DA66.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks. \\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission. \\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
+	quest.6CCDEEDA2C99DA66.quest_desc: [
+		"This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks. \\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission. \\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."
+		"Hi I'm in editing mode right now editing this :)"
+	]
 	quest.6CD1720B76F47806.quest_desc: ["This generator will burn Bio Fuel into energy. It produces around 140FE/t."]
 	quest.6CD7A3760C6D87E6.title: "Block of Diamond 4X"
 	quest.6CD7D99AA102A5C3.quest_desc: ["&n&f&lLogistics&r: \\nA system of moving, managing, and storing items or resources. \\n\\nIn Modded Minecraft it's quite the same, moving items! With Modded you will need items and by the thousands, heck if you want the &6&lStar&r it gets in the millions! So you'll need to move items from factories, machines, farms, and especially chests. That's what &l&fLogistics&r is for."]
@@ -11211,12 +11407,20 @@
 	]
 	quest.6FD65139CD50A8C0.quest_desc: ["Is that even possible?\\n\\nIf you wish to automate this process you can use &eProductive Bees&r or &aMystical Agriculture&r. Or I guess you could automate it, with...explosions."]
 	quest.6FD65139CD50A8C0.quest_subtitle: "Tired of blowing stuff up?"
+	quest.6FEED25FFAC4101F.quest_desc: ["Using &aStrigeor's Higher Binding&r, you can create Gray Paste. Smear this on a piece of impure white chalk to create Gray Chalk."]
+	quest.6FEED25FFAC4101F.title: "&8Gray Chalk"
 	quest.6FF04DD735346BED.quest_desc: ["Turns Latex into Dry Rubber."]
 	quest.6FF116239EACA390.title: "End Stone 5X"
 	quest.6FF20C2FB977C142.quest_desc: ["Steam is the foundation to your early progression through MI. Take a bucket of water and put it into the furnace with fuel to turn it into steam!"]
 	quest.6FF54B5D953E1797.quest_desc: ["If you know the term '&4Berserk&r' in most gaming, that will help you understand what the &cRage Glove&r does. If you don't know, the basics of &4Berserk&r is when someone gets low health or takes lots of damage, usually they will deal higher damage and be faster. That's what happens with First Ability, when you take damage you accumulate points which can be exchanged for higher damage and speed! \\n \\nThe Second Ability does that passively, and gives you Regeneration per the amount of health you lost. \\n \\nThe Third Ability is an active one, when using it (Alt Tab) you will dash and attack any mob you are looking at. When hit it'll set them on &cFire&r, give them Bleeding, and any accumulated &4Berserk&r points deal extra damage with it!"]
 	quest.6FF54B5D953E1797.quest_subtitle: "Found in Ruined Portals, Nether Fortresses, and Bastions"
 	quest.6FF54B5D953E1797.title: "&cRage Glove"
+	quest.6FFFAE334DFAAAAB.quest_desc: [
+		"As you've probably noticed, rituals tend to be... a little slow. But not anymore! Using &cSevira's Permanent Confinement&r, you can create the &bIesnium Ritual Bowl&r. "
+		""
+		"When using this in place of a Golden Ritual Bowl, it greatly reduces how long it takes to perform a ritual, taking it down to one fourth of its original time!"
+	]
+	quest.6FFFAE334DFAAAAB.quest_subtitle: "Super-speed rituals!"
 	quest.700F3FF7C23D0C0F.quest_desc: ["The &5Ender Cell&r will store power for a channel in your &7Ender Network&r. To increase the power capacity of the network, right click on the Ender Cell to open up the interface, then add either a &aBattery&r or an &9Energy Cell&r to increase the overall capacity."]
 	quest.70112194DFFD15D3.title: "&5Tyr Armor"
 	quest.7026E46FD8B3A81D.quest_desc: ["The &9Hydra&r is the infamous multi-headed beast from Greek Mythology.\\n\\nRanged attacks aren't as effective, meaning you'll need to get up close and personal.\\n\\nOnce defeated, you'll be able to find the next boss in the &2Dark Forest&r."]
@@ -11708,6 +11912,8 @@
 	quest.74015945716FD10A.quest_subtitle: "A configurable hopper"
 	quest.7408CCF998D9CD37.quest_desc: ["A Craftable &eSpell Book&r... yeah it's not easy to craft. \\n\\nHardest to get would be the Ruined Book, which you can find in &9Ancient City&r Chests. &4Blood Vials&r can be obtained from either putting a Mob (or even yourself) into a Cauldron above a Campfire or an Alchemical Cauldron. &5Bottle O' Lightning&r comes from using a Bottle on a Charged Creeper. \\n\\nOnce you do all that you can craft the Ancient Codex. Its 12 &3Spell&r Slots is very helpful!"]
 	quest.7408CCF998D9CD37.title: "Ancient Codex"
+	quest.74130EB1E4B8586D.quest_desc: ["Using &aIhagan's Enthrallment&r, you can sacrifice an allay, bat, bee, or parrot to summon the &6Possessed Bee&r. Upon defeating it, it will drop cursed honey, the main ingredient for making orange chalk!"]
+	quest.74130EB1E4B8586D.title: "&6Orange Chalk"
 	quest.7413BB136EF9D6C5.quest_desc: ["The Mechanical Drying Basin uses energy to dry"]
 	quest.74200A48498DD7F8.quest_desc: ["Generates power from the sun!"]
 	quest.74200A48498DD7F8.quest_subtitle: "Generates about 51FE/t"
@@ -12136,7 +12342,8 @@
 		""
 		"You will still need to be under the effects of the &3Third Eye&r to be able to harvest the Otherworld block."
 	]
-	quest.78ECC28DD4BA9696.title: "Hunting For &dOtherworld&r Materials"
+	quest.78ECC28DD4BA9696.quest_subtitle: "Hunting for &dOtherworld&r Materials"
+	quest.78ECC28DD4BA9696.title: "Tools of the Trade: Divination Rod"
 	quest.78FEDE6FA4845585.quest_desc: ["Some infusions need very very exact amounts of &aEterna&r, &cQuanta&r, or &5Arcana&r to get these you might need one of these shelves. Each lowers the amount of its respective amounts."]
 	quest.78FEDE6FA4845585.title: "&cNegative amounts"
 	quest.790EC3EDC2DB1FB0.quest_desc: ["Like it was mentioned before. This mod adds a ton of fun ways to generate power that require specific builds."]
@@ -12460,6 +12667,8 @@
 	quest.7BC616DDB5933479.quest_desc: ["This one can be created with a &5Blood Vial&r and normal ingrediants for Scrolls. \\nYou will need to make sure it is Level 10 and &6Legendary&r which you can upgrade it to."]
 	quest.7BC616DDB5933479.title: "&4Wither Skull Scroll"
 	quest.7BC8F50A89A3BE1A.quest_desc: ["These are just used to Connect &cLaser Nodes&r to each other and to Connectors. Not too important I just wanted to keep with the theme of Wrenches. \\n\\nIt does work as a Wrench for other Configs!"]
+	quest.7BCD4A425CF6199B.quest_desc: ["After slaying the Goat of Mercy summoned from &9Xeovrenth Adjure&r, you'll find yourself one Cruelty Essence richer. Combine this with some cocao beans to create Brown Chalk."]
+	quest.7BCD4A425CF6199B.title: "&#4E2C00Brown Chalk"
 	quest.7BCE96070C36D547.quest_subtitle: "&f7.5 &cAttack Damage"
 	quest.7BFC24607189B6D0.quest_desc: ["Makes you swim faster."]
 	quest.7BFC24607189B6D0.quest_subtitle: "Max: 1"
@@ -12753,8 +12962,12 @@
 	quest.7F042DED357DEF3C.quest_desc: ["Bookshelves are your starting point, but definitely not your end point. Atleast not normal bookshelves. With only normal bookshelves you can only get &aEterna&r up and to a max of 15. (I will explain the Enchantment Levels soon but just know you need them up)"]
 	quest.7F042DED357DEF3C.title: "Vanilla Max is just the start"
 	quest.7F076FC4F2187692.quest_subtitle: "&f8 &cAttack Damage"
-	quest.7F09F8F98C13F11B.quest_desc: ["What is a Demonic Ritual without a &cSacrifice&r! :D\\n\\nMost of the time, Demons just like items so don't be too afraid yet. However, if you have a favorite Cow, you might need to be worried. Sorry Betsy.\\n\\n&aSacrifical Bowls&r are used to place items needed for Rituals. These can be placed anywhere within the Ritual, as long as it isn't convering up any of the required Chalk.\\n\\nThe &6Golden Sacrificial Bowl&r is used in the middle of the Ritual to activate it, and also usually needs a Book of Binding for the Ritual in it."]
-	quest.7F09F8F98C13F11B.title: "Preparing for a Ritual: &dCrystals"
+	quest.7F09F8F98C13F11B.quest_desc: [
+		"What is a Demonic Ritual without a &cSacrifice&r! :D\\n\\nMost of the time, Demons just like items so don't be too afraid yet. However, if you have a favorite Cow, you might need to be worried. Sorry Betsy.\\n\\n&aSacrifical Bowls&r are used to place items needed for Rituals. These can be placed anywhere within the Ritual, as long as it isn't convering up any of the required Chalk. "
+		""
+		"For now, you'll only need four, but later on you'll need upwards of ten bowls for each ritual!\\n\\nThe &6Golden Sacrificial Bowl&r is used in the middle of the Ritual to activate it, and also usually needs a Book of Binding for the Ritual in it."
+	]
+	quest.7F09F8F98C13F11B.title: "Preparing for a Ritual: &6Bowls"
 	quest.7F0B2D58361FB00E.quest_desc: ["Just Dire Things is a jack of all trades mod. Just Dire Things adds a new crafting mechanic called Goo Spread, along with machines that assist in the automation of Goo Spread and other utilities."]
 	quest.7F0B2D58361FB00E.title: "Just Dire Things"
 	quest.7F0D59EC1573FDC0.quest_desc: ["The &n&5Depot&r is used to store items, mainly for the Spout."]
@@ -13152,6 +13365,7 @@
 	task.345245C32DB7B4D4.title: "Redstone Comb"
 	task.34551E919FD101CF.title: "Imperium Tools"
 	task.3489080F5FDE8B1B.title: "Heat"
+	task.348A7E3E3A3D324E.title: "Yes, I've read this and totally won't forget it!"
 	task.3490AE43AD653256.title: "Turnout Tracks"
 	task.349B2DA0A38AE9B5.title: "Framed Drawers"
 	task.34B6EB0B801E4743.title: "Netherite Chests"
@@ -13305,7 +13519,6 @@
 	task.510CE57C709D5A44.title: "Observe Hydrofluoric Acid in a Machine"
 	task.518B9569DCE0A771.title: "AllRightsReserved"
 	task.51A3E013D2B3D744.title: "Machine Upgrades"
-	task.51F776CF868BABEF.title: "Mining Demons"
 	task.52874F5B79ECAE65.title: "Stone Bricks"
 	task.529FFD7D692AEFA5.title: "Specialized Projectiles"
 	task.52BB142F044075B4.title: "Quests"
@@ -13313,6 +13526,7 @@
 	task.53A6720343E57302.title: "Sushi Go Crafting"
 	task.53A682560123F9B6.title: "Glassential"
 	task.53C6E9EAC8AC15EB.title: "Allthemodium Pickaxes"
+	task.53DE943DF951696B.title: "Demon Miner"
 	task.5400EB85133AAAEE.title: "Arcane Crystal Obelisks"
 	task.540231448A4DE43B.title: "End Layer Ores"
 	task.54231849B7094A32.title: "Tungstate or Scheelite Dust"

--- a/kubejs/server_scripts/Tweaks/tags.js
+++ b/kubejs/server_scripts/Tweaks/tags.js
@@ -19,6 +19,11 @@ ServerEvents.tags('block', allthemods => {
     '#c:storage_blocks/fire_essence',
     '#c:storage_blocks/water_essence'
   ])
+
+  //Entangled
+  allthemods.add('entangled:invalid_targets',
+      ['@ae2', '@advancedae', '@extended_ae', '@megacells', '@appflux', '@appmek']
+  )
 })
 
 ServerEvents.tags('item', allthemods => {


### PR DESCRIPTION
Thanks to TheBedrockMaster for helping me with this.
I am reuploading this because I caught some spelling errors and fixed them.
List of changes:

- Rearranged 90% of the existing quests to make the flow more natural/readable
- Renamed a few quests (mainly to add Tools of the Trade: to the beginning of tool quests)
- Deleted some quests and merged their requirements/text/rewards into new quests
- Changed dependencies of certain quests to better fit in with added quests
- Added more requirements to certain quests to better assist players in understanding the mod
- Changed descriptions of several of the existing quests to better assist players in understanding the mod
- Added quests:
  - The Basics of Rituals
  - Tools of the Trade: Butcher's Knife
  - Eziveus' Spectral Compulsion
  - Lime Chalk
  - Green Chalk
  - Strigeor's Higher Binding
  - Ihagan's Enthrallment
  - Chalk Repair
  - Tools of the Trade: Ritual Satchel
  - Gray Chalk
  - Orange Chalk
  - Abras' Open Conjure
  - Abras' Open Commanding Conjure
  - Pink Chalk
  - Red Chalk
  - Sevira's Permanent Confinement
  - Tools of the Trade: Artisanal Ritual Satchel
  - Iesnium Sacrificial Bowl
  - Repairing Items
  - Black Chalk
  - Abras' Fortified Conjure
  - Blue Chalk
  - Uphyxes' Inverted Tower
  - Xeovrenth Adjure
  - Fatmas' Incentivized Attraction
  - Iesnium Anvil
  - Magenta Chalk
  - Brown Chalk
  - Cyan Chalk
  - Light Blue Chalk
  - Osorin's Unbound Calling
  - Ronaza's Contact
  - Trinity Gem
  - Rainbow Chalk
  - Eldritch Chalice
  - Void Chalk (optional)
  - What's next?