### PR TITLE
Reworked Occultism Quests

### DIFF
--- a/config/ftbquests/quests/chapters/occultism.snbt
+++ b/config/ftbquests/quests/chapters/occultism.snbt
@@ -15,8 +15,8 @@
 			order: -1
 			rotation: 0.0d
 			width: 5.0d
-			x: 12.5d
-			y: 0.0d
+			x: 3.0d
+			y: 8.0d
 		}
 		{
 			color: 16711680
@@ -24,8 +24,8 @@
 			image: "occultism:textures/gui/book/robe.png"
 			rotation: 0.0d
 			width: 1.0d
-			x: 11.0d
-			y: 2.0d
+			x: 1.3571428571428399d
+			y: 10.285714285714242d
 		}
 		{
 			color: 16711680
@@ -33,8 +33,8 @@
 			image: "occultism:textures/gui/book/robe.png"
 			rotation: 0.0d
 			width: 1.0d
-			x: 13.95d
-			y: 2.0d
+			x: 4.642857142857125d
+			y: 10.285714285714242d
 		}
 		{
 			color: 16711680
@@ -42,8 +42,8 @@
 			image: "occultism:textures/gui/book/robe.png"
 			rotation: 0.0d
 			width: 1.0d
-			x: 15.0d
-			y: -0.5d
+			x: 5.5d
+			y: 7.5d
 		}
 		{
 			color: 16711680
@@ -51,8 +51,8 @@
 			image: "occultism:textures/gui/book/robe.png"
 			rotation: 0.0d
 			width: 1.0d
-			x: 10.0d
-			y: -0.5d
+			x: 0.5d
+			y: 7.5d
 		}
 		{
 			color: 16711680
@@ -60,8 +60,8 @@
 			image: "occultism:textures/gui/book/robe.png"
 			rotation: 0.0d
 			width: 1.0d
-			x: 12.5d
-			y: -2.5d
+			x: 3.0d
+			y: 5.5d
 		}
 		{
 			color: 255
@@ -69,8 +69,8 @@
 			image: "ftbquests:tasks/input_only"
 			rotation: 45.0d
 			width: 2.0d
-			x: 12.5d
-			y: 0.0d
+			x: 3.0d
+			y: 8.0d
 		}
 		{
 			color: 255
@@ -79,8 +79,8 @@
 			order: -1
 			rotation: -30.0d
 			width: 2.0d
-			x: 9.5d
-			y: 5.5d
+			x: 14.0d
+			y: 3.0d
 		}
 		{
 			color: 16711680
@@ -89,24 +89,24 @@
 			order: -1
 			rotation: 90.0d
 			width: 2.0d
-			x: 15.5d
-			y: 5.5d
+			x: 8.0d
+			y: 10.5d
 		}
 		{
 			height: 1.0d
 			image: "occultism:textures/gui/book/familiar_shub_niggurath.png"
 			rotation: 0.0d
 			width: 1.0d
-			x: 13.5d
-			y: 5.0d
+			x: 9.0d
+			y: 7.0d
 		}
 		{
 			height: 1.0d
 			image: "occultism:textures/gui/book/otherworld_bird.png"
 			rotation: 0.0d
 			width: 1.0d
-			x: 11.5d
-			y: 5.0d
+			x: 7.0d
+			y: 7.0d
 		}
 		{
 			alpha: 150
@@ -114,24 +114,24 @@
 			image: "occultism:block/stable_wormhole_frame"
 			rotation: 0.0d
 			width: 2.0d
-			x: 12.5d
-			y: 9.5d
+			x: 22.5d
+			y: 3.5d
 		}
 		{
 			height: 2.0d
 			image: "occultism:item/divination_rod/divination_rod_animation"
 			rotation: -45.0d
 			width: 2.0d
-			x: 12.5d
-			y: 14.0d
+			x: 18.0d
+			y: 15.5d
 		}
 		{
 			height: 0.5d
 			image: "occultism:block/chalk_glyph/0"
 			rotation: 0.0d
 			width: 0.5d
-			x: 10.5d
-			y: 1.0d
+			x: 1.0d
+			y: 9.0d
 		}
 		{
 			color: 6111187
@@ -139,8 +139,8 @@
 			image: "occultism:block/chalk_glyph/11"
 			rotation: 0.0d
 			width: 0.5d
-			x: 14.5d
-			y: 1.0d
+			x: 5.0d
+			y: 9.0d
 		}
 		{
 			color: 16711680
@@ -148,8 +148,8 @@
 			image: "occultism:block/chalk_glyph/12"
 			rotation: 0.0d
 			width: 0.5d
-			x: 14.0d
-			y: -1.5d
+			x: 4.5d
+			y: 6.5d
 		}
 		{
 			color: 16766720
@@ -157,32 +157,32 @@
 			image: "occultism:block/chalk_glyph/4"
 			rotation: 0.0d
 			width: 0.5d
-			x: 11.0d
-			y: -1.5d
+			x: 1.5d
+			y: 6.5d
 		}
 		{
 			height: 3.0d
 			image: "occultism:textures/gui/book/familiar_beholder.png"
 			rotation: 0.0d
 			width: 3.0d
-			x: 16.5d
-			y: 12.5d
+			x: 23.071428571428527d
+			y: 13.678571428571423d
 		}
 		{
 			height: 3.0d
 			image: "occultism:textures/gui/book/familiar_headless_ratman.png"
 			rotation: 0.0d
 			width: 3.0d
-			x: 8.5d
-			y: 12.5d
+			x: 13.5d
+			y: 13.5d
 		}
 		{
 			height: 3.0d
 			image: "occultism:textures/gui/book/infusion.png"
 			rotation: 0.0d
 			width: 3.0d
-			x: 0.0d
-			y: 0.0d
+			x: 2.0d
+			y: 3.0d
 		}
 		{
 			alpha: 100
@@ -191,7 +191,7 @@
 			rotation: 45.0d
 			width: 1.25d
 			x: 8.0d
-			y: 0.0d
+			y: 3.0d
 		}
 		{
 			alpha: 150
@@ -201,15 +201,15 @@
 			rotation: 45.0d
 			width: 1.5d
 			x: 8.0d
-			y: 0.0d
+			y: 3.0d
 		}
 		{
 			height: 9.0d
 			image: "atm:textures/questpics/occultism/maridlogo.png"
 			rotation: 0.0d
 			width: 6.0d
-			x: 1.0d
-			y: 7.0d
+			x: -3.0d
+			y: 8.0d
 		}
 		{
 			color: 16766720
@@ -217,32 +217,42 @@
 			image: "occultism:block/chalk_glyph/8"
 			rotation: 0.0d
 			width: 0.5d
-			x: 12.5d
-			y: 2.5d
+			x: 3.0d
+			y: 10.5d
 		}
 		{
 			height: 0.3d
 			image: "allthetweaks:item/atm_star"
 			rotation: 0.0d
 			width: 0.3d
-			x: 7.0d
-			y: 4.4d
+			x: 13.5d
+			y: 2.5d
 		}
 		{
 			height: 3.0d
 			image: "atm:textures/questpics/occultism/occultism_title.png"
 			rotation: 0.0d
 			width: 8.4d
-			x: 13.0d
-			y: -4.0d
+			x: 17.0d
+			y: 0.0d
 		}
 		{
 			height: 3.0d
 			image: "atm:textures/questpics/occultism/occultism_logo.png"
 			rotation: 0.0d
 			width: 3.0d
-			x: 12.5d
-			y: 6.5d
+			x: 8.0d
+			y: 8.0d
+		}
+		{
+			color: 255
+			height: 2.0d
+			image: "occultism:textures/gui/book/summoning.png"
+			order: -1
+			rotation: -30.0d
+			width: 2.0d
+			x: 38.0d
+			y: 5.0d
 		}
 	]
 	order_index: 6
@@ -269,8 +279,8 @@
 				item: { count: 1, id: "occultism:datura_seeds" }
 				type: "item"
 			}]
-			x: 0.0d
-			y: 0.0d
+			x: 2.0d
+			y: 3.0d
 		}
 		{
 			dependencies: ["5316DF321B45D2CA"]
@@ -286,11 +296,11 @@
 				item: { count: 1, id: "occultism:dictionary_of_spirits" }
 				type: "item"
 			}]
-			x: 2.0d
-			y: 0.0d
+			x: 4.0d
+			y: 2.0d
 		}
 		{
-			dependencies: ["6C1BBA559963B3DF"]
+			dependencies: ["5316DF321B45D2CA"]
 			id: "47358ADC1470C82A"
 			rewards: [{
 				id: "3BB86ECD39545201"
@@ -303,10 +313,13 @@
 				type: "item"
 			}]
 			x: 4.0d
-			y: 0.0d
+			y: 4.0d
 		}
 		{
-			dependencies: ["47358ADC1470C82A"]
+			dependencies: [
+				"47358ADC1470C82A"
+				"6C1BBA559963B3DF"
+			]
 			icon: {
 				components: {
 					"ftbquests:icon": "occultism:block/spirit_fire_0"
@@ -339,7 +352,7 @@
 				type: "item"
 			}]
 			x: 6.0d
-			y: 0.0d
+			y: 3.0d
 		}
 		{
 			dependencies: ["3D41D0092D94636B"]
@@ -379,11 +392,10 @@
 				}
 			]
 			x: 8.0d
-			y: 0.0d
+			y: 3.0d
 		}
 		{
-			dependencies: ["4C873491F6F0FFAF"]
-			hide_dependency_lines: true
+			dependencies: ["4DF0D7B85065ADC9"]
 			id: "6581D4AF1A6DE230"
 			shape: "diamond"
 			tasks: [
@@ -400,11 +412,11 @@
 					type: "item"
 				}
 			]
-			x: 13.5d
-			y: -1.0d
+			x: 2.0d
+			y: 7.0d
 		}
 		{
-			dependencies: ["4C873491F6F0FFAF"]
+			dependencies: ["5ACE97EE75813006"]
 			hide_dependency_lines: true
 			id: "1B5177A774FCEF64"
 			min_width: 350
@@ -426,11 +438,11 @@
 					type: "item"
 				}
 			]
-			x: 11.5d
-			y: 1.0d
+			x: 2.0d
+			y: 9.0d
 		}
 		{
-			dependencies: ["4C873491F6F0FFAF"]
+			dependencies: ["5ACE97EE75813006"]
 			hide_dependency_lines: true
 			id: "7F09F8F98C13F11B"
 			shape: "diamond"
@@ -447,11 +459,11 @@
 					type: "item"
 				}
 			]
-			x: 13.5d
-			y: 1.0d
+			x: 4.0d
+			y: 9.0d
 		}
 		{
-			dependencies: ["4C873491F6F0FFAF"]
+			dependencies: ["5ACE97EE75813006"]
 			hide_dependency_lines: true
 			id: "0B3EA604C5172D98"
 			shape: "diamond"
@@ -467,8 +479,8 @@
 					type: "item"
 				}
 			]
-			x: 11.5d
-			y: -1.0d
+			x: 4.0d
+			y: 7.0d
 		}
 		{
 			dependencies: [
@@ -478,10 +490,7 @@
 				"1B5177A774FCEF64"
 			]
 			icon: {
-				components: {
-					"ftbquests:icon": "occultism:block/chalk_glyph/5"
-				}
-				id: "ftbquests:custom_icon"
+				id: "occultism:ritual_dummy/custom_ritual_summon"
 			}
 			id: "4F35D04721DFC9FF"
 			min_width: 300
@@ -519,10 +528,11 @@
 					type: "item"
 				}
 			]
-			x: 12.5d
-			y: 0.0d
+			x: 3.0d
+			y: 8.0d
 		}
 		{
+			dependencies: ["4F35D04721DFC9FF"]
 			id: "1DE0F289821F55D1"
 			rewards: [{
 				id: "1B9CD287CB41E0E8"
@@ -542,58 +552,17 @@
 					item: { count: 1, id: "occultism:chalk_purple_impure" }
 					type: "item"
 				}
-			]
-			x: 12.5d
-			y: 6.5d
-		}
-		{
-			dependencies: ["1DE0F289821F55D1"]
-			icon: {
-				components: {
-					"occultism:spirit_name": "Crosorryn"
-				}
-				id: "occultism:book_of_binding_bound_djinni"
-			}
-			id: "08B1A64B01A8A604"
-			rewards: [{
-				id: "3EE821F59A85DDED"
-				type: "xp"
-				xp: 100
-			}]
-			shape: "diamond"
-			tasks: [
 				{
-					count: 4L
-					id: "6881D81F0E3CF9DC"
-					item: { count: 1, id: "minecraft:soul_sand" }
-					type: "item"
-				}
-				{
-					id: "20DA82068CC27F71"
-					item: { count: 1, id: "minecraft:diamond" }
-					type: "item"
-				}
-				{
-					id: "4D1D4DF4AE382EF5"
-					item: { count: 1, id: "minecraft:copper_ingot" }
-					type: "item"
-				}
-				{
-					id: "68B346594C63FC5E"
-					item: { count: 1, id: "alltheores:silver_ingot" }
-					type: "item"
-				}
-				{
-					id: "594F7571F053C9EB"
-					item: { components: { "occultism:spirit_name": "Fircresryn" }, count: 1, id: "occultism:book_of_binding_bound_djinni" }
+					id: "3E04DC4A0E760083"
+					item: { count: 1, id: "occultism:chalk_light_gray_impure" }
 					type: "item"
 				}
 			]
-			x: 9.5d
-			y: 5.5d
+			x: 8.0d
+			y: 8.0d
 		}
 		{
-			dependencies: ["1DE0F289821F55D1"]
+			dependencies: ["38A1295878B68F83"]
 			icon: {
 				id: "occultism:chalk_red_impure"
 			}
@@ -624,11 +593,12 @@
 					type: "item"
 				}
 			]
-			x: 14.0d
+			x: 20.0d
 			y: 8.0d
 		}
 		{
-			dependencies: ["08B1A64B01A8A604"]
+			dependencies: ["0D18BBB04693885A"]
+			hide_dependent_lines: true
 			id: "666EA8B8F13EB292"
 			rewards: [
 				{
@@ -644,17 +614,17 @@
 				}
 			]
 			shape: "hexagon"
-			size: 2.0d
+			size: 1.0d
 			tasks: [{
 				id: "1E44A3F521ED5DFC"
 				item: { count: 1, id: "occultism:soul_gem" }
 				type: "item"
 			}]
-			x: 7.0d
-			y: 5.5d
+			x: 14.0d
+			y: 3.0d
 		}
 		{
-			dependencies: ["1DE0F289821F55D1"]
+			dependencies: ["39647A2473F6F7D7"]
 			id: "2A5004EB99AE4F96"
 			rewards: [
 				{
@@ -666,7 +636,7 @@
 				{
 					id: "66AF59413C4ADCF3"
 					type: "xp"
-					xp: 50
+					xp: 100
 				}
 			]
 			tasks: [{
@@ -674,37 +644,11 @@
 				item: { count: 1, id: "occultism:otherworld_goggles" }
 				type: "item"
 			}]
-			x: 11.0d
-			y: 8.0d
+			x: 11.5d
+			y: 5.0d
 		}
 		{
-			dependencies: ["2A5004EB99AE4F96"]
-			id: "686AEC3EF1140D15"
-			rewards: [
-				{
-					exclude_from_claim_all: true
-					id: "0905ED561E579042"
-					table_id: 487623848494439020L
-					type: "loot"
-				}
-				{
-					id: "26FF1D11583ADA23"
-					type: "xp"
-					xp: 50
-				}
-			]
-			shape: "square"
-			size: 1.25d
-			tasks: [{
-				id: "73EA231C66874BB0"
-				item: { count: 1, id: "occultism:infused_pickaxe" }
-				type: "item"
-			}]
-			x: 9.5d
-			y: 9.5d
-		}
-		{
-			dependencies: ["686AEC3EF1140D15"]
+			dependencies: ["2A3683BF7E50EF83"]
 			id: "33106E24A3B5DDD8"
 			min_width: 450
 			rewards: [{
@@ -717,8 +661,8 @@
 				item: { count: 1, id: "occultism:iesnium_ore" }
 				type: "item"
 			}]
-			x: 11.0d
-			y: 11.0d
+			x: 17.0d
+			y: 4.0d
 		}
 		{
 			dependencies: ["33106E24A3B5DDD8"]
@@ -741,54 +685,14 @@
 				item: { count: 1, id: "occultism:iesnium_pickaxe" }
 				type: "item"
 			}]
-			x: 12.5d
-			y: 12.5d
-		}
-		{
-			dependencies: [
-				"57282D7E31EE61EE"
-				"145C8235BCCB9BA8"
-			]
-			icon: {
-				components: {
-					"occultism:spirit_name": "Merrymdor"
-				}
-				id: "occultism:book_of_binding_bound_marid"
-			}
-			id: "676BC41C19BEF1FC"
-			progression_mode: "linear"
-			rewards: [
-				{
-					exclude_from_claim_all: true
-					id: "4381289734981296"
-					table_id: 5564196992594175882L
-					type: "loot"
-				}
-				{
-					id: "29200B3A1B0AC9D1"
-					type: "xp"
-					xp: 100
-				}
-			]
-			shape: "square"
-			size: 1.25d
-			tasks: [
-				{
-					id: "5E80B6869FE42D9F"
-					item: { count: 1, id: "occultism:iesnium_block" }
-					type: "item"
-				}
-				{
-					id: "73801C9489E0E797"
-					item: { components: { "occultism:spirit_name": "Einvonddrin" }, count: 1, id: "occultism:book_of_binding_bound_marid" }
-					type: "item"
-				}
-			]
-			x: 15.5d
-			y: 9.5d
+			x: 20.0d
+			y: 3.5d
 		}
 		{
 			dependencies: ["57282D7E31EE61EE"]
+			icon: {
+				id: "occultism:dimensional_mineshaft"
+			}
 			id: "172D2A634E849562"
 			min_width: 350
 			rewards: [{
@@ -805,13 +709,13 @@
 					type: "item"
 				}
 				{
-					id: "51F776CF868BABEF"
-					item: { components: { "ftbfiltersystem:filter": "or(item_tag(occultism:miners/ores))" }, count: 1, id: "ftbfiltersystem:smart_filter" }
+					id: "53DE943DF951696B"
+					item: { components: { "ftbfiltersystem:filter": "ftbfiltersystem:item_tag(occultism:miners/ores)" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 					type: "item"
 				}
 			]
-			x: 12.5d
-			y: 9.5d
+			x: 22.5d
+			y: 3.5d
 		}
 		{
 			dependencies: ["1DE0F289821F55D1"]
@@ -847,11 +751,12 @@
 					type: "item"
 				}
 			]
-			x: 15.5d
-			y: 5.5d
+			x: 8.0d
+			y: 10.5d
 		}
 		{
 			dependencies: ["6CC5FE34778F0DFA"]
+			hide_dependent_lines: true
 			id: "42F50CE7FE715583"
 			min_width: 300
 			rewards: [
@@ -874,11 +779,12 @@
 				item: { components: { "ftbfiltersystem:filter": "or(item(occultism:storage_stabilizer_tier1)item(occultism:storage_stabilizer_tier2)item(occultism:storage_stabilizer_tier3)item(occultism:storage_stabilizer_tier4))" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 				type: "item"
 			}]
-			x: 18.0d
-			y: 5.5d
+			x: 8.0d
+			y: 14.0d
 		}
 		{
-			dependencies: ["3D41D0092D94636B"]
+			dependencies: ["4C873491F6F0FFAF"]
+			hide_dependency_lines: false
 			id: "78ECC28DD4BA9696"
 			rewards: [{
 				id: "755329C134364BB8"
@@ -890,12 +796,13 @@
 				item: { count: 1, id: "occultism:divination_rod" }
 				type: "item"
 			}]
-			x: 6.0d
-			y: -1.5d
+			x: 8.0d
+			y: 1.0d
 		}
 		{
 			dependencies: ["6CC5FE34778F0DFA"]
 			id: "5831B3192C0E8C56"
+			optional: true
 			rewards: [
 				{
 					exclude_from_claim_all: true
@@ -921,11 +828,11 @@
 					type: "item"
 				}
 			]
-			x: 16.5d
-			y: 7.0d
+			x: 6.5d
+			y: 11.5d
 		}
 		{
-			dependencies: ["08B1A64B01A8A604"]
+			dependencies: ["5ACE97EE75813006"]
 			icon: {
 				components: {
 					"ftbquests:icon": "occultism:textures/gui/book/familiar_headless_ratman.png"
@@ -933,6 +840,7 @@
 				id: "ftbquests:custom_icon"
 			}
 			id: "7F59941D62E672B0"
+			optional: true
 			rewards: [{
 				id: "1FEDC70622D3F66B"
 				type: "xp"
@@ -942,8 +850,8 @@
 				id: "6C3887D42B6B2122"
 				type: "checkmark"
 			}]
-			x: 8.5d
-			y: 7.0d
+			x: 10.5d
+			y: 1.0d
 		}
 		{
 			id: "6CCDEEDA2C99DA66"
@@ -960,8 +868,1133 @@
 					type: "checkmark"
 				}
 			]
-			x: 2.0d
-			y: -1.5d
+			x: 0.5d
+			y: 0.5d
+		}
+		{
+			dependencies: ["1DE0F289821F55D1"]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_craft"
+			}
+			id: "39647A2473F6F7D7"
+			min_width: 300
+			require_sequential_tasks: true
+			rewards: [{
+				id: "4AD6D3E0605F8F3C"
+				type: "xp"
+				xp: 25
+			}]
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [
+				{
+					count: 2L
+					id: "2119DB35CADF61FC"
+					item: { count: 2, id: "minecraft:experience_bottle" }
+					type: "item"
+				}
+				{
+					id: "523951BF097BA61F"
+					item: { components: { "ftbfiltersystem:filter": "ftbfiltersystem:item_tag(c:dusts/emerald)" }, count: 1, id: "ftbfiltersystem:smart_filter" }
+					type: "item"
+				}
+			]
+			x: 10.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["5ACE97EE75813006"]
+			hide_dependency_lines: true
+			id: "4DF0D7B85065ADC9"
+			tasks: [{
+				id: "630455630821CAB0"
+				item: { count: 1, id: "occultism:butcher_knife" }
+				type: "item"
+			}]
+			x: 1.0d
+			y: 6.0d
+		}
+		{
+			dependencies: ["39647A2473F6F7D7"]
+			icon: {
+				id: "occultism:chalk_lime_impure"
+			}
+			id: "30C5B597610F4AFB"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "3B1B9DB617500BAA"
+					table_id: 487623848494439020L
+					type: "loot"
+				}
+				{
+					id: "1ACB00A8A96B37B0"
+					type: "xp"
+					xp: 50
+				}
+			]
+			tasks: [
+				{
+					id: "308ADBEA527AF653"
+					item: { count: 1, id: "occultism:research_fragment_dust" }
+					type: "item"
+				}
+				{
+					id: "0C8EA5B6F92B41B7"
+					item: { count: 1, id: "occultism:chalk_lime_impure" }
+					type: "item"
+				}
+			]
+			x: 12.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["30C5B597610F4AFB"]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_possess"
+			}
+			id: "0BD6365534BF04D5"
+			min_width: 300
+			require_sequential_tasks: true
+			rewards: [{
+				id: "7911ABFD485D38FB"
+				type: "xp"
+				xp: 25
+			}]
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [
+				{
+					id: "1286B8BF842021A0"
+					item: { count: 1, id: "minecraft:honey_block" }
+					type: "item"
+				}
+				{
+					id: "0A765E7423C34F67"
+					item: { count: 1, id: "minecraft:honeycomb_block" }
+					type: "item"
+				}
+				{
+					id: "7E64536D4E1607F9"
+					item: { count: 1, id: "minecraft:honeycomb" }
+					type: "item"
+				}
+				{
+					id: "530CC694F2DED650"
+					item: { count: 1, id: "minecraft:honey_bottle" }
+					type: "item"
+				}
+			]
+			x: 14.0d
+			y: 9.0d
+		}
+		{
+			dependencies: ["0BD6365534BF04D5"]
+			icon: {
+				id: "occultism:chalk_orange_impure"
+			}
+			id: "74130EB1E4B8586D"
+			tasks: [
+				{
+					id: "56B5E2D58E61A670"
+					item: { count: 1, id: "occultism:cursed_honey" }
+					type: "item"
+				}
+				{
+					id: "7CC5188C1D471B63"
+					item: { count: 1, id: "occultism:chalk_orange_impure" }
+					type: "item"
+				}
+			]
+			x: 16.0d
+			y: 9.5d
+		}
+		{
+			dependencies: [
+				"6FEED25FFAC4101F"
+				"74130EB1E4B8586D"
+			]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_summon"
+			}
+			id: "38A1295878B68F83"
+			min_width: 300
+			require_sequential_tasks: true
+			rewards: [{
+				id: "1412ED0B0BCBCBA2"
+				type: "xp"
+				xp: 25
+			}]
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [
+				{
+					id: "57108C994437F25B"
+					item: { components: { "ftbfiltersystem:filter": "ftbfiltersystem:item_tag(ae2:all_nether_quartz)" }, count: 1, id: "ftbfiltersystem:smart_filter" }
+					type: "item"
+				}
+				{
+					id: "71A3B742D8757C89"
+					item: { count: 1, id: "minecraft:gunpowder" }
+					type: "item"
+				}
+				{
+					id: "07F6D01E644305E7"
+					item: { count: 1, id: "minecraft:netherrack" }
+					type: "item"
+				}
+				{
+					id: "52B4CBE9BE14AD70"
+					item: { count: 1, id: "minecraft:flint_and_steel" }
+					type: "item"
+				}
+			]
+			x: 18.0d
+			y: 7.0d
+		}
+		{
+			dependencies: ["30C5B597610F4AFB"]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_craft"
+			}
+			id: "0D18BBB04693885A"
+			min_width: 300
+			require_sequential_tasks: true
+			rewards: [{
+				id: "7363A3F35687ED86"
+				type: "xp"
+				xp: 25
+			}]
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [
+				{
+					id: "7B49FEA4BFE44D1C"
+					item: { count: 1, id: "minecraft:phantom_membrane" }
+					type: "item"
+				}
+				{
+					id: "365C31F15DC05036"
+					item: { count: 1, id: "minecraft:gunpowder" }
+					type: "item"
+				}
+				{
+					id: "070845F0D3E5A7FD"
+					item: { count: 1, id: "minecraft:gray_dye" }
+					type: "item"
+				}
+				{
+					id: "39FE4ED3B2A83A42"
+					item: { count: 1, id: "minecraft:clay_ball" }
+					type: "item"
+				}
+			]
+			x: 14.0d
+			y: 7.0d
+		}
+		{
+			dependencies: ["0D18BBB04693885A"]
+			icon: {
+				id: "occultism:chalk_gray_impure"
+			}
+			id: "6FEED25FFAC4101F"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "373390521D12FAFF"
+					table_id: 487623848494439020L
+					type: "loot"
+				}
+				{
+					id: "172458963B35A871"
+					type: "xp"
+					xp: 50
+				}
+			]
+			tasks: [
+				{
+					id: "6BCAF5C014C9B8CD"
+					item: { count: 1, id: "occultism:gray_paste" }
+					type: "item"
+				}
+				{
+					id: "4A9046ADC251E85F"
+					item: { count: 1, id: "occultism:chalk_gray_impure" }
+					type: "item"
+				}
+			]
+			x: 16.0d
+			y: 6.5d
+		}
+		{
+			dependencies: ["39647A2473F6F7D7"]
+			icon: {
+				id: "occultism:chalk_green_impure"
+			}
+			id: "11A0593C0E2E6A35"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "71825C8D99ADBB2A"
+					table_id: 487623848494439020L
+					type: "loot"
+				}
+				{
+					id: "40665ED40AD50F96"
+					type: "xp"
+					xp: 50
+				}
+			]
+			tasks: [
+				{
+					id: "3469624E1932FA86"
+					item: { count: 1, id: "occultism:nature_paste" }
+					type: "item"
+				}
+				{
+					id: "28577F9A1DE33F02"
+					item: { count: 1, id: "occultism:chalk_green_impure" }
+					type: "item"
+				}
+			]
+			x: 11.5d
+			y: 11.0d
+		}
+		{
+			dependencies: [
+				"2A5004EB99AE4F96"
+				"0D18BBB04693885A"
+			]
+			id: "2A3683BF7E50EF83"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "76340CDC577FD688"
+					table_id: 487623848494439020L
+					type: "loot"
+				}
+				{
+					id: "53894207A33668FB"
+					type: "xp"
+					xp: 50
+				}
+			]
+			tasks: [{
+				id: "02718432862B0267"
+				item: { count: 1, id: "occultism:infused_pickaxe" }
+				type: "item"
+			}]
+			x: 14.0d
+			y: 4.5d
+		}
+		{
+			dependencies: ["0D18BBB04693885A"]
+			id: "5AE80FF518B1BBA6"
+			optional: true
+			rewards: [{
+				id: "0C4945F14A4E9AD2"
+				type: "xp"
+				xp: 75
+			}]
+			tasks: [{
+				id: "12713B611A3AA745"
+				item: { count: 1, id: "occultism:ritual_satchel_t1" }
+				type: "item"
+			}]
+			x: 15.0d
+			y: 5.5d
+		}
+		{
+			dependencies: ["0D18BBB04693885A"]
+			icon: {
+				components: {
+					"ftbquests:icon": "occultism:block/chalk_glyph/0"
+				}
+				id: "ftbquests:custom_icon"
+			}
+			id: "61999669BDE127F9"
+			optional: true
+			tasks: [{
+				id: "2448345116BDC7C6"
+				type: "checkmark"
+			}]
+			x: 13.0d
+			y: 5.5d
+		}
+		{
+			dependencies: ["145C8235BCCB9BA8"]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_craft"
+			}
+			id: "2960FFE0C53DFEB1"
+			min_width: 300
+			require_sequential_tasks: true
+			rewards: [{
+				id: "32B5A1C3342B5DD9"
+				type: "xp"
+				xp: 25
+			}]
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [
+				{
+					count: 3L
+					id: "01ED52CC3C6D512C"
+					item: { count: 3, id: "minecraft:wither_rose" }
+					type: "item"
+				}
+				{
+					id: "2C5C6F411E2F0CAF"
+					item: { components: { "ftbfiltersystem:filter": "ftbfiltersystem:item_tag(c:dusts/netherite)" }, count: 1, id: "ftbfiltersystem:smart_filter" }
+					type: "item"
+				}
+				{
+					count: 2L
+					id: "5CAE467165ED08FA"
+					item: { count: 2, id: "occultism:crushed_blackstone" }
+					type: "item"
+				}
+			]
+			x: 22.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["2960FFE0C53DFEB1"]
+			icon: {
+				id: "occultism:chalk_black_impure"
+			}
+			id: "367E891A50991436"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "6FE0A14BDB35C40C"
+					table_id: 487623848494439020L
+					type: "loot"
+				}
+				{
+					id: "1D1E44C1ED4E349E"
+					type: "xp"
+					xp: 50
+				}
+			]
+			tasks: [
+				{
+					id: "43AD1E4B8B90C32B"
+					item: { count: 1, id: "occultism:witherite_dust" }
+					type: "item"
+				}
+				{
+					id: "7C5A8F34E6CE5B45"
+					item: { count: 1, id: "occultism:chalk_black_impure" }
+					type: "item"
+				}
+			]
+			x: 24.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["2960FFE0C53DFEB1"]
+			id: "4CE571F942461909"
+			optional: true
+			rewards: [{
+				id: "4EBE9A3D181D1F8D"
+				type: "xp"
+				xp: 100
+			}]
+			tasks: [{
+				id: "002AC613F837D5B5"
+				item: { count: 1, id: "occultism:ritual_satchel_t2" }
+				type: "item"
+			}]
+			x: 21.0d
+			y: 6.0d
+		}
+		{
+			dependencies: ["2960FFE0C53DFEB1"]
+			icon: {
+				components: {
+					"ftbquests:icon": "occultism:block/chalk_glyph/7"
+				}
+				id: "ftbquests:custom_icon"
+			}
+			id: "1848F431D0380DA9"
+			optional: true
+			tasks: [{
+				id: "7DA8A385C843AD5F"
+				type: "checkmark"
+			}]
+			x: 23.0d
+			y: 6.0d
+		}
+		{
+			dependencies: [
+				"74130EB1E4B8586D"
+				"6FEED25FFAC4101F"
+			]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_possess"
+			}
+			id: "429B5A81DF6C43FE"
+			min_width: 300
+			require_sequential_tasks: true
+			rewards: [{
+				id: "57CB202D58CB3A82"
+				type: "xp"
+				xp: 25
+			}]
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [
+				{
+					id: "28F295B4EC2EB476"
+					item: { count: 1, id: "minecraft:cherry_leaves" }
+					type: "item"
+				}
+				{
+					id: "656A1E143070FEF4"
+					item: { count: 1, id: "minecraft:pink_petals" }
+					type: "item"
+				}
+				{
+					id: "4DF03E583D33C20A"
+					item: { count: 1, id: "occultism:tallow" }
+					type: "item"
+				}
+				{
+					id: "6940EDB3C048802F"
+					item: { count: 1, id: "minecraft:quartz" }
+					type: "item"
+				}
+			]
+			x: 18.0d
+			y: 9.0d
+		}
+		{
+			dependencies: ["429B5A81DF6C43FE"]
+			icon: {
+				id: "occultism:chalk_pink_impure"
+			}
+			id: "2E68E1D96B25336D"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "5B284E8F9D2E2E51"
+					table_id: 487623848494439020L
+					type: "loot"
+				}
+				{
+					id: "50619186D8DC7176"
+					type: "xp"
+					xp: 50
+				}
+			]
+			tasks: [
+				{
+					count: 3L
+					id: "411F787B683CA921"
+					item: { count: 1, id: "occultism:demonic_meat" }
+					type: "item"
+				}
+				{
+					id: "714891B19615AC21"
+					item: { count: 1, id: "occultism:chalk_pink_impure" }
+					type: "item"
+				}
+			]
+			x: 18.0d
+			y: 11.0d
+		}
+		{
+			dependencies: [
+				"11A0593C0E2E6A35"
+				"2E68E1D96B25336D"
+				"1EB887F8072439A3"
+			]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_misc"
+			}
+			id: "67884BFA27870CCE"
+			min_width: 300
+			shape: "gear"
+			size: 1.5d
+			tasks: [{
+				id: "1BEBE185FBB4969A"
+				type: "checkmark"
+			}]
+			x: 18.0d
+			y: 13.0d
+		}
+		{
+			dependencies: ["367E891A50991436"]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_summon"
+			}
+			id: "53DEA3DFEDC4809E"
+			min_width: 300
+			require_sequential_tasks: true
+			rewards: [{
+				id: "689F05C25DEFD7E1"
+				type: "xp"
+				xp: 50
+			}]
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [
+				{
+					id: "7A7F8E95E037CD5E"
+					item: { count: 1, id: "minecraft:prismarine_crystals" }
+					type: "item"
+				}
+				{
+					id: "7E8C9E6DDB982A6D"
+					item: { count: 1, id: "minecraft:prismarine_shard" }
+					type: "item"
+				}
+				{
+					id: "2BA3F105CD095EC3"
+					item: { count: 1, id: "minecraft:ghast_tear" }
+					type: "item"
+				}
+				{
+					id: "197964C9AA25C7B1"
+					item: { count: 1, id: "minecraft:conduit" }
+					type: "item"
+				}
+				{
+					id: "6368ECA9DAB480CB"
+					item: { count: 1, id: "minecraft:trident" }
+					type: "item"
+				}
+			]
+			x: 26.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["53DEA3DFEDC4809E"]
+			icon: {
+				id: "occultism:chalk_blue_impure"
+			}
+			id: "03250A0202C25E80"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "327F077402F22592"
+					table_id: 487623848494439020L
+					type: "loot"
+				}
+				{
+					id: "64999ED05425EAEB"
+					type: "xp"
+					xp: 50
+				}
+			]
+			tasks: [
+				{
+					id: "7BFF993075EFB7B9"
+					item: { count: 1, id: "occultism:marid_essence" }
+					type: "item"
+				}
+				{
+					id: "5CE28B53187E9128"
+					item: { count: 1, id: "occultism:chalk_blue_impure" }
+					type: "item"
+				}
+			]
+			x: 28.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["03250A0202C25E80"]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_summon"
+			}
+			id: "2AD68066C1948C90"
+			min_width: 300
+			require_sequential_tasks: true
+			rewards: [{
+				id: "0252C0BC3DEF31F5"
+				type: "xp"
+				xp: 50
+			}]
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [
+				{
+					id: "0A4AA41F06C7DE11"
+					item: { count: 1, id: "minecraft:diamond_block" }
+					type: "item"
+				}
+				{
+					id: "4517C8E5F35C3414"
+					item: { count: 1, id: "minecraft:emerald_block" }
+					type: "item"
+				}
+				{
+					id: "78C5784F30116165"
+					item: { count: 1, id: "occultism:iesnium_block" }
+					type: "item"
+				}
+				{
+					id: "6CC8BD33A5503DEB"
+					item: { count: 1, id: "minecraft:ghast_tear" }
+					type: "item"
+				}
+			]
+			x: 29.5d
+			y: 9.5d
+		}
+		{
+			dependencies: ["03250A0202C25E80"]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_possess"
+			}
+			id: "56EC79AF11B0869E"
+			min_width: 300
+			require_sequential_tasks: true
+			rewards: [{
+				id: "51B3FB4AEFE0E2A2"
+				type: "xp"
+				xp: 50
+			}]
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [
+				{
+					count: 4L
+					id: "0D81CA284D83545D"
+					item: { count: 4, id: "minecraft:armadillo_scute" }
+					type: "item"
+				}
+				{
+					count: 4L
+					id: "1F1BB862B01DF36B"
+					item: { count: 4, id: "minecraft:rabbit_foot" }
+					type: "item"
+				}
+				{
+					count: 2L
+					id: "2EF2B9AE4AA75FBC"
+					item: { count: 2, id: "minecraft:pointed_dripstone" }
+					type: "item"
+				}
+				{
+					count: 2L
+					id: "3621D48E2CFAF2C2"
+					item: { components: { "ftbfiltersystem:filter": "ftbfiltersystem:item_tag(c:wools)" }, count: 1, id: "ftbfiltersystem:smart_filter" }
+					type: "item"
+				}
+			]
+			x: 31.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["03250A0202C25E80"]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_craft"
+			}
+			id: "2CF96A264EB5522C"
+			min_width: 300
+			require_sequential_tasks: true
+			rewards: [{
+				id: "624180C81D6D3EB9"
+				type: "xp"
+				xp: 50
+			}]
+			shape: "hexagon"
+			size: 1.5d
+			tasks: [
+				{
+					count: 3L
+					id: "3CF54D9FD7B66E32"
+					item: { count: 3, id: "minecraft:dragon_breath" }
+					type: "item"
+				}
+				{
+					count: 2L
+					id: "2096CB75E157FAE6"
+					item: { count: 2, id: "occultism:amethyst_dust" }
+					type: "item"
+				}
+				{
+					id: "387CD5A2169696CE"
+					item: { count: 1, id: "occultism:crushed_end_stone" }
+					type: "item"
+				}
+				{
+					count: 4L
+					id: "2C16905913038FD5"
+					item: { count: 4, id: "minecraft:end_crystal" }
+					type: "item"
+				}
+			]
+			x: 29.5d
+			y: 6.5d
+		}
+		{
+			dependencies: ["2AD68066C1948C90"]
+			icon: {
+				id: "occultism:chalk_light_blue_impure"
+			}
+			id: "1EB887F8072439A3"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "639F0D08BE538FE3"
+					table_id: 487623848494439020L
+					type: "loot"
+				}
+				{
+					id: "7E5E9C1DCC125331"
+					type: "xp"
+					xp: 50
+				}
+			]
+			tasks: [
+				{
+					id: "021F29CA7E51BA5F"
+					item: { count: 1, id: "occultism:crushed_ice" }
+					type: "item"
+				}
+				{
+					id: "09AF3B0519418345"
+					item: { count: 1, id: "occultism:crushed_packed_ice" }
+					type: "item"
+				}
+				{
+					id: "5C2F8463520C2BDF"
+					item: { count: 1, id: "occultism:crushed_blue_ice" }
+					type: "item"
+				}
+				{
+					id: "0B04FCA28ECB05DB"
+					item: { count: 1, id: "occultism:chalk_light_blue_impure" }
+					type: "item"
+				}
+			]
+			x: 25.5d
+			y: 11.0d
+		}
+		{
+			dependencies: [
+				"2CF96A264EB5522C"
+				"2AD68066C1948C90"
+			]
+			icon: {
+				id: "occultism:chalk_magenta_impure"
+			}
+			id: "3543563DF036D461"
+			tasks: [
+				{
+					id: "0B0C632E633B60C8"
+					item: { count: 1, id: "occultism:dragonyst_dust" }
+					type: "item"
+				}
+				{
+					id: "2935D5987F62BD6F"
+					item: { count: 1, id: "occultism:chalk_magenta_impure" }
+					type: "item"
+				}
+			]
+			x: 31.0d
+			y: 5.0d
+		}
+		{
+			dependencies: ["2AD68066C1948C90"]
+			icon: {
+				id: "occultism:chalk_cyan_impure"
+			}
+			id: "00A6020BC979947F"
+			tasks: [
+				{
+					id: "453BB853EA9182B1"
+					item: { count: 1, id: "occultism:echo_dust" }
+					type: "item"
+				}
+				{
+					id: "674E6AB8F52A57A0"
+					item: { count: 1, id: "occultism:chalk_cyan_impure" }
+					type: "item"
+				}
+			]
+			x: 31.0d
+			y: 11.0d
+		}
+		{
+			dependencies: ["56EC79AF11B0869E"]
+			icon: {
+				id: "occultism:chalk_brown_impure"
+			}
+			id: "7BCD4A425CF6199B"
+			tasks: [
+				{
+					id: "2BD7510CD96A57ED"
+					item: { count: 1, id: "occultism:cruelty_essence" }
+					type: "item"
+				}
+				{
+					id: "2A59204579B09A8B"
+					item: { count: 1, id: "occultism:chalk_brown_impure" }
+					type: "item"
+				}
+			]
+			x: 33.5d
+			y: 8.0d
+		}
+		{
+			dependencies: [
+				"3543563DF036D461"
+				"7BCD4A425CF6199B"
+				"00A6020BC979947F"
+			]
+			icon: {
+				id: "occultism:ritual_dummy/custom_ritual_misc"
+			}
+			id: "0A25276925EB0CBA"
+			min_width: 300
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "516706F4DCD89A14"
+					table_id: 4196188979167302596L
+					type: "loot"
+				}
+				{
+					id: "7BC9E8E58C40E3CC"
+					type: "xp_levels"
+					xp_levels: 1
+				}
+			]
+			shape: "gear"
+			size: 2.0d
+			tasks: [
+				{
+					id: "313C481463E421F7"
+					item: { count: 1, id: "occultism:chalk_white_impure" }
+					type: "item"
+				}
+				{
+					id: "0DD67B59254DDB95"
+					item: { count: 1, id: "occultism:chalk_light_gray_impure" }
+					type: "item"
+				}
+				{
+					id: "002EA4824248BCD2"
+					item: { count: 1, id: "occultism:chalk_gray_impure" }
+					type: "item"
+				}
+				{
+					id: "1F19833D693F324F"
+					item: { count: 1, id: "occultism:chalk_black_impure" }
+					type: "item"
+				}
+				{
+					id: "0F58A0EAC35E51BB"
+					item: { count: 1, id: "occultism:chalk_brown_impure" }
+					type: "item"
+				}
+				{
+					id: "46E0A7B9A053277D"
+					item: { count: 1, id: "occultism:chalk_red_impure" }
+					type: "item"
+				}
+				{
+					id: "0A4A298A7AA69522"
+					item: { count: 1, id: "occultism:chalk_orange_impure" }
+					type: "item"
+				}
+				{
+					id: "068263DD30A6961D"
+					item: { count: 1, id: "occultism:chalk_yellow_impure" }
+					type: "item"
+				}
+				{
+					id: "0F0619C13F633AC3"
+					item: { count: 1, id: "occultism:chalk_lime_impure" }
+					type: "item"
+				}
+				{
+					id: "279C3E75AA687B08"
+					item: { count: 1, id: "occultism:chalk_green_impure" }
+					type: "item"
+				}
+				{
+					id: "4CDB7E20D683AD29"
+					item: { count: 1, id: "occultism:chalk_green_impure" }
+					type: "item"
+				}
+				{
+					id: "6F7BE78E7C2F1AEC"
+					item: { count: 1, id: "occultism:chalk_cyan_impure" }
+					type: "item"
+				}
+				{
+					id: "0A6AE6AC767FFE65"
+					item: { count: 1, id: "occultism:chalk_light_blue_impure" }
+					type: "item"
+				}
+				{
+					id: "4F9EB45160D4E2A9"
+					item: { count: 1, id: "occultism:chalk_blue_impure" }
+					type: "item"
+				}
+				{
+					id: "5D0C4878FBCE6213"
+					item: { count: 1, id: "occultism:chalk_purple_impure" }
+					type: "item"
+				}
+				{
+					id: "6D5EAFADDF110214"
+					item: { count: 1, id: "occultism:chalk_magenta_impure" }
+					type: "item"
+				}
+				{
+					id: "232F31CB4D1351E3"
+					item: { count: 1, id: "occultism:chalk_pink_impure" }
+					type: "item"
+				}
+			]
+			x: 36.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["0A25276925EB0CBA"]
+			id: "690B89D23134B624"
+			require_sequential_tasks: false
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "40582796F09FEC70"
+					table_id: 4196188979167302596L
+					type: "loot"
+				}
+				{
+					id: "364D9D1E440B9756"
+					type: "xp_levels"
+					xp_levels: 1
+				}
+			]
+			tasks: [{
+				id: "687E54A17D6F09AB"
+				item: { count: 1, id: "occultism:chalk_rainbow" }
+				type: "item"
+			}]
+			x: 38.5d
+			y: 8.0d
+		}
+		{
+			dependencies: ["690B89D23134B624"]
+			id: "54378277B8D28B1D"
+			optional: true
+			tasks: [{
+				id: "4A935B03FA1DD7C3"
+				item: { count: 1, id: "occultism:chalk_void" }
+				type: "item"
+			}]
+			x: 41.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["2CF96A264EB5522C"]
+			id: "1BDB369FD243D4C6"
+			min_width: 300
+			shape: "gear"
+			size: 1.25d
+			tasks: [{
+				id: "0210448E8118E45C"
+				item: { count: 1, id: "occultism:iesnium_anvil" }
+				type: "item"
+			}]
+			x: 28.0d
+			y: 5.0d
+		}
+		{
+			dependencies: ["2960FFE0C53DFEB1"]
+			hide_dependent_lines: true
+			id: "6FFFAE334DFAAAAB"
+			rewards: [{
+				id: "5EDBE01DE9B25580"
+				type: "xp"
+				xp: 100
+			}]
+			tasks: [{
+				id: "10037D5225C2D20E"
+				item: { count: 1, id: "occultism:iesnium_sacrificial_bowl" }
+				type: "item"
+			}]
+			x: 22.0d
+			y: 5.0d
+		}
+		{
+			dependencies: [
+				"0A25276925EB0CBA"
+				"666EA8B8F13EB292"
+			]
+			id: "2FD22502E6481269"
+			tasks: [{
+				id: "3F319A5CD7E4E884"
+				item: { count: 1, id: "occultism:trinity_gem" }
+				type: "item"
+			}]
+			x: 38.0d
+			y: 5.0d
+		}
+		{
+			dependencies: [
+				"0A25276925EB0CBA"
+				"6FFFAE334DFAAAAB"
+			]
+			id: "08697EB269B011FD"
+			tasks: [{
+				id: "05A43D4098C30ED1"
+				item: { count: 1, id: "occultism:eldritch_chalice" }
+				type: "item"
+			}]
+			x: 38.0d
+			y: 11.0d
+		}
+		{
+			dependencies: [
+				"2FD22502E6481269"
+				"690B89D23134B624"
+				"08697EB269B011FD"
+				"42F50CE7FE715583"
+			]
+			hide_details_until_startable: true
+			icon: {
+				components: {
+					"ftbquests:icon": "occultism:textures/gui/book/infusion.png"
+				}
+				id: "ftbquests:custom_icon"
+			}
+			id: "29C83B00AC4AFC23"
+			min_width: 300
+			rewards: [{
+				id: "1CA2FF5D585D03DF"
+				type: "xp_levels"
+				xp_levels: 1
+			}]
+			shape: "rsquare"
+			size: 2.5d
+			tasks: [{
+				id: "2B54A5BE4392F79C"
+				type: "checkmark"
+			}]
+			x: 44.0d
+			y: 8.0d
+		}
+		{
+			dependencies: ["4C873491F6F0FFAF"]
+			icon: {
+				id: "minecraft:book"
+			}
+			id: "5ACE97EE75813006"
+			min_width: 300
+			tasks: [{
+				id: "348A7E3E3A3D324E"
+				type: "checkmark"
+			}]
+			x: 10.5d
+			y: 3.0d
 		}
 	]
 }

--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -2759,7 +2759,7 @@
 	quest.1BD5B25B80EC0F97.quest_desc: ["Also makes those magnetic iron rods for just some energy - save your redstone!"]
 	quest.1BD5B25B80EC0F97.quest_subtitle: "Magnetizing!"
 	quest.1BDB369FD243D4C6.quest_desc: [
-		"Arguably the most useful item that you can create in Occultism, the &bIesnium Anvil&r is a super-powerful version of the Anvil."
+		"Arguably the most useful item that you can create in Occultism, the &bIesnium Anvil&r is a super-powerful version of the Vanilla Anvil."
 		""
 		"Created using &9Uphyxes' Inverted Tower&r, it:"
 		""
@@ -4742,6 +4742,7 @@
 	quest.2FC15D3916DBF4E4.quest_subtitle: "More Filtering Options"
 	quest.2FC15D3916DBF4E4.title: "&eAdvanced Void Upgrade"
 	quest.2FD22502E6481269.quest_desc: ["Using &dRonaza's Contact&r, you can upgrade your Soul Gem to create a Trinity Gem. It's basically just a beefed up version of the Soul Gem that can capture larger enemies, although it still can't contain most bosses."]
+	quest.2FD22502E6481269.title: "Trinity Gem"
 	quest.2FDACD6F153D5B64.quest_desc: ["Processing Sheldonite and purifying it will allow you to get the highest return on Platinum Group Sludge. This Sludge contains resources you need to progress."]
 	quest.2FDACD6F153D5B64.quest_subtitle: "My Friend Sheldon went to a club on nite."
 	quest.2FE4B7B70D90A455.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks.\\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission.\\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
@@ -13319,6 +13320,7 @@
 	task.2C268116DA162155.title: "AllRightsReserved"
 	task.2C621D97D1ED56DE.title: "FE Generation"
 	task.2C816285392535F0.title: "AllRightsReserved"
+	task.2C5C6F411E2F0CAF.title: "Any #c:dusts/netherite"
 	task.2CC38211F4C54ED8.title: "Draconic Comb"
 	task.2CE553B282962E01.title: "Buckets"
 	task.2D0212699F99459F.title: "My First Network"
@@ -13371,6 +13373,7 @@
 	task.34E5BD34C83CD6F9.title: "AllRightsReserved"
 	task.35320BB07FB39D05.title: "AllRightsReserved"
 	task.359396879CBA62D5.title: "Nest Spawning"
+	task.3621D48E2CFAF2C2.title: "Any #c:wools"
 	task.362D501E0D663695.title: "RFTools Storage"
 	task.36397CBA6D39DC0D.title: "Tungsten Ingot"
 	task.363BADA865C39474.title: "AllRightsReserved"
@@ -13516,6 +13519,7 @@
 	task.510CE57C709D5A44.title: "Observe Hydrofluoric Acid in a Machine"
 	task.518B9569DCE0A771.title: "AllRightsReserved"
 	task.51A3E013D2B3D744.title: "Machine Upgrades"
+	task.523951BF097BA61F.title: "Any #c:dusts/emerald"
 	task.52874F5B79ECAE65.title: "Stone Bricks"
 	task.529FFD7D692AEFA5.title: "Specialized Projectiles"
 	task.52BB142F044075B4.title: "Quests"
@@ -13539,6 +13543,7 @@
 	task.56A486D09B8B90EC.title: "Observe Alloy Blast Smelter"
 	task.56D7513E9D02F900.title: "Drill Heads"
 	task.570BF38EA2870300.title: "Quests By AllTheMods"
+	task.57108C994437F25B.title: "Any #ae2:all_nether_quartz"
 	task.57895147416291FE.title: "AllRightsReserved"
 	task.57DD9261905988F3.title: "Mekanism Iron Swords"
 	task.57F40CFA03BD36EF.title: "The Hard Part"

--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -28,7 +28,7 @@
 	chapter.3DEB33F78398EAD6.chapter_subtitle: ["And LaserIO"]
 	chapter.3DEB33F78398EAD6.title: "Basic Logistics"
 	chapter.415BA265E2C00859.title: "Getting Started"
-	chapter.4293754F9B2D05F0.title: "&aChapter 2&r: &eAllthemodium"
+	chapter.4293754F9B2D05F0.title: "&aChapter 2&r: &eAllTheModium"
 	chapter.43BB00A7A7E1042C.title: "Mahou Tsukai"
 	chapter.4791C8461B1B4D5F.title: "Basic Armor"
 	chapter.48410B67C276ED1F.title: "The Bumblezone"
@@ -41,7 +41,6 @@
 	chapter.59395B6806F2A98A.title: "Cataclysm"
 	chapter.5B00676D79306EA2.title: "Welcome"
 	chapter.5C764279146E5E66.title: "Mystical Agriculture"
-	chapter.5D045EF1AB73DF70.title: "Basic Power"
 	chapter.5E31DF282998B992.title: "PneumaticCraft"
 	chapter.65A95C2312976E49.title: "The Undergarden"
 	chapter.69299302373C4CBC.title: "Integrated Dynamics"
@@ -86,7 +85,6 @@
 	quest.002B8F2DE2CB4D2C.quest_desc: ["Hold a Shield in your off hand and the &7Scroll of Strengthening&r in your main and hold Right Click."]
 	quest.002B8F2DE2CB4D2C.title: "Strong Shield"
 	quest.002D65E4D7E8F62B.title: "Tier 2 Grader Catalyst"
-	quest.00307A898A639191.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks.\\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission.\\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
 	quest.00453FF528AA0B1C.quest_desc: ["Lonestar Skeletons are hostile Mobs that can spawn anywhere. \\n\\nThey have 10 Hearts and will throw their Sword at you to attack you. \\n\\nOn death they can drop Bones, Swamp Silver Nuggets, Shattered Swords, and the drops added by Corail for Undead Mobs."]
 	quest.00453FF528AA0B1C.title: "Lonestar Skeletons"
 	quest.004D61425172324F.quest_desc: ["&8Chainmail Armor&r is a little worse than Iron. Its main use in &l&2Minecraft&r was its elusive nature, only being obtained through Trades and Mob Drops. \\n\\nOf course this is modded though, so we can craft it now! Which takes away its purpose..."]
@@ -118,6 +116,8 @@
 	quest.00A17728A387B426.quest_desc: ["Wood Nests are used to lure Carpenter Bees and the Blue Banded Bee.\\n\\nDark Oak Nests lures 3 different bees.\\n\\nThese can be placed in any Overworld Biome."]
 	quest.00A17728A387B426.quest_subtitle: "Can be used in any Overworld biome"
 	quest.00A17728A387B426.title: "Wood Nests"
+	quest.00A6020BC979947F.quest_desc: ["With your freshly summoned &9Marid Crusher&r, you can break down an echo shard and an Iesnium ingot, which combine with a glow ink sac to create Cyan Chalk."]
+	quest.00A6020BC979947F.title: "&3Cyan Chalk"
 	quest.00A91BD731486644.quest_subtitle: "Ceylon Ebony + Sour Cherry"
 	quest.00AC7CC291A3E590.quest_desc: ["You've probably (definitely) seen structures around the world with what looks like Beacons coming out of them. They're made of cobblestone, have 4 legs supporting them, kinda high in the air! \\n\\nHopefully you know it but they're called &8Dark Temples&r and they have an &aEnviromental Accumulator&r which we need. \\n\\nYou'll have to wait for Thunderstorm to happen to fill your Weather Container. Then, you can make your &3Lightning Bomb&r!"]
 	quest.00AC7CC291A3E590.title: "&3Lightning Bomb"
@@ -205,13 +205,9 @@
 	quest.01748C2CD9C97523.title: "&cReappearing \\& Vanishing Blocks"
 	quest.019CA0E35F888222.quest_subtitle: "More Filtering Options"
 	quest.019CA0E35F888222.title: "&eAdvanced Restock Upgrade"
-	quest.019D5A05A2134C7E.title: "&dAtomic Alloy"
-	quest.01AFC11EAAB6CB3B.quest_desc: ["&eBone Reptile Armor&r is made from &eKoboleton Bones&r, &eAncient Metal&r, and for the Helmet a &eKobolediator Skull&r. \\n\\nThese don't appear to do anything special, just give very good stats for cheap Armor!"]
-	quest.01AFC11EAAB6CB3B.title: "&eBone Reptile Armor"
 	quest.01B13BBB41BBB460.quest_desc: ["&cUtherium Armor&r has same stats as Netherite Armor! \\n\\nWithout needing a Smithing Template!"]
 	quest.01B13BBB41BBB460.title: "&cUtherium&r Armor"
 	quest.01B2DDD81065B4EF.quest_subtitle: "Jungle + Cherry"
-	quest.01C169A7FA424F6E.quest_subtitle: "Tier: &a2"
 	quest.01C5D8357D8B0D62.quest_desc: ["If you know how a Detector Rail works then this Module will be explanatory for you. \\n\\nBasically if a certain Item is in the Router, it will emit a Redstone Signal out of the Router. \\n\\nIn the Module you can set the Item, where the Signal comes from, and how strong a Signal."]
 	quest.01CF1A9D9F29AFF7.quest_subtitle: "Pomelo + Orange"
 	quest.01D895369791881A.quest_desc: ["Now we get 2 ZPM processors for each craft! This is a great breakthrough, and will make expanding our machine footprint much easier!"]
@@ -244,8 +240,8 @@
 	]
 	quest.020E6AF37A0421C8.title: "Water Tank"
 	quest.02190383FEE793ED.quest_desc: ["All that is left to do is use a &eChemical Reaction&r to pull the Chlorine off the Iridium!"]
-	quest.022C38096F79EF07.quest_desc: ["&6&lForbidden \\& Arcanus&r is all about using the Arcane to do rituals with the Forge to become stronger! \\n\\nOr what most know it for, Eternal Stella. There's more to the Mod you know! "]
-	quest.022C38096F79EF07.title: "&6&lForbidden \\& Arcanus"
+	quest.022C38096F79EF07.quest_desc: ["&6&lForbidden Arcanus&r is all about using the Arcane to do rituals with the Forge to become stronger! \\n\\nOr what most know it for, Eternal Stella. There's more to the Mod you know! "]
+	quest.022C38096F79EF07.title: "&6&lForbidden Arcanus"
 	quest.0251FD45582C3164.quest_subtitle: "Don't sniff this"
 	quest.0253D241383EC848.quest_desc: ["Raiden is a Fictional Character in the Mortal Kombat Fightin.... Oh wait... It said Radon, not Raiden..."]
 	quest.0253D241383EC848.quest_subtitle: "Raiden"
@@ -337,6 +333,8 @@
 	]
 	quest.030AC1AF8F735550.quest_desc: ["To get liquids into the Tank you'll need some sort of Pipes.\\n\\nThe Hydro Pump can automatically put Water into them at a slow rate, but also for free!"]
 	quest.030AC1AF8F735550.title: "Pipes"
+	quest.03250A0202C25E80.quest_desc: ["After you've successfully slain the &9unbound Marid&r demon that you summoned with &4Abras' Fortified Conjure&r, you can use the &9Marid Essence&r that it drops to craft the \"highest\" Colored Chalk, Blue Chalk."]
+	quest.03250A0202C25E80.title: "&9Blue Chalk"
 	quest.032B654201E71618.quest_desc: ["These &cTrack Kits&r are for using entities with your &7Carts&r (Entities aka Mobs). \\n\\nThe &cEmbarking Kit&r will pick up any Mobs nearby and put them in a &7Cart&r. \\nThe &cDisembarking Kit&r unloads Mobs from the &7Carts&r. \\nThe &cDumping Kit&r will drop the mobs in the &7Carts&r below the &6tracks&r its on."]
 	quest.032B654201E71618.title: "&cTrack Kits&r for moving entities"
 	quest.033BF8D12E32A5E5.quest_desc: ["Take that Ruthenium Dust and get to mixing! "]
@@ -463,7 +461,7 @@
 	quest.048BD38532A1DDCF.quest_subtitle: "Holds a max of 1M LP"
 	quest.048F2942436D3C46.title: "&6Master of The Sky"
 	quest.0496E8E786262464.quest_desc: ["Do I really need to explain the &2Overworld&r to you?"]
-	quest.0496E8E786262464.title: "&2Overworld&r: Land of &m3&r 4 bosses"
+	quest.0496E8E786262464.title: "&2Overworld&r: Land of 3 bosses"
 	quest.0498A578D0EC3254.quest_desc: ["Infusing Osmium with Redstone in a Metallurgic Infuser will create you one of these."]
 	quest.0498A578D0EC3254.quest_subtitle: "The Basic Control Circuit"
 	quest.04A1D582003A0D9A.quest_desc: [
@@ -479,9 +477,9 @@
 	quest.04A371896B1E0CEC.quest_subtitle: "Enhance"
 	quest.04A7AA70C23830FF.quest_desc: ["Sickles tools that can be used to clear large amount of organic materials. Sickles break blocks in an area around the block you mine."]
 	quest.04B31A600004F7CB.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks. \\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission. \\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
-	quest.04B40BB107F14330.quest_desc: ["The &4Meat Shredder&r is a Melee weapon you can make from &4Witherite&r. \\n\\nIt has two attacks, either using Left Click or Right Click. \\n\\nWhen you Left Click it'll use the &4Meat Shredder&r like an Axe, hitting them once from a decent range. \\n\\nWhen you hit Right Click it will repeatedly shred them with it's Saw, doing much quicker Damage from closer."]
+	quest.04B40BB107F14330.quest_desc: ["The Meat Shredder is a Melee weapon you can make from Witherite. It has two attacks, tapping left click and holding it. When you tap left click it'll use the Meat Shredder like an Axe, hitting them once from a decent range. When you hold it though it will repeatedly shred them with it's saw doing much quicker damage from closer."]
 	quest.04B40BB107F14330.quest_subtitle: "Straight outta Fallout 3 DLC The Pitt"
-	quest.04B40BB107F14330.title: "&4Meat Shredder"
+	quest.04B40BB107F14330.title: "Meat Shredder"
 	quest.04B6E31120663EB2.quest_subtitle: "Tier: &a2"
 	quest.04BE9F63E6003475.quest_desc: ["&3LPG&r can be used to make Molten Plastic."]
 	quest.04BE9F63E6003475.quest_subtitle: "The one we need"
@@ -541,7 +539,7 @@
 	]
 	quest.050D8480EE9D8E62.title: "Wigglewood Forest"
 	quest.0515422E36E4E9A3.quest_desc: ["Grants invisibility when sneaking."]
-	quest.0518551637F76C50.quest_desc: ["A little expensive but the &9Echoing Deepshelf&r is like a much better &bSeashelf&r. (BTW you'll need to kill quite a few wardens to advance more in Enchanting... should've warned you earlier). Also increases Max &aEterna&r to &a75&r."]
+	quest.0518551637F76C50.quest_desc: ["A little expensive but the &9Echoing Deep Shelf&r is like a much better &bSeashelf&r. (BTW you'll need to kill quite a few wardens to advance more in Enchanting... should a warned you earlier). Also increases Max &aEterna&r to &a75&r."]
 	quest.0518551637F76C50.title: "&9Echoing Deepshelf"
 	quest.051E0C85E7B71CE0.quest_desc: ["I'm going to assume you've been out mining, right? It is MINEcraft after all.\\n\\nYou'll find a ton of new ores that might confuse you, but you can stick to the vanilla materials to get you started!\\n\\nCopper is abundant and has plenty of uses for things like &aOre Hammers&r or &eDrawer Upgrades&r, so make sure to grab plenty of it!\\n\\nIron is probably one of the most important ores you'll want to get every time you run into it. The world of modded MC pretty much runs on Iron."]
 	quest.051E0C85E7B71CE0.title: "The &9Metal&r Age"
@@ -552,8 +550,7 @@
 		"{image:atm:textures/questpics/bumblezone/bumble_blue2.png width:200 height:100 align:center}"
 	]
 	quest.053483E3349B2F8A.title: "&bBlue Sempiternal Sanctum"
-	quest.0539AF15A10B2859.quest_desc: ["&lCompact Machines&r allow you to enter a compacted dimension. After placing a &lCompact Machine&r, you can enter it using the Personal Shrinking Device.\\n\\nThe size of the &lCompact Machine&r is dependent on the recipe, ranging from 5x5x5 to 45x45x45!\\n\\nYou can't break the &lCompact Machine&r's walls, and you can exit by Right Clicking the Personal Shrinking Device."]
-	quest.0539AF15A10B2859.title: "Compact Machines"
+	quest.0539AF15A10B2859.quest_desc: ["Hyperboxes are similar to Compact Machines! \\n\\nAfter placing and naming a Hyperbox you can enter it. Which will bring you to the Hyperbox Dimension. \\n\\nHere you will be in the Hyperbox you just made and named, it is a 13x13x13 Cube. You can't break the Hyperbox Walls (in Survival) but you can Right Click the Aperture Blocks to leave it."]
 	quest.0542FE108089A0A2.quest_desc: ["&l&6Theurgy&r is the art of using Magic for Alchemy! Or in our sense using Machines and Items to make more or different Items! \\n\\nLot's of the Machines that we need for &l&6Theurgy&r needs Copper so start there!"]
 	quest.0542FE108089A0A2.title: "&l&6Theurgy"
 	quest.054D2D3C20C2D32F.quest_desc: [
@@ -610,8 +607,13 @@
 	quest.05B0A7D0B991050F.title: "Reactor (Hardened)"
 	quest.05B5E640F1B68A28.quest_desc: ["{image:atm:textures/questpics/basicarmor/armor_golem.png width:100 height:150 align:center}"]
 	quest.05B5E640F1B68A28.title: "&3Golem Steel&r"
-	quest.05B6DB75AEC01187.quest_desc: ["RFTools Power has &9Powercells&r to store power, which are multi-block storage units that can be customized and upgraded to store power.\\\\n\\\\nYou will need a Wrench to determine inputs and outputs for power."]
-	quest.05B6DB75AEC01187.title: "&9RFTools Power: &cPowercells"
+	quest.05B6DB75AEC01187.quest_desc: [
+		"RFToolsPower has &9Powercells&r to store power, which are multi-block storage units that can be customized and upgraded to store power. "
+		""
+		"You will need a wrench to determine inputs and outputs for power."
+	]
+	quest.05B6DB75AEC01187.quest_subtitle: "RFTools"
+	quest.05B6DB75AEC01187.title: "Powercells from RFTools"
 	quest.05B8C64EB012F6EA.quest_desc: ["Another option is using Chronal exchange; gain mahou for 12 hours, then spend it for 12 hours. If you make a second Chronal exchange circle when the first starts spending, it becomes a loop. "]
 	quest.05B8C64EB012F6EA.title: "Chronal Exchange"
 	quest.05B977269171EB06.quest_desc: [
@@ -643,8 +645,6 @@
 		"{image:atm:textures/questpics/justdirethings/goo_spread_ferricore.png width:200 height:200 align:center}"
 	]
 	quest.05DBDD86FCFF3BA8.title: "&5Lightning&r Upgrade Orb"
-	quest.05DE9E1CDFBC22DE.quest_desc: ["&dVoid Scatter Arrows&r are Crafted with a Spectral Arrow and a &dVoid Jaw&r. \\n\\nThey can be shot by any Bow or Crossbow. When they hit any Mob or Block they will break apart. \\n\\nWhen they break apart, many parts will be thrown around the area, damaging whatever they hit!"]
-	quest.05DE9E1CDFBC22DE.title: "&dVoid Scatter Arrows"
 	quest.05E668CE6687AC64.quest_desc: ["The &bToken of Joy&r is the first Token you should craft, tokens are important crafting materials for items in &aNature's Aura&r."]
 	quest.05E668CE6687AC64.title: "&bToken of Joy"
 	quest.05F0FCBBEADA8489.quest_desc: ["You can use a &eFluid Heater&r or a &eDistillery&r on &aProgram 1&r to turn the &3Dissolved Calcium Acetate&r into &cAcetone&r"]
@@ -678,8 +678,12 @@
 	quest.064BBCC379A69748.quest_desc: ["This one is around twice as good as a vanilla furnace, and is more efficient to boot! While it gets outclassed by other furnace mods, for a strictly MI playthrough this furnace is incredibly strong!"]
 	quest.0650996C7818ADB5.quest_desc: ["The Heat Generator has 2 modes to generate power:\\n\\n&9Passive:&r Surrounding the generator with lava source or flowing blocks creates passive power by creating heat. Place one lava source block on top, and let it flow over the sides. Make sure to connect pipes first!\\n\\n&9Active:&r Placing combustible materials such as coal or wood into the generator will burn the fuel to create power."]
 	quest.0650996C7818ADB5.quest_subtitle: "Basic Power Gen"
-	quest.0661E9669E639621.quest_desc: ["Some saplings can't be pollinated. These saplings have a random chance to grow into another tree.\\n\\nFor example if you want to get a &4Red Crepe Myrtle Sapling&r, first grow a Purple Crepe Sapling. You will have a chance to get a &4Red Crepe Myrtle Tree&r from that."]
-	quest.0661E9669E639621.quest_subtitle: "Self Breeding?"
+	quest.0661E9669E639621.quest_desc: [
+		"Some saplings can't be pollinated. These saplings have a random chance to grow into another tree. "
+		""
+		"For example if you want to get a &7Red Crepe Myrtle Sapling&r, first grow a Purple Crepe Sapling. You will have a chance to get a &7Red Crepe Myrtle&r tree from that!"
+	]
+	quest.0661E9669E639621.quest_subtitle: "There is more rng"
 	quest.066438B01655D866.quest_desc: ["While their &dEssence&r is useful, we can also capture these Spirits for later use. That sounds evil, doesn't it?\\n\\nTo become a Spirit Hunter, you'll need to create the &dVengeance Focus&r first. This is used to &aFreeze Spirits&r in place, then you place a &9Box of Eternal Closure&r near the Spirit. This will then suck the Spirit in for later use."]
 	quest.066438B01655D866.title: "Capturing &dSpirits"
 	quest.066B8A75B299AED8.quest_desc: [
@@ -798,13 +802,12 @@
 		"Breaks nearby grass and flowers when activated."
 	]
 	quest.076A648E3E3245C9.quest_desc: ["Very fast Rate of making Energy from Fuel which makes it the very efficient. Only problem is it can't be upgraded anymore. Still uses normal Furnace Fuel."]
-	quest.076A648E3E3245C9.title: "&aEmerald Generator"
+	quest.076A648E3E3245C9.title: "&aEmerald Furnace"
 	quest.076DFB0B39A4259F.quest_desc: [
 		"{atm9.quest.enchant.desc.infused_seashelf}"
 		"{image:atm:textures/questpics/apotheosis/enchant_sea.png width:100 height:100 align:1}"
 	]
 	quest.076DFB0B39A4259F.title: "{atm9.quest.enchant.infused_seashelf}"
-	quest.07751E1BE48C6024.quest_subtitle: "Tier: &b4"
 	quest.07753C5D94312A50.quest_desc: [
 		"&3Augment&r: Generator is the opposite of the &3Augment&r: Factory, instead of using Energy to Smelt, it Smelts for Energy. You will no longer smelt items in it, every Fuel used will be made into Energy!"
 		""
@@ -854,11 +857,14 @@
 	quest.08457BEED799E600.title: "&7Carts&r and &6Tracks"
 	quest.0848056FDD3F9BDA.quest_desc: ["A &9Singularity&r is a theorized point of ultimate density. Scientists believe the Universe we live in once was a &9Singularity&r. Every molecule in our Universe, in a single point smaller than a grain of sand. \\n\\nOf course with &l&bAE2&r drifting along the line of theoritical sciences they have their own &9Singularity&r. \\n\\nThere's 2 ways of crafting it but each require condensing a multitude of Items into one point!"]
 	quest.0848056FDD3F9BDA.title: "&9Singularity"
-	quest.0853917693A259C2.quest_desc: ["&3The Annihilator&r is a very fun weapon made from &3Cursium&r and Black Steel. \\n\\nYou can smack enemies around with it all day! But you know what's more fun than one &3Annihilator&r? \\n\\nTwo &3Annihilators&r! \\n\\nIf you have an &3Annihilator&r in each Hand, then you can Hold Right Click to do a powerful ground pound, damaging all around you!"]
-	quest.0853917693A259C2.title: "&3The Annihilator"
 	quest.0854AD352218E1C3.quest_desc: ["Don't you hate when you have all this power but no Heating? \\n\\nNow you can change that with the Caloric Flux Emitter! Shift Right Click with it to bind it to a Machine. Then place it down and power it to send Heat. \\n\\nCan't be set to multiple Machines!"]
 	quest.0854AD352218E1C3.quest_subtitle: "How?"
 	quest.0854AD352218E1C3.title: "Wireless Heat"
+	quest.08697EB269B011FD.quest_desc: [
+		"With &dRonaza's Contact&r, you can upgrade your &bIesnium Sacrificial Bowl&r to the Eldritch Chalice. When used in a ritual, reduces the time it takes to complete... entirely. "
+		""
+		"Yes, the Eldritch Chalice makes it so that all rituals complete instantly!"
+	]
 	quest.087726194EED4BDF.quest_desc: ["Hold a Shield in your off hand and the Scroll of Strengthening in your main and hold right click."]
 	quest.087726194EED4BDF.title: "Strong Shield"
 	quest.088D685775ED92EE.quest_desc: [
@@ -884,8 +890,6 @@
 	quest.08903890F577D43A.title: "Scroll of Strengthening"
 	quest.0893EFCAC7031FEA.quest_desc: ["Time to bake a cake, if you've got some milk and eggs ready."]
 	quest.0893EFCAC7031FEA.quest_subtitle: "Have your Cake and Eat it too"
-	quest.0894EB1F3FCFCECA.quest_desc: ["&3Draugrs&r are similar to &5Deeplings&r as they have rankings. The &3Draugr&r rankings are: &3Draugr&r, &3Royal Draugr&r, and &3Elite Draugr&r. \\n\\nNormal &3Draugr&r have 14 &4Hearts&r and carry Black Steel Swords and Axes. These drop Rotten Flesh, Bones, and rarely Black Steel Nuggets. \\n\\nNext in line are &3Royal Draugr&r. These have 15 &4Hearts&r and carry Black Steel Targes along with the Swords and Axes. They drop the same Items as normal &3Draugrs&r. \\n\\nLast is the &3Elite Draugr&r. These switch between Black Steel Swords and Crossbows, depending on how far you are from them. They have 16 &4Hearts&r and drop, of course, the same loot!"]
-	quest.0894EB1F3FCFCECA.title: "&3Draugrs"
 	quest.0897F7A3203E45AF.quest_desc: [
 		"Can convert certain blocks into liquids."
 		""
@@ -895,14 +899,6 @@
 	quest.089D22E6B361EBA4.quest_desc: ["Preparing components for the Micro Universe Drill Ship."]
 	quest.089D22E6B361EBA4.quest_subtitle: "Thrusters to Full!"
 	quest.08AC2D81A1004984.title: "&6Allthemodium &5Alloy &3Trident"
-	quest.08B1A64B01A8A604.quest_desc: [
-		"While there are other methods to move Demons around, you can create an &dEmpty Soul Gem&r to capture a Demon and place it somewhere else."
-		""
-		"To make this, we'll need to do a more advanced Ritual called &aStrigeor's Higher Binding&r. For this, you'll need &a8 Sacrificial Bowls&r as well as the items required for this quest."
-		""
-		"Remember, you can always use the multi-block preview by finding the Pentacle in the &bDictionary of Spirits&r to help you build the structure."
-	]
-	quest.08B1A64B01A8A604.title: "&bCapturing &dDemons"
 	quest.08B60D8A25008CCC.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks. \\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission. \\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
 	quest.08C66BCA3AAE765B.quest_desc: ["This one adds Non-&2&lMinecraft&r Blocks so I'd rather not discuss it."]
 	quest.08C66BCA3AAE765B.title: "&b&lMacaw's Roofs"
@@ -1044,6 +1040,13 @@
 	quest.0A207A437AF153AA.title: "&2Phantom Armor"
 	quest.0A21773B773F34F8.quest_desc: ["Color is one of the most important parts of making a Build more lively! \\n\\nIt gives it life, personality, and color! \\n\\nStart with the Dyes!"]
 	quest.0A21773B773F34F8.title: "Colored Blocks"
+	quest.0A25276925EB0CBA.quest_desc: [
+		"Once you've gathered every single Colored Chalk and Foundation Chalk, you can perform the second &dDemon-less&r type ritual, &dRonaza's Contact&r. This is ultimate ritual, using everything you've learned so far!"
+		""
+		"It has limited uses, but everything created with this ritual is super powerful!"
+	]
+	quest.0A25276925EB0CBA.quest_subtitle: "With this sacred treasure I summon..."
+	quest.0A25276925EB0CBA.title: "&dRonaza's Contact"
 	quest.0A2675CF16B6443B.quest_desc: [
 		"Extruders force ingots into various shapes with the use of the extruder mold"
 		""
@@ -1094,15 +1097,23 @@
 	quest.0ACC0092A8F722C6.title: "&cWire Coils"
 	quest.0AD2B11565B484E7.quest_desc: ["You'll need every Furnace before &5Netherite&r for these. Yes all, even the &6Copper&r! Even the &7Silver&r! Even the &3Crystal&r!"]
 	quest.0AD2B11565B484E7.title: "&cR&6a&ei&2n&3b&9o&5w &cP&6l&ea&2t&3i&9n&5g"
-	quest.0ADBE90B33ACC9FB.quest_desc: ["The &cR&6a&ei&2n&3b&9o&5w&r &cG&6e&en&2e&3r&9a&5t&ce&6r&r is a boost to the &cR&6a&ei&2n&3b&9o&5w&r &cF&6u&er&2n&3a&9c&5e&r while using &3Augment&r: Generator. If all other 8 Furnaces (not counting &5Netherite Furnace&r) are around the &cR&6a&ei&2n&3b&9o&5w&r &cF&6u&er&2n&3a&9c&5e&r, have &3Augment&r: Generator, and are actively making Energy (fueled up and not full) they will give a boost to a &cR&6a&ei&2n&3b&9o&5w&r &cF&6u&er&2n&3a&9c&5e&r that has &3Augment&r: Generator and is working. It will make 2kFE a tick more!"]
-	quest.0ADBE90B33ACC9FB.title: "&cR&6a&ei&2n&3b&9o&5w &cG&6e&en&2e&3r&9a&5t&co&6r"
+	quest.0ADBE90B33ACC9FB.quest_desc: ["The &cR&6a&ei&2n&3b&9o&5w&r &cG&6e&en&2e&3r&9a&5t&ce&6r&r is a boost to the &cR&6a&ei&2n&3b&9o&5w&r &cF&6u&er&2n&3a&9c&5e&r while using &3Augment&r: Generator. If all other 8 Furnaces (not counting &5Netherite Furnace&r) are around the &cR&6a&ei&2n&3b&9o&5w&r &cF&6u&er&2n&3a&9c&5e&r, have &3Augment&r: Generator, and are actively making Energy (fueled up and not full) they will give a boost to a &cR&6a&ei&2n&3b&9o&5w&r &cF&6u&er&2n&3a&9c&5e&r that has &3Augment&r: Generator and is working. It will make 50kFE a tick more!"]
+	quest.0ADBE90B33ACC9FB.title: "&cR&6a&ei&2n&3b&9o&5w &cG&6e&en&2e&3r&9a&5t&ce&6r"
 	quest.0AE28C998A3BF136.quest_subtitle: "531,441 Netherrack"
 	quest.0AE6AD813928DE4F.quest_desc: ["The External Heater can be used with Furnaces, like the &2&lVanilla&r ones, not &c&lCrude Blast Furnace&r! \\n\\nIt takes in &cEnergy&r from the Bottom and uses it for Heat. \\n\\nThe Heat comes out of the other sides of it, to adjacent Blocks. \\n\\nIt is technically used for the &4&lImproved Blast Furnace&r, by Crafting the Preheaters but I don't count that!"]
 	quest.0AEAEA976ED0C470.quest_desc: ["The &3Charging Station&r is used to charge various tools and gadgets in &aPneumaticCraft&r using pressure."]
 	quest.0AEAEA976ED0C470.quest_subtitle: "Where's the cord?"
-	quest.0AEC181F5E21A299.quest_desc: ["If you've ever heard of someone talking about \"Melon Power\", this is it. Mekanism's &dGas-Burning Generator&r can produce a good amount of power by pumping in &9Ethylene&r made from Melon Slices.\\\\n\\\\nTo produce &dEthylene&r, start by crushing organic materials in a &eCrusher&r to create &6Bio Fuel&r. Melon Slices are typically used for this! This is then pumped into a &dPressurized Reaction Chamber&r (PRC for short).\\\\n\\\\nThe PRC needs Water, Bio Fuel, and some Hydrogen to create Ethylene. You can get the Hydrogen from separating water in an &9Electrolytic Separator&r.\\\\n\\\\nOnce you've started producing the Ethylene, pump it into the Gas-Burning Generator to start generating power!"]
-	quest.0AEC181F5E21A299.quest_subtitle: "MELON POWER!"
-	quest.0AEC181F5E21A299.title: "&9Mekanism: &dGas-Burning Generator"
+	quest.0AEC181F5E21A299.quest_desc: [
+		"If you've ever heard of someone talking about 'Melon Power', this is it. Mekanism's &9Gas-Burning Generator&r can produce a good amount power by pumping in &9Ethylene&r made from Melon Slices. "
+		""
+		"To produce &dEthylene&r, start by crushing organic materials in a &eCrusher&r to create &6Bio Fuel&r. Melon Slices are typically used for this! This is then pumped into a &dPressurized Reaction Chamber&r (PRC for short). "
+		""
+		"The PRC needs Water, Bio Fuel, and some Hydrogen to create Ethylene. You can get the Hydrogen from separating water in an &9Electrolytic Separator&r.  "
+		""
+		"Once you've started producing the Ethylene, pump it into the Gas-Burning Generator to start generating power!"
+	]
+	quest.0AEC181F5E21A299.quest_subtitle: "The Power of the Melon"
+	quest.0AEC181F5E21A299.title: "&eMekanism's&r &dGas-Burning Generator&r"
 	quest.0AF5FB1B5AA5AA11.quest_subtitle: "Tier: &b4"
 	quest.0AFC5B1AF055811A.quest_desc: [
 		"The &2Edelwood Bucket&r can store more than one bucket of liquid, and can also be used to capture small animals like chickens or squids."
@@ -1121,8 +1132,11 @@
 	quest.0B2B8247DA280E90.quest_desc: ["This rune increases the total capacity of the Altar by 20% for each Capacity rune."]
 	quest.0B37355262121DD5.quest_desc: ["The &aInfusion Altar&r is how you make all of the seeds. Place down the Altar first and it'll show you where to place the Pedestals after.\\n\\nIn order for the Infusing to start, the Alter requires a &4Redstone signal&r."]
 	quest.0B37355262121DD5.quest_subtitle: "Creating Seeds"
-	quest.0B37355262121DD5.title: "&4Infusion Altar"
-	quest.0B3EA604C5172D98.quest_desc: ["For us to specify which &c&mDemon&r &9Friend&r we want to summon, we'll need to make a specific &bBook of Binding&r.\\n\\nTo make this, you'll need to purify some Black Dye in &dSpiritfire&r to get Purified Ink. With this, we're going to make our first Book of Binding which will summon a &aFoliot&r Demon."]
+	quest.0B3EA604C5172D98.quest_desc: [
+		"For us to specify which &c&mDemon&r &9Friend&r we want to summon, we'll need to make a specific &bBook of Binding&r.\\n\\nTo make this, you'll need to purify some Black Dye in &dSpiritfire&r to get Purified Ink. With this, we're going to make our first Book of Binding which will summon a &aFoliot&r Demon."
+		""
+		"Alternatively, you can make an Empty Book of Binding, which can be dyed later to fit whatever tier of ritual you need."
+	]
 	quest.0B3EA604C5172D98.title: "&bBooks of &dBinding"
 	quest.0B485DB737A036E9.quest_desc: ["Machine Settings Copier allows players to copy settings between machines."]
 	quest.0B6772E52FE97284.quest_subtitle: "&f11&r &4Damage&r"
@@ -1130,10 +1144,10 @@
 	quest.0B6D35F5B3A11FD2.quest_subtitle: "Caching in!"
 	quest.0B6D35F5B3A11FD2.title: "&9Aura Cache"
 	quest.0B70D40FA951E13B.quest_subtitle: "Oak + Birch"
-	quest.0B7F2B63D867D221.quest_desc: ["To find these we'll need a little archeology! \\n\\nIn the giant shaft you'll take to get to the &e&lAncient Remnant&r, there are 3 rooms on the sides of it. \\n\\n2 of these rooms have Suspicious Sand which you can use a Brush on to get Loot! Including the &eNecklace of Desert&r. \\nThen, Right Click the &e&lAncient Remnant&r with the &eNecklace of Desert&r to resurect it!"]
+	quest.0B7F2B63D867D221.quest_desc: ["Once you get to the bottom of the &eCursed Pyramid&r you might notice that the &eAncient Remnant&r doesn't move much. That's because you'll need a Necklace of Desert to ressurect the beast. To find it you'll need to brush the sus sand in the &eCursed Pyramid&r. (Hope you read this before heading all the way down)."]
 	quest.0B7F2B63D867D221.quest_subtitle: "Resurecting an Ancient Remnant"
-	quest.0B7F2B63D867D221.title: "&eNecklace of the desert"
-	quest.0B9BBE2A764631BF.quest_desc: ["The simple swapper can teleport items, blocks, mobs or players above it to another simple sawper it is linked to. To link swapers use the Ferricore wrench."]
+	quest.0B7F2B63D867D221.title: "Necklace of the desert"
+	quest.0B9BBE2A764631BF.quest_desc: ["The simple swaper can teleport items, blocks, mobs or players above it to another simple sawper it is linked to. To link swapers use the Ferricore wrench."]
 	quest.0B9F2B443813F43C.quest_desc: ["Have you ever wanted to be able to attack things with a Shovel, and have it hurt? I would ask why, but this is EvilCraft.\\n\\nWell look no further! This serves as both a weapon, and a tool for breaking soft things!"]
 	quest.0BA5A0DDD4A5363C.quest_subtitle: "Cobaltite be here"
 	quest.0BA5A0DDD4A5363C.title: "Garnierite Vein"
@@ -1148,12 +1162,12 @@
 	]
 	quest.0BB0DF36B079558F.quest_desc: ["When the &6Entangled Chalice&r is placed in the world, it can pump in Blood. When activated in your inventory, it will try to fill up your items that use &cBlood&r as a resource.\\n\\nIf you want to make more Chalices using the same network, just use the crafting recipe that uses a Chalice instead of a Gold Ingot"]
 	quest.0BB0DF36B079558F.title: "&6Entangled Chalice"
-	quest.0BB367839D28607D.quest_desc: ["These &8Coal Generators&r are some of the easiest generators to make.\\n\\nThey are very simple to use and create a decent amount of power based on the combustible material you put in. They also automatically distributes power to adjacent blocks."]
-	quest.0BB367839D28607D.quest_subtitle: "Fossil Fuels"
-	quest.0BB367839D28607D.title: "&8Coal Generators"
-	quest.0BB42C5861B22D32.quest_desc: ["The &bMycelial Reactor&r consists of all the Mycelial Generators working at the same time, near the reactor block, and it produces a total of &a25MFE/t&r.\\n\\nAll sounds good, but you need to automate some stuff to get it working, see what each Mycelial Generator consumes to work, and automate it, most things are simple, but others, not that much... &olooking at Disenchanting Mycelial Generator&r.\\n\\nBut after you get it all automated, you don't need to stop at one, you can make more reactors."]
-	quest.0BB42C5861B22D32.quest_subtitle: "It's not Yourcelial Reactor"
-	quest.0BB42C5861B22D32.title: "&9Industrial Foregoing: &bMycelial Reactor"
+	quest.0BB367839D28607D.quest_desc: [
+		"The RFTools Coal Generator is one of the easiest coal-burning generators to make. "
+		""
+		"It is very simple to use and creates a decent amount of power based on the combustible material you input. It automatically distributes power to adjacent blocks as well."
+	]
+	quest.0BB367839D28607D.title: "Coal Generator"
 	quest.0BB562FB44B0AAA7.quest_desc: ["Cards aren't the only ones with limits, so they also aren't the only ones with Overclockers! \\n\\nThese go into the &cNode&r itself on bottom right and boost how fast it does Operations."]
 	quest.0BB562FB44B0AAA7.quest_subtitle: "Max: 8"
 	quest.0BB8D556305EB307.quest_desc: [
@@ -1167,6 +1181,17 @@
 	quest.0BCC79C1D002F532.title: "Infinite &9Water&r!!!"
 	quest.0BCCDE24D378F260.quest_subtitle: "Tier: &d3"
 	quest.0BCCDE24D378F260.title: "&dAdvanced Machine Frame"
+	quest.0BD6365534BF04D5.quest_desc: [
+		"With our lime chalk in hand, it's time to delve into &5Possesion Rituals&r. These rituals are slightly different from the others because they all require a live sacrifice, usually small mobs such as chickens, bees, bats, etc. However, as rituals get more complicated, they will require larger and larger sacrifices. "
+		""
+		"Even if you've placed all of the items needed and the Book of Binding into the Golden Sacrificial Bowl, the Ritual will not begin until you kill the sacrifice on top of the runes."
+		""
+		"We reccomend that you make some sort of mob capture item such as an empty soul gem, jar, Mob Imprisonment Tool, or Quantum Catcher!"
+		""
+		"The first tier of &5Possession rituals&r is &eHeidryn's Lure&r, which is only used to get mundane items like skeleton skulls and end stone. Because of this, we're skipping right to the second tier ritual, &aIhagan's Enthrallment&r. "
+	]
+	quest.0BD6365534BF04D5.quest_subtitle: "Who ya gonna call?"
+	quest.0BD6365534BF04D5.title: "&aIhagan's Enthrallment"
 	quest.0BD908937BC6E97B.quest_subtitle: "Kapok + Rosewood"
 	quest.0BE2E7C9454058C3.quest_desc: [
 		"Part of the beautiful &d&lFloral Meadow&r is a &dCherry Tree&r much older and bigger than the rest. \\n\\nThe &6B&8e&6e&8s&r have seemed to take a liking to these &dTrees&r and have set up mini &eHives&r next to them full of their young!"
@@ -1271,6 +1296,9 @@
 	quest.0CF6D11016BAF3D0.quest_subtitle: "Complex Naquadah"
 	quest.0D01524F249E25D7.quest_subtitle: "Who turned off the lights?"
 	quest.0D01524F249E25D7.title: "&8Dark Xychorium Gems"
+	quest.0D18BBB04693885A.quest_desc: ["Strigeor's Higher Binding is the second tier of &6Infusion Rituals&r. It's used for a TON of different things, but the main things we'll need are the Infused Pickaxe and Gray Paste."]
+	quest.0D18BBB04693885A.quest_subtitle: "The \"everything\" ritual"
+	quest.0D18BBB04693885A.title: "&aStrigeor's Higher Binding"
 	quest.0D19FB62C2C1D9F7.quest_desc: ["Once you've got at least 200 &4Mahou&r you might want to make a Boundary of Life Drain. \\n\\nFor every Mob that dies in that boundary, you get 10 &4Mahou&r back, but this is a SLOW process."]
 	quest.0D19FB62C2C1D9F7.title: "Boundary of Life Drain"
 	quest.0D1A6B32FEB51FAD.quest_desc: [
@@ -1393,7 +1421,6 @@
 	quest.0E057B7F76401421.title: "&6Copper Backpack"
 	quest.0E0CAA31480EC0A1.quest_desc: ["Allows the Backpack to pick up items."]
 	quest.0E0CAA31480EC0A1.quest_subtitle: "Allows the backpack to pick up items."
-	quest.0E1ABCAA87120367.quest_subtitle: "Tier: &c5"
 	quest.0E20A9B79D1C6637.quest_desc: ["The Warden is a boss added in 1.20. \\n\\nHe spawns by having 3 naturally spawning Sculk Shriekers going off in a row, or any Shriekers going off after a first Warden has spawned. \\n\\nHe is the most powerful Mob added by Minecraft, with 500 Hearts and over 20 Hearts damage with his attacks. \\n\\nHis attacks include hitting you and Sonar Blasts for those farther. \\n\\nHis only weakness is being blind, but like daredevil it just made his other senses much stronger! If you are close he can smell you and careful with making noise! \\n\\nIf you somehow kill him he will drop: Sculk Catalysts, Warden Carapace, and Heart of the Deep."]
 	quest.0E20A9B79D1C6637.title: "Kill The Warden"
 	quest.0E2515424291BB59.quest_desc: ["&bDiamond&r version of &d&lArs&r Armors!"]
@@ -1490,8 +1517,6 @@
 	quest.0ED7B25DC1AA767B.quest_desc: ["Within the &9Twilight Forest&r, there are loot chests that can give you rare saplings.\\n\\nCollect them all!"]
 	quest.0ED7B25DC1AA767B.quest_subtitle: "Growing Trees"
 	quest.0ED7B25DC1AA767B.title: "&aThe Real Final Boss"
-	quest.0EE0946240B41A00.quest_desc: ["&bIgnitium&r is an upgrade for Netherite. You'll need an &bIgnitium Upgrade&r which is Crafted, and an &bIgnitium Ingot&r which is dropped from the &b&lIgnis&r. \\n\\nThe &bIgnitium Helmet&r allows you to see clearly under Lava. \\n\\nThe &bIgnitium Chestplate&r can combined with an Elytra. \\n\\nThe &bIgnitium Leggings&r don't make us flame-proof, rather the Fires that are covering our bodies will go out quicker! \\nThe &bIgnitium Boots&r allow us to walk over Lava. Like Leather Boots over Powdered Snow, you can Hold Shift to lower into the Lava."]
-	quest.0EE0946240B41A00.title: "&bIgnitium Armor"
 	quest.0EE2D22A577D10B0.quest_desc: [
 		"This rune accelerates the operations of other runes, like the Charging or Displacement Rune."
 		""
@@ -1543,6 +1568,7 @@
 		"If you plan on making a bunch of steel, Enrich your Charcoal first!"
 	]
 	quest.0F326EEEC2EBE4E5.quest_subtitle: "Enrich your items first!"
+	quest.0F326EEEC2EBE4E5.title: "Enriched Items"
 	quest.0F36FE9BCBA83129.quest_subtitle: "&f5&r &4Damage&r"
 	quest.0F3BD102F9F93DDD.quest_desc: ["The &9Quantum Catcher&r is used to capture and transport mobs."]
 	quest.0F3BD102F9F93DDD.title: "Entity Tools"
@@ -1577,11 +1603,8 @@
 	quest.0F7BB4ECCA5C082C.title: "&eSulfur&r Vessel"
 	quest.0F89BFD4A3F63A48.quest_desc: ["Some mobs (mostly monsters) need certain Light Levels to spawn. Hostile ones needing lower levels and passive needing higher ones. Using a Soul Lantern makes it so you never have to worry about Light Levels as it ignores them! This does not ignore other requirements for spawning like livestock animals needing Grass."]
 	quest.0F89BFD4A3F63A48.title: "Ignore Light"
-	quest.0F8F0F7880235BA2.quest_desc: [
-		"&cThe Soul BlackSmith&r resides in the Nether&r. Don't overlook it thinking it is a Bastion, it's much worse. \\n\\nYou can find Gold, Blackstone, and Netherite here. \\n\\nThe only hostile Mobs that spawn here is the boss... the &c&lNetherite Monstrosity&r!"
-		"{image:atm:textures/questpics/cataclysm/cataclysm_blacksmith.png width:200 height:100 align:center}"
-	]
-	quest.0F8F0F7880235BA2.title: "&cSoul BlackSmith&f: Home of the &c&lNetherite Monstrosity&r"
+	quest.0F8F0F7880235BA2.quest_desc: ["&cThe Soul BlackSmith&r resides in the Nether&r. Don't overlook it thinking it is a Bastion, it's much worse. You can find Netherite and the &cNetherite Monstrosity&r. You won't need anything to activate him, just your presence."]
+	quest.0F8F0F7880235BA2.title: "&cSoul BlackSmith&r: Home of the &cNetherite Monstrosity&r"
 	quest.0F8F37D7E12078F5.quest_subtitle: "Complete all the tips!"
 	quest.0F9829B0A5EEE67B.quest_desc: [
 		"Finally, the diode is within reach"
@@ -1608,7 +1631,7 @@
 		"{image:atm:textures/questpics/forbidden/forbidden_forge1.png width:100 height:100 align:center}"
 		"To start making your Forge, place down our &9Polished Darkstone&r, &6Arcane Polished Darkstone&r, and &6Gilded Chiseled Polished Darkstone&r in this pattern. "
 		"{image:atm:textures/questpics/forbidden/forbidden_forge2.png width:100 height:100 align:center}"
-		"\"Next place our Smithing Table on the inner &6Gilded Chiseled Polished Darkstone&r and smack it with &cMundabitur Dust&r, you'll get the &6&lHephaestus Forge&r!\\\\n\\\\nLastly place our &6Darkstone Pedestals&r on top of the 8 outside &6Gilded Chiseled Polished Darkstone&r!\""
+		"Next place our &6Darkstone Pedestals&r on top of the 8 outside &6Gilded Chiseled Polished Darkstone&r and our Smithing Table on the inner one. \\n\\nLastly smack your Smithing Table with &cMundabitur Dust&r! And you'll get the &6&lHephaestus Forge&r!"
 	]
 	quest.0FD638380EECFFBD.title: "Building the &6&lForge"
 	quest.0FE30548F25FEDB1.quest_desc: ["If you're like me and don't like living in a Box (it reminds me too much of School), then you'll like to have Glass in your Builds to see outside. \\n\\nWhile the normal Vanilla ones are nice of course we can do much better! \\n\\nWe can even get some use out of it!"]
@@ -1665,7 +1688,7 @@
 	quest.10C527C66EE4E95A.title: "{atm9.quest.enchant.Soul_sculk}"
 	quest.10DF2125B647379E.quest_desc: ["I promise, this is not something you want to touch or get on your skin..."]
 	quest.10DF2125B647379E.quest_subtitle: "Do Not Touch!"
-	quest.10E8BC20D406D9FB.quest_subtitle: "Makes various Nether Materials"
+	quest.10E8BC20D406D9FB.quest_desc: ["Makes various Nether materials."]
 	quest.10EF30B919EBA5C6.quest_desc: ["It's a pickaxe with Fortune V on it. That's all.\\n\\nDefinitely won't summon spirits when you are mining. &o&5&lDefinitely won't&r."]
 	quest.110BF3A2BE85F911.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks.\\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission.\\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
 	quest.110D27EA86CDA62B.quest_desc: ["Magnets items into the Backpack."]
@@ -1691,8 +1714,8 @@
 	quest.117241986C99E475.quest_desc: ["With the Glowing Bee, breed it with the Chocolate Mining Bee to get a Redstone Bee!"]
 	quest.117241986C99E475.quest_subtitle: "Glowing + Chocolate Mining"
 	quest.117241986C99E475.title: "Redstone Bee"
-	quest.1178E4123E8818E2.quest_desc: ["Sorry, you can't wear these anymore, now they are just Items! \\n\\nBy Right Clicking with them, 2 &eSandstorms&r will spawn. The &eSandstorms&r will circle you and move with you. \\n\\nWhatever is hit by them will be Damaged and Knockbacked."]
-	quest.1178E4123E8818E2.title: "&eBottle O' Sandstorm"
+	quest.1178E4123E8818E2.quest_desc: ["Sandstorm in a bottle is an item you wear for a special effect. It goes in the Belt slot and when you press default X you will turn into a sandstorm. It is solely for movement, as you can fly for a little bit, it doesn't deal damage or reflect it, just movement. It doesn't negate fall damage though so careful when you get out of it."]
+	quest.1178E4123E8818E2.title: "Bottle O' Sandstorm"
 	quest.1187F9D4F4E0D254.quest_desc: ["The Wrench is a tool that can do two things: \\n-> Rotate blocks \\n-> Break Refined Storage covers.\\n\\nSimply sneak and right click when using the Wrench."]
 	quest.1187F9D4F4E0D254.quest_subtitle: "You spin me right round'"
 	quest.1187F9D4F4E0D254.title: "Wrench"
@@ -1710,6 +1733,8 @@
 	quest.1194FF35ADAA9957.quest_subtitle: "Sharks with Laser beams?"
 	quest.119FF09D481F9178.quest_desc: ["What good would a tech mod be without barrels and tanks. They could be useful, but functions the same as other items of the same."]
 	quest.119FF09D481F9178.title: "Tanks and Barrels"
+	quest.11A0593C0E2E6A35.quest_desc: ["Using &eEziveus' Spectral Compulsion&r, we can imbue a myriad of different nature blocks to form some &2Nature Paste&r. Combine this paste with some impure white chalk to create Green Chalk."]
+	quest.11A0593C0E2E6A35.title: "&2Green Chalk"
 	quest.11AAA1DCB452DFFC.quest_subtitle: "For"
 	quest.11B0B93D725ABE43.quest_desc: ["Silent Gear gear can be repaired using a &9Repair Kit&r.\\n\\nTo repair an item, place the Repair Kit into a crafting grid, then place the materials needed to repair the tool in with it. This will \"fill\" the Repair Kit.\\n\\nTo repair the tool, combine the filled Repair Kit with the tool you'd like to repair in a crafting grid."]
 	quest.11B0B93D725ABE43.quest_subtitle: "No Anvils required"
@@ -1735,8 +1760,15 @@
 	quest.11C5F17C6BB1237B.quest_desc: ["While wearing the &5Withered Bracelet&r Melee Attacks have a chance to give the Wither Effect.\\n\\nSorry Bow users!"]
 	quest.11C5F17C6BB1237B.quest_subtitle: "Wrists (Hands)"
 	quest.11C5F17C6BB1237B.title: "&5Withered Bracelet&r"
-	quest.11D09E918015355C.quest_desc: ["Mekanism's &cHeat Generator&r is a different take on basic power production. It has two modes of creating power:\\\\n\\\\n&9Passive:&r Surrounding the generator with Lava source or flowing blocks creates passive power over time through heat. Place one Lava source block on top and let it flow over the sides. Make sure to have Pipes connected for energy first!\\\\n\\\\n&9Active:&r Placing combustible materials such as Coal or Wood into the generator will burn the fuel to create power. This is not very efficient."]
-	quest.11D09E918015355C.title: "&cHeat Generator"
+	quest.11D09E918015355C.quest_desc: [
+		"&aMekanism's&r Heat Generator is a different take on basic power production. It has two modes of creating power: "
+		""
+		"&9Passive:&r Surrounding the generator with lava source or flowing blocks creates passive power over time through heat. Place one lava source block on top and let it flow over the sides. Make sure to have pipes connected for energy first! "
+		""
+		"&9Active:&r Placing combustible materials such as coal or wood into the generator will burn the fuel to create power. This is not very efficient."
+	]
+	quest.11D09E918015355C.quest_subtitle: "Mekanism's Starter Power Solution"
+	quest.11D09E918015355C.title: "Heat Generator"
 	quest.11D16434F78D2C2C.quest_desc: [
 		"You can use an Extractor to get glass in a liquid state for making the diode"
 		""
@@ -1974,8 +2006,6 @@
 		"For more information on the items in the mod, make sure to check out the &aLexica Botania&r."
 	]
 	quest.13D401048A926A74.title: "Welcome to &aBotania&r"
-	quest.13D5F689E6884281.quest_desc: ["&eKobolediators&r are one of the two mini-bosses within the &eCursed Pyramid&r. \\n\\nThey will remain dormant until a Player (in Survival, took me awhile to figure that out) walks near them and they will wake up. \\n\\nThey have 1080 &4Hearts&r and will inflict Mining Fatigue on you. \\n\\nThey will swing their Sword at you if you get too close! If you gain some distance from them, they will charge at you as if you were holding a Football and running for the endzone! \\n\\nOn death they will drop Koboleton Bones, Ancient Metal Ingots, and their Skull!"]
-	quest.13D5F689E6884281.title: "&eKobolediator"
 	quest.13E3DE157B89E847.quest_desc: [
 		"A very simple structure, some &6B&8e&6e&8s&r and other stuff got frozen into a popsicle."
 		"{image:atm:textures/questpics/bumblezone/bumble_ice.png width:200 height:100 align:center}"
@@ -1990,8 +2020,14 @@
 		"{image:atm:textures/questpics/iron_spells/spells_mountaintower.png width:200 height:100 align:center}"
 	]
 	quest.13F77C38AC015E9F.title: "&bMountain Tower"
-	quest.1409C17773B6A131.quest_desc: ["All Upgrades increase the amount the &e&lPipez&r move but each grant more options to use with the &e&lPipe&r. \\n\\nBasic Upgrade allows Redstone Activation with &e&lPipez&r.\\n\\nImproved Upgrade allows you to change distribution either:Closest First, Farthest First, Round-Robin, or Random.\\n\\nAdvanced Upgrade gives you option to add Filters.\\n\\nUltimate doesn't grant anything new it just moves a lot!"]
-	quest.1409C17773B6A131.title: "&9Pipez: &aUpgrades"
+	quest.1409C17773B6A131.quest_desc: [
+		"To make your pipes extract more power, you'll want to make it an upgrade. "
+		""
+		"Once you've shift+right-clicked a pipe to set it to extract, you can insert a pipe upgrade into it by right-clicking the pipe with the upgrade. You can also right-click with an empty hand and add it using the GUI! "
+		""
+		"To be able to set filters, you'll need at least an &9Advanced Pipe Upgrade&r. "
+	]
+	quest.1409C17773B6A131.title: "Upgrading our Pipez"
 	quest.140DADB32EF10D58.quest_desc: ["Dragon Egg Seeds require a Dragon Egg Crux placed below in order for them to grow."]
 	quest.140DADB32EF10D58.quest_subtitle: "Tier: &56"
 	quest.140DE53DC0FCD9F4.quest_desc: [
@@ -2025,16 +2061,11 @@
 	quest.1452D9CF827782B5.quest_subtitle: "16"
 	quest.1452D9CF827782B5.title: "&fArctic Gear"
 	quest.145C8235BCCB9BA8.quest_desc: [
-		"No, not that kind."
+		"If we want to collect all of the Chalks, we'll need to summon and kill aa not-so friendly &cAfrit&r."
 		""
-		"&cAfrit Demons&r are Demons of &cFire&r. They are more advanced Demons, which some are friends and some are....not."
-		""
-		"If we want to collect all of the Chalks, we'll need to summon a not-so friendly Ifrit. And kill it."
-		""
-		"This specific Ritual will need a live sacrifice. Once you've placed all of the items needed and the Book of Binding into the Golden Sacrificial Bowl, the Ritual will not start until you sacrifice the living creature nearby it. In this instance, we'll be sacrificing a cow. Sorry again, Betsy."
+		"Even though this isn't a &5Possession Ritual&r, you'll need a live sacrifice for this ritual. In this instance, we'll be sacrificing a cow. Sorry Betsy!"
 	]
-	quest.145C8235BCCB9BA8.quest_subtitle: "R.I.P. Betsy"
-	quest.145C8235BCCB9BA8.title: "&cHot Demons"
+	quest.145C8235BCCB9BA8.title: "&cRed Chalk"
 	quest.145E7D1A88B83DDD.quest_desc: ["Where'd you go?"]
 	quest.145E7D1A88B83DDD.quest_subtitle: "Scarf (Necklace)"
 	quest.145E7D1A88B83DDD.title: "&9Scarf of Invisibility&r"
@@ -2056,7 +2087,7 @@
 	]
 	quest.1482F2D45E8F761D.quest_subtitle: "Casings and Glass"
 	quest.1482F2D45E8F761D.title: "Fission Reactor Building Basics"
-	quest.148A33CC36B2563A.quest_desc: ["The &dDraconic Endshelf&r is the last Shelf we'll need for perfect set up. It might only give &aEterna&r but it has the Max Max &aEterna&r of &a100&r."]
+	quest.148A33CC36B2563A.quest_desc: ["The &dDraconic Shelf&r is the last Shelf we'll need for perfect set up. It might only give &aEterna&r but it has the Max Max &aEterna&r of &a100&r."]
 	quest.148A33CC36B2563A.title: "&5Draconic Endshelf"
 	quest.149BD1A9F82FA19A.quest_subtitle: "&f6 &cAttack Damage"
 	quest.149C260C10B34BB0.quest_subtitle: "5/5"
@@ -2097,7 +2128,7 @@
 	quest.14D9C071E184DE3B.quest_subtitle: "Purple Crepe + Luck"
 	quest.14DB8A515CA50932.quest_desc: ["The &9Enchanter's Sword&r allows you to attach a Touch Spell to the sword. \\n\\nAll spells on the Sword gain 1 additional Amplify augment to the last effect on the spell. \\n\\nTo apply a spell to the sword, use a Scribe's Table. Create the spell without using a form."]
 	quest.14E5349DD740D026.quest_desc: [
-		"To insert fuel into the reactor, you'll need to pick one of the sides that has a &9Reactor Solid Access Port&r and pump in &eUranium&r from an inventory.\\n\\nThe easiest way to do this is to use something like a &aStorage Drawer&r or even just a &aChest&r with an &9Item Pipe&r connected at the top, like the image shown below.\\n"
+		"To insert fuel into the reactor, you'll need to pick one of the sides that has a &9Reactor Solid Access Port&r and pump in &eUranium&r from an inventory.\\n\\nThe easiest way to do this is to use something like a &aStorage Drawer&r or even just a &aChest&r with an &9Item Pipe&r connected at the top, like the image shown below."
 		"{image:atm:textures/questpics/extremereactors/importexample.png width:150 height:150 align:1}"
 	]
 	quest.14E5349DD740D026.title: "Fueling our Passive Reactor"
@@ -2108,7 +2139,6 @@
 	quest.14E7D8E642DE7463.quest_subtitle: "A dense alloy ingot with magic in every bite."
 	quest.14EB725643E9F8FE.quest_desc: ["Allows the Mana Burst to move a block just as if a piston would."]
 	quest.14F6ED7F0C1DC503.quest_desc: ["Drink 8 &6Bottles of Honey&r. \\n\\nThis ones the hardest for me I can't stand the noise of drinking &6Honey Bottles&r."]
-	quest.14F7F256DA863280.quest_subtitle: "Makes various Twilight Forest Materials"
 	quest.14F856E0D32FBB5B.quest_subtitle: "Teak + Balsa"
 	quest.15006CF73F8CAB7C.quest_desc: ["Just like the &cCharm of Life I&r, the &eCharm of Life II&r is consumed to prevent your death. When consumed, you'll regen all of your health and be given Regen IV, Resistance, and Fire Resistance for 30 seconds.\\n\\nThese can be crafted with 4 &cCharms of Life I&r."]
 	quest.15006CF73F8CAB7C.title: "&eCharm of Life II"
@@ -2156,7 +2186,7 @@
 	quest.158F48B73171BDE1.title: "Metal Tools"
 	quest.1591013DDD4766E1.quest_desc: ["&l&cCooking for Blockheads&r is all about making the Kitchen your home. \\n\\nI recommend using everything it gives as every Item has a use and looks amazing!"]
 	quest.1591013DDD4766E1.title: "&l&cCooking for Blockheads&r"
-	quest.15978093237448FE.quest_desc: ["Why upgrade &cNetherite&r to &6Allthemodium&r or even anything else when we can upgrade it to &3Warden Armor&r! \\n\\nYou'll need a few Warden Drops in order to make it though!"]
+	quest.15978093237448FE.quest_desc: ["Why upgrade &cNetherite&r to &6AllTheModium&r or even anything else when we can upgrade it to &3Warden Armor&r! \\n\\nYou'll need a few Warden Drops in order to make it though!"]
 	quest.15978093237448FE.quest_subtitle: "24"
 	quest.15978093237448FE.title: "&3Warden Armor"
 	quest.15A1D6D05A785919.quest_desc: ["Did you know that NOR logic gates can be used to make every other logic gate? That's why we use it so much for making circuits!"]
@@ -2218,9 +2248,8 @@
 	quest.16522A3A1E66C914.quest_desc: ["Yet again, we revisit the EBF's and upgrade the coils, a necessary process so that we can process metals and alloys through the EBF's."]
 	quest.16522A3A1E66C914.quest_subtitle: "Trinium Coils are nice"
 	quest.1659A59303C15CC9.quest_desc: ["Barrels work the same as Chests only they can't be combined together into 1. They look cool though."]
-	quest.166971866A9234C7.quest_desc: ["Infusing a &6Copper Ingot&r with &4Redstone Dust&r in a Metallurgic Infuser will make an &cInfused Alloy&r."]
+	quest.166971866A9234C7.quest_desc: ["Infusing Iron with Redstone in a Metallurgic Infuser will get you one of these."]
 	quest.166971866A9234C7.quest_subtitle: "The Basic Alloy for Crafting Items"
-	quest.166971866A9234C7.title: "&cInfused Alloy"
 	quest.166DF03D93BC11F1.quest_desc: ["The Reforging Table does everything a Simple one does but better, it can do Epic and Mythic Affixes!"]
 	quest.166DF03D93BC11F1.title: "(Better) Reforing Table"
 	quest.167E1474644C9908.quest_desc: ["The Quartz makes whatever the other item does, it does the opposite for the Spawner. With Quartz in your offhand and the other Spawner Modification item in your main it will do the opposite of its role. With Quartz and Blaze Rods instead of increasing Spawn Range it will decrease it. With Quartz and Ghast Tears it'll decrease Max Entities."]
@@ -2291,7 +2320,7 @@
 		"&9Bee Conversion&r requires you to feed a bee a specific item to convert it into a new Bee."
 	]
 	quest.17419401147B5C02.quest_subtitle: "The Bees and the Bees"
-	quest.1744E700CF742CE2.quest_desc: ["&5The Coralssus&r works as a Guard and Steed for the &5Sunken City&r. \\n\\nThey can be ridden by &5Deeplings&r to move quicker and attack together! \\n\\nThey have 160 &4Hearts&r and basic attacks . Its attacks are just smacking and throwing you. \\n\\nWhen killed it'll drop Coral Chunks which can be used to make the &5Abyssal Sacrifice&r."]
+	quest.1744E700CF742CE2.quest_desc: ["&5The Coralssus&r works as a Guard and Steed for the &5Sunken City&r. They're used with the &5Deeplings&r but he's different so he gets his own quest! They have only 110 Hearts and basic attacks but the &5Deeplings&r with them make it much more dangerous. Its attacks are just smacking and throwing you. When killed it'll drop Crystalized Coral which is needed to make the Abyssal Sacrifice."]
 	quest.1744E700CF742CE2.title: "&5Coralssus&r"
 	quest.174D18D9D732EC10.quest_subtitle: "8 Wet Green Blocks"
 	quest.17542D7633FBF098.quest_desc: [""]
@@ -2343,9 +2372,6 @@
 	]
 	quest.1780A9FDD6983435.title: "Tier 3 Sigils"
 	quest.17885C2DE986F1BD.quest_desc: ["&n&5Casings&r are used as a crafting ingredient for most blocks."]
-	quest.17989643018D00C1.quest_desc: ["Do Hives annoy you when they drip? If so, you're in luck because there's an easy solution.\\n\\nYou can place a &eSponge&r in the Bottle slot of an Advanced Hive to stop it from dripping."]
-	quest.17989643018D00C1.quest_subtitle: "You got no Drip"
-	quest.17989643018D00C1.title: "Stopping Dripping"
 	quest.17A68C4E9E9EA2B7.quest_desc: ["&eGolden Armor&r is right between Iron and &7Leather&r. But its Durability is much closer to &7Leather&r. \\n\\nThere is not much use for it besides having Piglins Neutral towards you when wearing some &eGold Armor&r."]
 	quest.17A68C4E9E9EA2B7.quest_subtitle: "11"
 	quest.17A68C4E9E9EA2B7.title: "&eGolden Armor"
@@ -2380,11 +2406,8 @@
 		"&lAbility Function:&r"
 		"Highlights nearby mobs with particals when activated."
 	]
-	quest.17CA9D80D8EC3EF7.quest_desc: [
-		"&4&lThe Harbinger&r takes a lot of inspiration from what powers him, the Nether Star. \\n\\nHe has 15,600 &4Hearts&r and will attack every Mob and Player he sees that doesn't spawn in the &4Ancient Factory&r. \\n\\nHe will fly around and even charge at you. Like &0The Wither&r, &l&4The Harbringer&r will break almost every Block in its path. \\n\\nTo attack he can shoot &4Wither Missiles&r at you which can give you &0Wither Effect&r or shoot &4Wither Howitzers&r from his back which will shoot off in every direction. \\n\\nHe also has &4Lasers&r he can shoot you with, &4Laser Gatlings&r, and a &4big mouth beam&r. \\n\\nHe has a big weakness, like the other living machines, he is weak to the &4EMPs&r! If you use them on him, he will be stun locked, unable to move or fight for a few seconds."
-		"{image:atm:textures/questpics/cataclysm/cataclysm_harbinger.png width:100 height:100 align:center}"
-	]
-	quest.17CA9D80D8EC3EF7.title: "&4&lThe Harbinger&r"
+	quest.17CA9D80D8EC3EF7.quest_desc: ["&4The Harbinger&r takes a lot of inspiration from what powers him, the Nether Star. He will fly around and shoot Wither Missiles at you which can give you wither effect. He also has lasers he can shoot you with, laser gatlings and a big mouth beam. He has 7800 Hearts and a big weakness, the EMPs. When powered with redstone they'll damage all the machines nearby. Once defeated he'll drop a block of Witherite and perhaps a music disc: Monster Fight."]
+	quest.17CA9D80D8EC3EF7.title: "&4The Harbinger&r"
 	quest.17D7D34F519F7E5F.quest_desc: ["To create the final tier of your Spellbook, you'll need to have killed the &6Wilden Chimera&r. \\n\\nThis is a Ritual that you'll need to complete using a &9Ritual Brazier&r."]
 	quest.17D82EEA20D02EC8.quest_desc: ["Lining the Sea floor is Dusted Gravel. \\n\\nIt can be used as a replacement for normal Gravel and can rarely drop Dusted Shards which can make other Blocks!"]
 	quest.17DC77F7F8C68AE6.quest_desc: ["Trash Cans act as a way to destroy unwanted items, liquid, and power."]
@@ -2435,6 +2458,15 @@
 	]
 	quest.1834B5C1F8435D7A.quest_subtitle: "Fluids"
 	quest.1843C79133DFB024.quest_desc: ["The most powerful and efficient Generator, the Netherstar Generator. Take a guess what it uses to make Energy!"]
+	quest.1848F431D0380DA9.quest_desc: [
+		"Similar to the Chalk Repairing function of &aStrigeor's Higher Binding&r, &cSevira's Permanent Confinement&r can be used to repair items using the power of an Afrit demon."
+		""
+		"This ritual can repair just about anything, so &edemon miners&r, tools, and armor can all be restored to their original durability! "
+		""
+		"All items that are repaired using this ritual retain their original properties (affixes, enchantments, etc.), so don't worry about your precious level 10 enchantments!"
+	]
+	quest.1848F431D0380DA9.quest_subtitle: "Free(ish) durability!"
+	quest.1848F431D0380DA9.title: "Repairing Items"
 	quest.184F98BE0F6710E2.quest_desc: ["These 2 &cTrack Kits&r are for using &7Carts&r and Redstone.\\n\\nThe &cActivator Kit&r will activate whatever &7Cart&r goes over it. \\nThe &cDetector Kit&r will activate a redstone signal whenever a &7Cart&r passes over it. \\n\\nBoth are similar to their &2Vanilla&r counters for regular &6tracks&r."]
 	quest.184F98BE0F6710E2.title: "&cTrack Kits&r for using Redstone"
 	quest.185074907753AE77.quest_desc: ["If you are using Routers I hope you have some game knowledge. \\n\\nJust incase, to void an Item means to delete it. \\n\\nAny items that come into the Router, will be deleted forever! \\n\\nRecommend using Filters with this one..."]
@@ -2452,7 +2484,7 @@
 	quest.186826F12973BA28.quest_desc: ["Around twice as fast as the Bronze Macerator. One of the most important machines during this age since you'll need such a huge amount of ores. You'll want a few of these so you can process large quantities of ores."]
 	quest.187281092C0BC9CE.quest_desc: ["Wafers and Silicon Boules need to be cut. This cutter, paired with the Engraving Laser will make sure we keep our stock of Chips up!"]
 	quest.187281092C0BC9CE.quest_subtitle: "Waffles and Boules"
-	quest.1873205CF5247E3E.quest_desc: ["The last sets of Shelves you'll need are &dEndshelves&r, to get them you need Infused Dragon's Breath. This one was hard to get but you need atleast &a80 Eterna&r, &c15%-30% Quanta&r, and atleast &560% Arcana&r. It has to be between &c15%-25% Quanta&r to get that you can try &910 Echoing Sculkshelves&r and &29 Melonshelves &ror &92 Echoing Sculkshelves&r and &b4 Heart-Forged Seashelves&r."]
+	quest.1873205CF5247E3E.quest_desc: ["The last sets of Shelves you'll need are &dEndshelves&r, to get them you need Infused Dragon's Breath. This one was hard to get but you need atleast &a80 Eterna&r, &c15%-30% Quanta&r, and atleast &560% Arcana&r. It has to be between &c15%-25% Quanta&r to get that you can try &910 Echoing Skulkshelves&r and &29 Melonshelves &ror &92 Echoing Skulkshelves&r and &b4 Heart-Forged Seashelves&r."]
 	quest.1873205CF5247E3E.title: "&5Endshelf"
 	quest.187816477B732517.quest_desc: ["The &3Transfer Gadget&r acts like a Hopper that can be placed inbetween blocks."]
 	quest.187816477B732517.quest_subtitle: "Smaller Hopper"
@@ -2489,7 +2521,7 @@
 	quest.18EADBAFC932F864.quest_desc: ["To shear Sheep you need Shears, you wouldn't get Wool any other way...right?"]
 	quest.18EADBAFC932F864.quest_subtitle: "Pacifist Run"
 	quest.18EADBAFC932F864.title: "It's Clippin' Time"
-	quest.18EB86F91CBBCCC6.quest_desc: ["Not all Cataclysm Dungeons are as easy to find as the &eCursed Pyramids&r are. \\n\\nSo, a specific Eye might help you find them! \\n\\nEach of the different Eyes will lead you to its set structure; and don't worry, the Eyes rarely break."]
+	quest.18EB86F91CBBCCC6.quest_desc: ["Not all Cataclysm Dungeons are as easy to find as the Pyramids are, so a special Eye might help you find them. Each of the different Eyes will lead you to its set structure, and don't worry them breaking is very rare."]
 	quest.18EB86F91CBBCCC6.title: "Eye see you!"
 	quest.18F88DE24EFBA7A7.quest_desc: [
 		"Coal is great to use in a furnace as fuel, but you'll find out fast that it is easy to burn through. "
@@ -2503,7 +2535,7 @@
 	quest.18F88DE24EFBA7A7.title: "Fuel for our Furnace"
 	quest.18F948FF9FE015FB.quest_subtitle: "Feed a Vanilla Bee TNT"
 	quest.18F948FF9FE015FB.title: "CreeBee"
-	quest.18FAD56CDE05646A.quest_desc: ["Before Quarries in the &7&lMining Dimension&r used to mine everything but leave &6Allthemodium Ore&r. \\n\\nNow it will Mine &6Allthemodium&r but Void the drops... might want to be careful with your Quarries now! \\n\\nI recommend Mining with Ore Sight Potions if you are looking strictly for &6Allthemodium&r!"]
+	quest.18FAD56CDE05646A.quest_desc: ["Before Quarries in the &7&lMining Dimension&r used to mine everything but leave &6AllTheModium Ore&r. \\n\\nNow it will Mine &6AllTheModium&r but Void the drops... might want to be careful with your Quarries now! \\n\\nI recommend Mining with Ore Sight Potions if you are looking strictly for &6AllTheModium&r!"]
 	quest.18FEFB1BC6DFE49C.quest_desc: ["Bringing more power output to our Substations, which as we progress will help immensely in ensuring our equipment stays running!"]
 	quest.18FEFB1BC6DFE49C.quest_subtitle: "Substation Tier up!"
 	quest.1906C5D1C80035E4.quest_desc: [
@@ -2533,11 +2565,6 @@
 		""
 		"Let's combine ethylene with chlorine in the &echemical reactor&r and get some Vinyl Chloride"
 	]
-	quest.196E55B64667AE35.quest_desc: [
-		"You can place Bee Flowers on Feeding Slabs that are placed in front of Hives, as shown in the image below.\\n"
-		"{image:atm:textures/questpics/bees/feeder.png width:175 height:100 align:center fit:true}"
-	]
-	quest.196E55B64667AE35.quest_subtitle: "Slapping down a Slab"
 	quest.1972B36F72808D55.quest_desc: ["Only some of theses stones are chipped though."]
 	quest.1972B36F72808D55.title: "&l&bChipped&r Stones"
 	quest.1985CFD1F0425E88.quest_subtitle: "More Filtering Options"
@@ -2612,7 +2639,6 @@
 	quest.19F58E291A543228.quest_desc: ["&eGold&r version of &d&lArs&r Armors!"]
 	quest.19F58E291A543228.quest_subtitle: "11"
 	quest.19F58E291A543228.title: "&5Sorceror's Outfit"
-	quest.19FFD64154AFC89D.quest_subtitle: "Tier: &b4"
 	quest.1A000021C07943C4.quest_desc: ["Take that steam you were making and turn it into EU!"]
 	quest.1A000021C07943C4.quest_subtitle: "No Power No Problem"
 	quest.1A0368CB49B8CBFF.quest_desc: ["This &eSpell Book&r is a rare drop from &cBlazes&r. I remember that because I was confused when I got 1 from my &cBlaze&r Farm. \\n\\nIt gives a Boost to &cFire Spells&r and has 10 &3Spell&r Slots."]
@@ -2653,11 +2679,6 @@
 	quest.1A8440C0048EEB02.title: "&cBlazegold Armor"
 	quest.1A8F2408970BFCCF.quest_desc: ["&eElectrum&r is an Alloy made from &eGold&r and &7Silver&r. \\n\\nYou can guess by its name it is used a ton in everything electricity related. Wires, Connectors, Transformers, ETC!"]
 	quest.1A8F2408970BFCCF.title: "&eElectrum Ingot&r"
-	quest.1A8F438DB8508276.quest_desc: [
-		"The &3Frosted Prison&r is a massive Castle like structure on top and within the Snowy Mountains. \\n\\nWithin you will find dozens of cells, armories, and a great room which the &3Cursed Tombstone&r lies. \\n\\nYou can find plenty of Chests full of Loot, including Black Steel. There's Decorated Pots everywhere for the taking! \\n\\nAnd of course Mobs enemies to stand in your way: &3Draugrs&r and &3Aptrgangr&r."
-		"{image:atm:textures/questpics/cataclysm/cataclysm_prison.png width:200 height:100 align:center}"
-	]
-	quest.1A8F438DB8508276.title: "&3Frosted Prison&r: Home of the &3&lMaledictus"
 	quest.1A96C595CBA42840.quest_desc: ["Kivi Seeds can be used to grow Kivi Essence which can be crafted in Kivi!"]
 	quest.1A96C595CBA42840.title: "Kivi Automation"
 	quest.1AA81C41431FD145.quest_desc: ["Pull..! Pull..! Pull..! \\n\\nThe Puller is the opposite of the Sender, it pulls items from Inventories into the Router's Buffer. \\n\\nThe Inventory has to be adjacent to the Router."]
@@ -2702,8 +2723,6 @@
 	]
 	quest.1B219582114D287D.quest_desc: ["This infact is not Crude Oil. Its literally Liquid Gold, Once of the densest elements on the periodic table!"]
 	quest.1B219582114D287D.quest_subtitle: "Wait.. This isnt Oil!"
-	quest.1B4ED65C614B102F.quest_desc: ["The &bIgnited Revenant&r stands in our way to kill the &b&lIgnis&r. \\n\\nThe &bRevenant&r looks and acts like a Blaze, but instead of being Rods, he has Shields! \\n\\nThese Shields make him invunerable to all attacks, you'll need to wait for him to lift them, to attack him! \\n\\nHe has 1200 &4Hearts&r and has 2 attacks: one where he lifts in the air and throws Blaze Rods all around him, and the other where he spins his Shields around as if he was doing Spinjitzu. \\n\\nOn death he will drop the &bBurning Ashes&r."]
-	quest.1B4ED65C614B102F.title: "&bIgnited Revenant&r"
 	quest.1B5177A774FCEF64.quest_desc: ["Before we start enlisting the help of our Demon friends, we will need to create the most important item needed for Rituals: &aChalk&r.\\n\\nThere are several colors of chalk needed, with higher level Rituals requiring several to activate. To start with, &bWhite Chalk&r is the easiest to get.\\n\\nStart by tossing Otherstone in a furnace, and tossing Otherworld Logs into &dSpiritfire&r. With the items you create, you'll be able to make the Impure White Chalk.\\n\\nTo purify any piece of Chalk, simply throw it into &dSpiritfire&r to cleanse it. Using the Purified Chalk on the ground will draw &mdemonic&r pretty symbols on the ground. These are a pain to remove, unless of course, you make yourself the &aChalk Brush&r. Do it, it's worth it."]
 	quest.1B5177A774FCEF64.title: "Preparing for a Ritual: &eChalk"
 	quest.1B5C86AE05678420.quest_desc: ["When you right-click on an interface, it brings up several options, here's what they all do:\\n\\n&lSet Side&r: At the top of the screen, you can set the side that the interface \"acts\" like it's on. It can be useful for machines with specific input/output sides.\\n\\n&lTicks/Operation&r: If an interface is set to 10 ticks/operation, it will import/export once every 10 ticks (0.5 seconds).\\n\\n&lPriority&r: Sends items to the inventory with the higher priority interface on it.\\n\\n&lItem/Energy Channels&r: This will split your system into multiple channels. You can push and pull from different places in your network."]
@@ -2739,9 +2758,19 @@
 	quest.1BCE8D02CDD13838.quest_desc: ["Can Create \\\"Liquid\\\" Potions that can be bottled into Potions."]
 	quest.1BD5B25B80EC0F97.quest_desc: ["Also makes those magnetic iron rods for just some energy - save your redstone!"]
 	quest.1BD5B25B80EC0F97.quest_subtitle: "Magnetizing!"
+	quest.1BDB369FD243D4C6.quest_desc: [
+		"Arguably the most useful item that you can create in the Occultism modpack, the &bIesnium Anvil&r is a super-powerful version of the anvil."
+		""
+		"Created using &9Uphyxes' Inverted Tower&r, it:"
+		""
+		"- Is unbreakable"
+		"- Increases the maximum level of all enchants for anything combined on it by one level"
+		"- Costs 1/2 as much xp as the estimate says (rounded down, so if it says 25, it'll cost 12)"
+		"- Has a smaller xp-requirement increase for repeated edits on the same item"
+		"- Increases the maximum xp level at which you can edit items (the point at which it says \"Too Expensive!\")"
+	]
 	quest.1BE26A00A420DAE3.quest_desc: ["In this mod, you'll need &aFlux Cores&r and &aFlux Blocks&r to craft the core parts of your network. Make a few of each!"]
-	quest.1BE26A00A420DAE3.quest_subtitle: "Of Cores you need these"
-	quest.1BE26A00A420DAE3.title: "The \"Core\" Crafting Materials"
+	quest.1BE26A00A420DAE3.title: "The 'Core' Crafting Materials"
 	quest.1BE2CB4684AF7DFB.quest_subtitle: "Diamonds may be hidden in here"
 	quest.1BE2CB4684AF7DFB.title: "Graphite Vein"
 	quest.1BE69992D2C5085B.quest_desc: ["&n&aEvocation:&r\\nTo invoke a Spirit or Deity. \\n\\n&a&lEvokation&r is all about what &aEvokers&r do, mainly summoning. Whether it be &aFangs&r or &aVexes&r if it's summoned it's most likely an &aEvokation&r. \\n\\n&a&lEvokation's&r Focus Material is &aEmeralds&r. You can either craft the Rune or get it from the &a&lArchevoker&r. \\n\\n&aEvokation Scrolls&r are &fWhite&r with &0Black&r texts."]
@@ -2770,9 +2799,9 @@
 	quest.1C566975C4EC5D93.quest_desc: ["Honestly just use &2&lMA&r for this one. It is the easiest way to get all of them. \\n\\nPlease don't make mass &2Turtle&r breeders and mass &bGuardian&r slaughter farms. TPS is important!"]
 	quest.1C566975C4EC5D93.title: "&9Sea Prism"
 	quest.1C5E273723637C43.title: "2 Antimatter Pellets"
-	quest.1C5EA7D62BAF2108.quest_desc: ["In order to fight &5&lThe Leviathan&r you'll need a sacrifice. The &5Abyssal Sacrifice&r to be specific. \\n\\nThe most basic Items needed is the Blocks of Ingots and Amethyst which are just &2&lVanilla&r Items. \\n\\nThen, you'll need a Nautilus Shell and a Heart of the Sea. These are &2&lVanilla&r Items which are rare to get... unless you kill &5Deeplings&r which can drop them! \\n\\nYou'll also need an Athame which is a weapon used by &5Deepling Warlocks &fand &5Priests&r and dropped by them on death. \\nThe last part gives us a choice, either Crystallized Coral or Coral Chunk. Both are drops from &5Coral Golem&r and &5Coralssus&r."]
+	quest.1C5EA7D62BAF2108.quest_desc: ["In order to fight &5The Leviathan&r you'll need a sacrifice. Abyssal Sacrifice to be specific. You'll need a Nautil Shell, Heart of the Sea, Athame, and Crystalized Coral. All of those can be gotten from the &5Sunken City&r. The other blocks probably not. Just take your sacrifice and put it into the Altar of Abyss and boom &5Leviathan&r!"]
 	quest.1C5EA7D62BAF2108.quest_subtitle: "Waking up The Leviathan"
-	quest.1C5EA7D62BAF2108.title: "&5Abyssal Sacrifice"
+	quest.1C5EA7D62BAF2108.title: "Abyssal Sacrifice"
 	quest.1C6B815C0F43312D.quest_desc: [
 		"A change in pace for &6&lBumblezone&r. \\n\\nThe &d&lFloral Meadow&r has Grass, Cherry Trees, and more &dFlowers&r than imaginable. (This reminds me, you should follow Minty Meadow on Twitch). \\n\\nWait if &6B&8e&6e&8s&r have &dFlowers&r in their &eHives&r why do we need to put &dFlowers&r outside of it?!?!?!?!"
 		"{image:atm:textures/questpics/bumblezone/bumble_meadow.png width:200 height:100 align:center}"
@@ -2855,8 +2884,8 @@
 	quest.1D4973B187284CBB.title: "&aEssence of Life"
 	quest.1D4E7F548431263A.quest_desc: ["Easily the simplest of these Blocks to make. \\n\\nIron and &4Redstone&r you'll just get from &2&lVanilla&r gameplay, the only \"difficult\" Item is the &7Iron Sheetmetal&r."]
 	quest.1D4E7F548431263A.title: "&4Redstone Engineering Block"
-	quest.1D56D3B444A4B2D4.quest_desc: ["The &dGauntlet of &bBulwark&r acts different from what you'd assume. \\n\\nInstead of bringing mobs closer it pushes them away, when Holding Right Click, and gives them &bBlazing Brand&r. \\n\\nThen when you release Right Click you'll charge in the direction you are looking. \\n\\nIt's made by fusing the &dGauntlet of Guard&r with a &bBulwark of Flame&r in the &4Mechanical Fusion Anvil&r."]
-	quest.1D56D3B444A4B2D4.title: "&dGauntlet of &bBulwark"
+	quest.1D56D3B444A4B2D4.quest_desc: ["The Gauntlet of Bulwark acts not as you'd assume. Instead of bringing mobs closer it pushes them away, when holding right click, and gives them Blazing Brand. Then when you release right click you'll do the normal charge. It's made by fusing the Gauntlet of Guard with a Bulwark of Flame in the Mechanical Fusion Anvil."]
+	quest.1D56D3B444A4B2D4.title: "Gauntlet of Bulwark"
 	quest.1D6FAF0E25A0D596.quest_subtitle: "Clove + Allspice"
 	quest.1D7104AE853A3D86.quest_desc: [
 		"&dMekanism&r is a mod that you can start from the beginning, and still be working on it right before you complete the pack. "
@@ -2916,7 +2945,7 @@
 	quest.1DCFC67A8E3DCA2C.quest_desc: ["Similar to the Alchemy Catalyst, when placed under a Mana Pool, the &9Conjuration Catalyst&r unlocks the abillity to use conjuration recipes. "]
 	quest.1DDA5ADA11DF868F.quest_desc: ["Now we can upgrade our Multiblock structures Tiers! EBF's, VF's, Crackers, LFD, and more! They can process faster, and they can process &dLuV&r tier materials! Lets Go!"]
 	quest.1DDA5ADA11DF868F.quest_subtitle: "LuV Energy Hatch at Last!"
-	quest.1DE0F289821F55D1.quest_desc: ["Now that we have a Foliot Crusher, we can &muse&r politely ask it to crush down some &eEnd Stone&r and &9Obsidian&r for us. We'll use these to make some new Chalk!"]
+	quest.1DE0F289821F55D1.quest_desc: ["Now that we have a Foliot Crusher, we can &muse&r politely ask it to crush down some &eEnd Stone&r, &9Obsidian&r, &7Calcite&r for us. We'll use these to make some new Chalk!"]
 	quest.1DE0F289821F55D1.title: "&aChalking It Up"
 	quest.1DE8B0C9A7195720.quest_desc: [
 		"Once you've finished placing in all of the required blocks to build the Reactor, it should give off red particles to show that it is complete.\\n\\nRight clicking anywhere on the Reactor will open up the &aInterface&r. This will have all of the information you need to run the Reactor properly, as well as two buttons to turn on and off the Reactor.\\n\\nOn the left, you have 2 tanks: One for &bCoolant&r and one for &3Fissile Fuel&r. On the right, you have one for &8Nuclear Waste&r, and one for &bHeated Coolant&r, which will most likely be &bSteam&r.\\n\\nThe &cTemperature&r bar will show you how hot the Reactor is. After a certain temp, the Reactor will start taking &4Damage&r, which will eventually cause the Reactor to explode.\\n\\nTo adjust the &cBurn Rate&r of the Fissile Fuel and see more statistics, click on the (I) tab on the left side. Here, you can adjust the Rate Limit, which controls how much fuel the Reactor burns per tick.\\n"
@@ -2943,7 +2972,6 @@
 	]
 	quest.1E0F92F07FDD162E.quest_desc: ["You will need &bProsperity Seed Bases&r in order to create resource crops."]
 	quest.1E0F92F07FDD162E.quest_subtitle: "I'm all about that (Seed) Base"
-	quest.1E0F92F07FDD162E.title: "&bProsperity Seed Base"
 	quest.1E13D7CE5A9EFF74.quest_desc: [
 		"Frostfields are one of the cold Biomes in the &2&lUndergarden&r. You can tell it is cold by the massive icesicles, Powdered Snow, and Frozen Deepturf! \\n\\nAlso here instead of the usual Depthrock underground you will find Shiverstone. \\n\\nShiverstone acts more like Ice than real Stone. Well atleast when standing on it!"
 		"{image:atm:textures/questpics/undergarden/undergarden_frosty.png width:200 height:100 align:center}"
@@ -2993,6 +3021,8 @@
 	quest.1EABF2E7AE7B8F22.title: "&8Netherite&r"
 	quest.1EB04FE105ACA4BE.quest_desc: ["When a &9Warden&r dies it has a chance to drop a &9Heart of the Deep&r. \\n\\nThis can be used for the &6&lATM Star&r, or to activate the Portal in the Ancient City! \\n\\nThere can't be anything in the Portal to activate it, that includes &9Sculk&r!"]
 	quest.1EB04FE105ACA4BE.title: "&9Heart of the Deep"
+	quest.1EB887F8072439A3.quest_desc: ["After using &9Fatma's Incentivized Attraction&r to summon a &9Marid Crusher&r, you can turn ice, packed ice, and blue ice into their crushed forms, and use these to create Light Blue Chalk."]
+	quest.1EB887F8072439A3.title: "&bLight Blue Chalk"
 	quest.1EBD5E4410A6DF34.quest_subtitle: "Feed a Ghostly Bee a Soulium Dagger"
 	quest.1EBD5E4410A6DF34.title: "Soulium Bee"
 	quest.1EBF234015B26F15.quest_desc: ["Basic Armor added by &a&lRoots Classic&r, you'll need a Ritual to get it though!"]
@@ -3042,8 +3072,12 @@
 	]
 	quest.1F7DA060792D716A.title: "&l&dMixer"
 	quest.1F7DFA5AA65F2812.quest_desc: ["The &bAcceleration Card&f, depending on the device being upgraded with it, will either increase the speed at which the device operates or allow the device to carry out more operations in one go.\\n\\nIn the case of the &eMolecular Assembler&f, a full set of 5 cards reduces the time taken for the MA to fulfil a craft from one second (with no cards) to one &otick&r."]
-	quest.1F81EA5E45424308.quest_desc: ["If you're looking for different ways to get power out of your machines, this is where you can find it!\\\\n\\\\nThere are several options, both &awired&r and &9wireless&r, for transferring power."]
-	quest.1F81EA5E45424308.title: "&f&lTransferring Power"
+	quest.1F81EA5E45424308.quest_desc: [
+		"If you're looking for different ways to get power out of your machines, this is where you can find it! "
+		""
+		"There are several options, both &awired&r and &9wireless&r, for transferring power."
+	]
+	quest.1F81EA5E45424308.title: "Transferring Power"
 	quest.1F82DBE75059C139.title: "&9The Starter Dungeons"
 	quest.1F88C697817A7680.quest_desc: ["Buffs:\\n\\n - Absorption II (3:00)"]
 	quest.1F88C697817A7680.title: "&aInferium Apple"
@@ -3082,7 +3116,7 @@
 		""
 		"Tip: In the Mining Dimension, this ore is a lot more common."
 	]
-	quest.1FD4C32B3937E1C7.title: "Allthemodium Ore"
+	quest.1FD4C32B3937E1C7.title: "AllTheModium Ore"
 	quest.1FD60B7448CED1EB.quest_desc: ["This &b&lMacaw&r Mod adds new types of Fences, Gates, and Walls. \\n\\nYes, the barbed wire will hurt you. \\n\\nNo, you can't jump over any of them normally."]
 	quest.1FD60B7448CED1EB.title: "&b&lMacaw's Fences and Walls"
 	quest.1FDC8725105D822A.quest_desc: ["The Kitchen holds many Blocks that can hold, preserve, and Cook Food! \\n\\nMost the Blocks that cook or prepare Food do need Energy, so check out the Electrical Set to learn more!"]
@@ -3140,7 +3174,7 @@
 		"At least we can get our Naquadah Coils going now, and help our EBF's to process more metals!"
 	]
 	quest.2036ED4A823C1456.quest_subtitle: "We're going to need more Naq"
-	quest.203C91B992BA8CF9.quest_desc: ["In order to remake the &6&lATM Star&r we'll need an Infused &dPatrick &aStar&r, which also needs a &dPatrick &aStar&r for it. Both are made via &6&lRunic Star Altar&r. \\n\\nThe other items needed to make Infused &dPatrick &aStar&r are the 4 &5Mending Books&r and &dInfused Dragon's Breath&r which are obtained through &5&lRunic Enchanting&r. \\n\\n&6Star Shards&r which we get from our Bees! \\n\\nAnd Alloy Ingots: &3Vibranium&f-&6Allthemodium&r, &5Unobtainium&f-&6Allthemodium&r, and &5Unobtainium&f-&3Vibranium&r Ingots. \\n\\nAll three are crafted in their own unique ways described in the &6&lAllthemodium&r chapter! \\n\\nThrow all of these into a &6&lRunic Star Altar&r, plus 85MFE, and we'll get our Infused &dPatrick &aStar&r!"]
+	quest.203C91B992BA8CF9.quest_desc: ["In order to remake the &6&lATM Star&r we'll need an Infused &dPatrick &aStar&r, which also needs a &dPatrick &aStar&r for it. Both are made via &6&lRunic Star Altar&r. \\n\\nThe other items needed to make Infused &dPatrick &aStar&r are the 4 &5Mending Books&r and &dInfused Dragon's Breath&r which are obtained through &5&lRunic Enchanting&r. \\n\\n&6Star Shards&r which we get from our Bees! \\n\\nAnd Alloy Ingots: &3Vibranium&f-&6AllTheModium&r, &5Unobtainium&f-&6AllTheModium&r, and &5Unobtainium&f-&3Vibranium&r Ingots. \\n\\nAll three are crafted in their own unique ways described in the &6&lAllTheModium&r chapter! \\n\\nThrow all of these into a &6&lRunic Star Altar&r, plus 85MFE, and we'll get our Infused &dPatrick &aStar&r!"]
 	quest.203C91B992BA8CF9.title: "Infused &dPatrick &aStar"
 	quest.20436AFCC7E6855D.quest_desc: ["With Magic Beans and Uberous Soil, you'll want to look for a large cloud in the highland biomes.\\n\\nPlant the magic beans in the soil to grow a beanstalk all the way up. Here, you'll find the Giants.\\n\\nYou'll need to kill the Miner Giant and get their pickaxe to continue on."]
 	quest.20436AFCC7E6855D.quest_subtitle: "The giants look like me, but are nothing LIKE me"
@@ -3299,11 +3333,8 @@
 	quest.219A5BDA5A01A420.title: "&4Master Infusion Crystal"
 	quest.219AA017149C36E2.quest_desc: ["Trapped Trader Carpets will kill any Wandering Traders that spawn near it instantly!\\n\\nThese might be the best items in the entire pack."]
 	quest.219AA017149C36E2.quest_subtitle: "No more Annoying Traders!"
-	quest.21A0FD474FBB49F7.quest_desc: [
-		"Another structure to cover the barreness of &5The End&r, the &dRuined Citadel&r. \\n\\nThe &dRuined Citadel&r is a Palace of &5Obsidian&r, Endstone, and &dPurpur&r. \\n\\nIn the palace you'll find Chests, Shulker Boxes, Shulkers, and even the unique &dVoid Stone&r! \\n\\nJust be careful of the afformentioned Shulkers, &dEndermaptera&r, and &dEnder Golems&r."
-		"{image:atm:textures/questpics/cataclysm/cataclysm_citadel.png width:200 height:100 align:center}"
-	]
-	quest.21A0FD474FBB49F7.title: "&dRuined Citadel&r: Home of the &d&lEnder Guardian&r"
+	quest.21A0FD474FBB49F7.quest_desc: ["Another structure to cover the barren &5End&r, the &dRuined Citadel&r. Don't worry this ones on the ground! In it you'll find &dEndmaptera&r, &dEnder Golem&r, and the Altar of Void. Thankfully you don't need to sacrifice anything to summon the &dEnder Guardian&r, just get to the Altar of Void."]
+	quest.21A0FD474FBB49F7.title: "&dRuined Citadel&r: Home of the &dEnder Guardian&r"
 	quest.21A90474590FCDB8.quest_desc: ["The \"Furnace\" is an upgraded version of a vanilla Furnace that can be upgraded for faster speed and better efficiency."]
 	quest.21A90474590FCDB8.title: "\"Furnace\""
 	quest.21AB14A8553896E9.quest_desc: ["Guys I think you didn't hear me right I said &e&lProductive Bees&r! Oh wait there's another Mod! \\n\\nThis one is related to &e&lProductive Bees&r as you'll need them for breeding Trees. \\n\\nNo, Trees do not use Wheat to breed, they use Bees. \\n\\n&oThe Trees and the Bees&r."]
@@ -3323,7 +3354,7 @@
 	quest.21D323D95F5A7DB3.title: "Strong Stick"
 	quest.21EA29A8C7F950CE.quest_desc: ["&bDiamonds&r the staple of &2Minecraft&r, and of upgraded Furnaces apparently...\\n \\nThese work even faster only taking 80 Ticks or 4 Seconds to smelt items. That's even faster than a Blast Furnace! \\n \\nThese are only crafted by &eGold Furnaces&r and can be crafted into &3Crystal&r or &aEmerald Furnaces&r."]
 	quest.21EA29A8C7F950CE.title: "&bDiamond Furnace"
-	quest.21EE522DDBF0BF72.quest_desc: ["The last sets of Shelves you'll need are &dEndshelves&r, to get them you need Infused Dragon's Breath. This one was hard to get but you need atleast &a40%% Eterna&r, &c15%%-25%% Quanta&r, and atleast &560%% Arcana&r. It has to be between &c15%%-25%% Quanta&r to get that you can try &99 Echoing Sculkshelves&r and 4 Melonshelves or &92 Echoing Sculkshelves&r and &b10 Heart-Forged Seashelves&r."]
+	quest.21EE522DDBF0BF72.quest_desc: ["The last sets of Shelves you'll need are &dEndshelves&r, to get them you need Infused Dragon's Breath. This one was hard to get but you need atleast &a40%% Eterna&r, &c15%%-25%% Quanta&r, and atleast &560%% Arcana&r. It has to be between &c15%%-25%% Quanta&r to get that you can try &99 Echoing Skulkshelves&r and 4 Melonshelves or &92 Echoing Skulkshelves&r and &b10 Heart-Forged Seashelves&r."]
 	quest.21EE522DDBF0BF72.title: "&dEndshelf&r"
 	quest.21F4CFF171246537.quest_subtitle: "Tier: &b4"
 	quest.21F5EED683499B71.quest_desc: [
@@ -3355,8 +3386,7 @@
 	quest.2239673CCF5B5BF7.quest_desc: ["In order to get spells you'll need powdered items. To get powdered items you'll need a Mortar and Pestle."]
 	quest.2239673CCF5B5BF7.title: "Mortar and Pestle"
 	quest.224CE21E56703F6E.quest_desc: ["The Wand can be used to activate the Infusion Alter, just right-click on the altar to activate the infusion process."]
-	quest.224CE21E56703F6E.quest_subtitle: "You're a Wizard (Insert your name)!"
-	quest.224CE21E56703F6E.title: "&2Wand"
+	quest.224CE21E56703F6E.quest_subtitle: "You're a Wizard (Your name)!"
 	quest.22572456571C3F8D.quest_desc: ["The &3Charging Module&r depressurizes any pressurizable things in containers it points at."]
 	quest.225F77308C834EA8.quest_desc: [
 		"Have you been &eElectrolyzing&r &9Salt Water&r? It is a great source of Chlorine Gas, which comes in handy especially with making Dichlorobenzene, and as a byproduct you'll get this &3Sodium Hydroxide Dust&r"
@@ -3391,9 +3421,9 @@
 	]
 	quest.229455730219F7B1.quest_subtitle: "Red Iron"
 	quest.229455730219F7B1.title: "&cVentium"
-	quest.2296CE4418AE62D4.quest_desc: ["&6Allthemodium Armor&r but with buffs to &d&lArs Nouveau&r Spells!"]
+	quest.2296CE4418AE62D4.quest_desc: ["&6AllTheModium Armor&r but with buffs to &d&lArs Nouveau&r Spells!"]
 	quest.2296CE4418AE62D4.quest_subtitle: "24"
-	quest.2296CE4418AE62D4.title: "&6Allthemodium Arcanist Gear"
+	quest.2296CE4418AE62D4.title: "&6AllTheModium Arcanist Gear"
 	quest.22A0A9C81A5C85A1.quest_subtitle: "Holding everything together"
 	quest.22A1C68078EFB38B.quest_subtitle: "Amplifies Potion Effect"
 	quest.22AC248B6BB88486.quest_desc: [
@@ -3495,8 +3525,6 @@
 	quest.235E3C386E8D36A3.title: "&9Deepshelf"
 	quest.23631A4A743D4F0C.quest_desc: ["Don't even complain about this one. \\n\\nThere are dozens of ways of getting Iron and it's needed for even just normal progression. \\n\\nYou will get Iron, you will make it into a Block, and you will make it pretty!"]
 	quest.23631A4A743D4F0C.title: "&l&bChipped&r Metals"
-	quest.236EA8D18ECD5FE8.quest_desc: ["This one is quite unique in its spawning! After you kill the &b&lIgnis&r, there's a chance &bIgnited Berserkers&r will spawn in Nether Fortresses. \\n\\nThey are just like &bRevenants&r just instead of Shields they have Swords! Their Swords won't protect against damage like the Shields do, instead they deal more damage. \\n\\nThey have much less health, at 65 &4Hearts&r and will drop Dying Embers when killed. 4 Dying Embers can be Crafted into 1 &bBurning Ashes&r."]
-	quest.236EA8D18ECD5FE8.title: "&bIgnited Berserker"
 	quest.23737103592776C2.quest_desc: ["The &3Kerosene Lamp&r is a great light source that uses fuel (Kerosene being the best) to produce light."]
 	quest.23737103592776C2.quest_subtitle: "Mega Torches are nothing!"
 	quest.237D11FF5B09BA88.quest_desc: [
@@ -3543,7 +3571,7 @@
 	]
 	quest.23ADD20D9B1AE0F3.quest_desc: ["Use a &bPure Daisy&r to convert Stone into Livingrock!"]
 	quest.23ADD20D9B1AE0F3.title: "&7Livingrock"
-	quest.23AE395433AED3C0.quest_desc: ["The &6&lATM Star&r needs a few Blocks to hold together the different Items, and make its star shape! \\n\\nThe first Blocks are &5Unobtainium&r - &6Allthemodium&r &5Alloy&r &6Blocks&r. You need to use an Enchanting Apparatus from &d&lArs Nouveau&r to make them! To make 28 to be exact. \\n\\nFor 17 X3 Netherstar Blocks you'll need 111,537 Netherstars. (Please I am begging you use &l&bHNN&r just don't spawn and kill 111,537, please!)"]
+	quest.23AE395433AED3C0.quest_desc: ["The &6&lATM Star&r needs a few Blocks to hold together the different Items, and make its star shape! \\n\\nThe first Blocks are &5Unobtainium&r-&6AllTheModium&r &5Alloy&r &6Blocks&r. You need to use an Enchanting Apparatus from &d&lArs Nouveau&r to make them! To make 28 to be exact. \\n\\nFor 17 X3 Netherstar Blocks you'll need 111,537 Netherstars. (Please I am begging you use &l&bHNN&r just don't spawn and kill 111,537, please!)"]
 	quest.23AE395433AED3C0.title: "&6&lThe Star's&r Casing"
 	quest.23B55A8C7D6482FF.quest_desc: [
 		"Grab your tools and open up the maintenance hatch, there are problems to fix!"
@@ -3653,7 +3681,7 @@
 	quest.24BD32102AFA1691.quest_desc: ["An upgraded crafter that holds more patterns and has an increased crafting speed."]
 	quest.24BD32102AFA1691.title: "&5Netherite Crafter&r"
 	quest.24C0F267B330CD23.quest_desc: ["With the damage of a Diamond Sword, the &2Terra Blade&r will sometimes fire a beam that will deal as much as a melee hit would."]
-	quest.24C757B8AA6841F6.quest_desc: ["Apothic Spawners knows how annoying Tridents can be to get so they made it easier... well kinda easier. You can now make an Inert Trident and Infuse it to get a normal Trident. The Trident requires between &a40 Eterna&r, &c20%-50% Quanta&r, and atleast &535% Arcana&r. You can get this with &94 Echoing Sculkshelves&r, &2Melonshelf &rand Normal Bookshelf."]
+	quest.24C757B8AA6841F6.quest_desc: ["Apothic Spawners knows how annoying Tridents can be to get so they made it easier... well kinda easier. You can now make an Inert Trident and Infuse it to get a normal Trident. The Trident requires between &a40 Eterna&r, &c20%-50% Quanta&r, and atleast &535% Arcana&r. You can get this with &94 Echoing Skulkshelves&r, &2Melonshelf &rand Normal Bookshelf."]
 	quest.24C757B8AA6841F6.title: "Making a real Trident"
 	quest.24C9BA6DC32CFAD9.quest_desc: ["Coal is your first real source of power. If you are running low and cant find any Coal a better alternative for you will be Charcoal. "]
 	quest.24C9BA6DC32CFAD9.quest_subtitle: "Smelt your logs"
@@ -3716,7 +3744,7 @@
 		"This Shield, like what seems most Items here, can be: found in structures, crafted, or traded with the &5Bee Queen&r. \\n\\nIt works like a &2Vanilla&r Shield, hold it in your off-hand and block attacks. \\n\\nWhat makes it different (and better) is that after you repair it with &5Honey Crystals&r it will grow stronger."
 		"{image:atm:textures/questpics/bumblezone/bumble_shield.png width:100 height:150 align:center}"
 	]
-	quest.2542D8A6894816C6.quest_desc: ["The &eEye of Desert&r will take you to the &eCursed Pyramid&r to fight the &e&lAncient Remnant&r."]
+	quest.2542D8A6894816C6.quest_desc: ["&eThe Eye of Desert&r will take you to the &eCursed Pyramid&r to fight the &eAncient Remnant&r"]
 	quest.2542D8A6894816C6.title: "&eEye of Desert&r"
 	quest.2543F16043EE2777.quest_desc: [
 		"For the Star, we'll need to explore the world of Magic using the mod &dArs Nouveau&r! "
@@ -3729,7 +3757,7 @@
 	quest.254DD23FB7AEB36B.title: "&dVoid Mining&r"
 	quest.2555BA914C466B5C.quest_desc: ["I am sure that  you now see why these plates will be vital. But as you already know, they will provide a great benefit."]
 	quest.2555BA914C466B5C.quest_subtitle: "The Best Casing"
-	quest.2559201BCF5D497C.quest_subtitle: "Makes various Overworld Materials"
+	quest.2559201BCF5D497C.quest_desc: ["Makes various Overworld materials."]
 	quest.257C80468B080B3C.quest_desc: ["The Electromagnet is &8&lIE's&r take on the Absorption Hopper. \\n\\nWell, kinda! It won't hold the &eItems&r rather they will be moved closest to the Top face of the Electromagnet. \\n\\nThis can be used to get them onto &eBelts&r or hoppers! \\n\\nIt will require &cEnergy&r to be used though."]
 	quest.257D8912FC58DB59.quest_subtitle: "Brazilwood + Mahogany"
 	quest.2581B7D8E6C6E510.quest_subtitle: "Tier: &63"
@@ -3763,8 +3791,6 @@
 	quest.2598273041353196.title: "Importing Waste"
 	quest.25A3E30F722B38B6.quest_desc: ["Why are you surprised that &eGold&r is actually used in mods? You've seen it in real life it does plenty! Also opens up for more unique Generators that don't just take Furnace Fuel!"]
 	quest.25A3E30F722B38B6.title: "&eGold Generator"
-	quest.25ACB08E4F12CE79.quest_desc: ["The &cNetherite Ministrosity&r is a Pet given to us by &4&lCataclysm&r! \\n\\nFirst, you'll need to Craft a &cNetherite Effigy&r. \\n\\nThen, we can kill the &c&lNetherite Monstrosity&r for the &cLava Power Cells&r. \\n\\nFinally, place down the &cEffigy&r and feed it a &cPower Cell&r to tame him! \\n\\nOnce tamed he can be Shift Right Clicked to edit whether he is following, staying, or wandering. \\n\\nYou can also Right Click him to open his Inventory, aka cracking open his entire head like a Rock Monster from Lego Power Miners. He has an Inventory of 15 Slots. \\n\\nHe also has 3000 &4Hearts&r and I can't find a way to heal him..."]
-	quest.25ACB08E4F12CE79.title: "&cNetherite Ministrosity"
 	quest.25AFD10D008DF30B.quest_desc: ["Ender Chests all share the same inventory and that inventory is different for every player. They can't be combined together into 1."]
 	quest.25C1A764618E601B.quest_subtitle: "&9Tier 1&r"
 	quest.25D4406CB86C8CBB.quest_desc: ["Now that we are collecting some &9waste&r from our reactor, part of the progression requires you to \"Fluidize\" some of the ingots you get. You know what that means?\\n\\nWe need to make a &aFluidizer&r! The main component is the &aFluidizer Controller&r. Once built, you can right-click on this to open up the interface. Here, you can turn it on or off, see what's inside, and the current power level."]
@@ -3887,8 +3913,13 @@
 	quest.279BC6FAF7827738.quest_subtitle: "IV"
 	quest.27A0BCE75F198A82.quest_subtitle: "Tier: &e1"
 	quest.27A4FA38992448A0.quest_desc: [
-		"Flux Networks also provides a way to charge your items wirelessly, even across dimensions!\\n\\nOnce you have a Plug attached to your power system, you'll want to make the &9Flux Controller&r and place it down.\\n\\nRight-click on it to bring up the interface, and go to the \"Wireless Charging\" tab. From there, you can select each section of your inventory you'd like to keep charged. To activate, make sure to hit the toggle button at the bottom to enable Wireless Charging, then click apply!\\n"
-		"{image:atm:textures/questpics/basic_power/wireless_ui.png width:125 height:150 align:center}"
+		"Flux Networks also provides a way to charge your items wirelessly, even across dimensions! "
+		""
+		"Once you have a Plug attached to your power system, you'll want to make the &9Flux Controller&r and place it down. "
+		""
+		"Right click to bring up the interface, and go to the 'Wireless Charging' tab. From here, you can select each section of your inventory you'd like to keep charged. To activate, make sure to hit the toggle at the bottom to Enable Wireless charging, then click apply!"
+		""
+		"{image:atm:textures/questpics/flux/wireless_ui.png width:125 height:150 align:1}"
 	]
 	quest.27A4FA38992448A0.title: "Wireless Charging"
 	quest.27B5D0329DD92126.quest_desc: ["Soup... made from Bees? Seems kinda inhumane... \\n\\nEating/Drinking this will give you Beenergized Effect for awhile and gives a chance at giving Luck! \\n\\nAlso a chance at Levitation, Slow Falling, Poison, and Paralized. \\n\\nAlso while talking about Paralized you can make Paralizing Potions using the Soup."]
@@ -4007,9 +4038,9 @@
 	quest.29131C3532610ADF.title: "Tier 2 Starlight Charger Pillar Cap"
 	quest.29164630E1BD76B5.quest_desc: ["This is the main resource in the mod. Go out and mine some!"]
 	quest.29164630E1BD76B5.title: "Arcane Crystals"
-	quest.291C76140DE97E3C.quest_desc: ["&bIgnitium&r is like Netherite but it takes actual skill to get. \\n\\nThe &b&lIgnis&r will only drop 1 so get good use of it! \\n\\nYou can use it to upgrade your Netherite Armor or use it to make the Weapons."]
-	quest.291C76140DE97E3C.quest_subtitle: "Better than Netherite?"
-	quest.291C76140DE97E3C.title: "&bIgnitium"
+	quest.291C76140DE97E3C.quest_desc: ["Ignitium is like Netherite but takes actual skill to get it. The &bIgnis&r will only drop 1 so get good use of it. You can use it to upgrade your netherite armor or use it to make 2 weapons."]
+	quest.291C76140DE97E3C.quest_subtitle: "Better than Netherite?!?!?!"
+	quest.291C76140DE97E3C.title: "Ignitium"
 	quest.291EE514A1602C46.quest_subtitle: "Balsa + Flowering Azalea"
 	quest.29283BF1B6ED3634.quest_desc: ["The Mechanical Crossbow is made like a normal Crossbow just with Golem Steel. \\n\\nIt works like a normal Crossbow just much stronger! And can be enchanted to do even more!"]
 	quest.29417616D8F673D5.quest_desc: ["Moving forward a lot of mixed metals and alloys will need to be made in the ABS. As Fluids they are then pushed through a Vacuum Freezer with an Ingot Mold to make the ingots. The Multiblock Structures referenced in the following quests all have support blocks which utilize metals which need the ABS to be made. Making at least 1 Alloy Blast Smelter now will be beneficial."]
@@ -4023,6 +4054,13 @@
 	quest.2951B1D7080C5EF9.quest_desc: ["Using the &6Lamp of Cinders&r, you are able to break the Thorns in the Thornland Biome.\\n\\nGather some &cThorn Roses&r to continue on to the &2Final Plateau&r."]
 	quest.2951B1D7080C5EF9.title: "Every Thorn has its Rose"
 	quest.295C77EEC89000FC.quest_subtitle: "Generates Source from Mob Deaths and Animal Breeding"
+	quest.2960FFE0C53DFEB1.quest_desc: [
+		"&cSevira's Permanent Confinement&r is the third tier of &6Infusion Rituals&r. It's mainly used to create the next level of foundation chalk, Black Chalk."
+		""
+		"It's also used to create a couple of items that can speed up ritual making and performing by a significant amount."
+	]
+	quest.2960FFE0C53DFEB1.quest_subtitle: "The \"even more everything\" ritual"
+	quest.2960FFE0C53DFEB1.title: "&cSevira's Permanent Confinement"
 	quest.29706E3681616E41.quest_subtitle: "That's a Lot of Different Dusts!"
 	quest.2982D38BD5EE6349.quest_subtitle: "Feed a Shroombee Warped Fungus"
 	quest.2982D38BD5EE6349.title: "Warped Shroombee"
@@ -4046,6 +4084,16 @@
 		"{image:atm:textures/questpics/bumblezone/bumble_purple2.png width:200 height:100 align:center}"
 	]
 	quest.29C78845B488EDF8.title: "&5Purple Sempiternal Sanctum"
+	quest.29C83B00AC4AFC23.quest_desc: [
+		"Now that you've completed the Occultism questline, you may be asking yourself, what's next? Well, there are so many more things to explore in Occultism! "
+		""
+		"You can see a comprehensive list of every single ritual and item in your &6Dictionary of Spirits&r, try going through all the rituals' outcomes to see if you can find something that piques your interest!"
+		""
+		"If you haven't already, you could lie out and decorate three separate ritual areas, one for summons, one for possessions, and one for infusions."
+		""
+		"With any mod, there's always new ways to use each and every seemingly mundane feature to maximize your experience with the modpack. Happy ritual crafting!"
+	]
+	quest.29C83B00AC4AFC23.title: "What's Next?"
 	quest.29C9F8719DA63D8D.quest_desc: ["The &2&lBuzzsaw&r works similar to the &4&lMining Drill&r, just for &2Trees&r! \\n\\nIt requires &2Bio-Diesel&r as Fuel, which I won't explain how to get here either! \\n\\nAnd some sort of &8Sawblade&r. Which you can attach via the Top Slot in the &6Engineer's Workbench&r. \\n\\nSimply break Logs on a &2Tree&r and every Log, Leaf, and Birds Nest will come down with it! You can hold Shift to not break everything attached. \\n\\nThe &2&lBuzzsaw&r also does 10 Damage! Dang, why even use a Sword? Oh yeah &8Saws&r have Durability and it needs &2Bio-Diesel&r. \\n\\nThe &2&lBuzzsaw&r can hold 1 &8Blade&r or &8Disk&r and 2 Upgrades."]
 	quest.29C9F8719DA63D8D.title: "&2&lBuzzsaw"
 	quest.29CD5C0A253425D5.quest_desc: [
@@ -4056,7 +4104,6 @@
 	quest.29CD5C0A253425D5.quest_subtitle: "How about &dLuV&r Energy Hatch, But 4x?"
 	quest.29D28983E0200A3C.quest_desc: ["&l&dArs Nouveau&r is all about using Glyphs in Spellbooks to be able to cast them as Spells!"]
 	quest.29D28983E0200A3C.title: "&d&lArs Nouveau"
-	quest.29D309F9740FAEEA.quest_subtitle: "Tier: &c5"
 	quest.29DF2E7D0402284F.title: "Radiance"
 	quest.29E2033EA65E706E.quest_desc: [
 		"Here you can find the home of a Slime Rancher just making a living... wait what? How did a Villager get here?\\n"
@@ -4092,8 +4139,8 @@
 	quest.2A0B3C91D72E8B75.quest_desc: ["Small Yetis and Winter Wolves drop Arctic Fur, which can be used to make &6Arctic Armor&r."]
 	quest.2A0B3C91D72E8B75.quest_subtitle: "It's Dyable!"
 	quest.2A0B3C91D72E8B75.title: "&6Arctic Armor"
-	quest.2A196974431FCC42.quest_desc: ["The &cInfernal Forge&r is a drop from the &c&lNetherite Monstrosity&r and is technically not a weapon, it's a pickaxe! \\nIt can be used to mine up to Netherite Tier, so it can mine Allthemodium Ore. \\n\\nWhen right clicked it will attack in an AOE mode. Pounding the ground hitting everything close by. \\n\\n(It can be enchanted with Sword and Pickaxe enchantments!)"]
-	quest.2A196974431FCC42.title: "&cInfernal Forge"
+	quest.2A196974431FCC42.quest_desc: ["The Infernal Forge is a drop from the &cNetherite Monstrosity&r and is technically not a weapon, it's a pickaxe! It can be used to mine up to netherite tier, so it can mine Allthemodium ore. When right clicked it will attack in an AOE mode. Pounding the ground hitting everything close by. (Can be enchanted with sword and pickaxe enchantments)"]
+	quest.2A196974431FCC42.title: "Infernal Forge"
 	quest.2A1BFB2E0F1F3312.quest_desc: ["&dEnd Rod&r does 10 Damage as well as hits Endermen. \\n&5Enderpearls&r won't hit Mobs, rather they will teleport you much farther when shot. \\n&3Trident&r acts like a normal &3Trident&r throw, dealing 8 Damage. \\n&cBlaze Rods&r deal 10 Damage and set the Mobs on Fire!"]
 	quest.2A1BFB2E0F1F3312.title: "&5&lRailgun&r Ammo from &2&lMinecraft"
 	quest.2A20000FAEC2E16A.quest_desc: ["To extract power or items from your reactor, or even input fuel, you'll need these &crequired&r blocks.\\n\\nThe &cPower Tap&r provides a way for you to \"tap\" into the power that a &9passive&r reactor makes. You can attach pipes and cables to extract the power from it.\\n\\nThe &aAccess Ports&r are required for every reactor, and allows you to both input fuel from the reactor, or extract waste. It's usually a good idea to have 2 per reactor, one for each job."]
@@ -4128,6 +4175,12 @@
 		""
 		"There is an alternate recipe that uses Allyl Chloride and Hypochlorous Acid, if you so choose to go that route"
 	]
+	quest.2A3683BF7E50EF83.quest_desc: [
+		"Most of the items we've needed from the &3Otherworld&r so far just needed some Spiritfire. However, we will need to use the help of the &3Third Eye&r to find the Ore of the &3Otherworld&r."
+		""
+		"We'll also need a special pickaxe to be able to mine it. For this, we'll need to Infuse a Demon into a &dSpirit Attuned Pickaxe Head&r to create a pickaxe that can break this new kind of ore."
+	]
+	quest.2A3683BF7E50EF83.title: "Tools of the Trade: Infused Pickaxe"
 	quest.2A4FE9644F3B9DC1.quest_desc: ["Upgraded version of &2Prudentium&r."]
 	quest.2A4FE9644F3B9DC1.quest_subtitle: "26"
 	quest.2A4FE9644F3B9DC1.title: "&cTertium Armor"
@@ -4136,7 +4189,8 @@
 		""
 		"This is what the &dOtherworld Goggles&r are for! When equipped (even in your Curios slot), it gives the Third Eye effect!"
 	]
-	quest.2A5004EB99AE4F96.title: "Quit Eating That Fruit!"
+	quest.2A5004EB99AE4F96.quest_subtitle: "Quit eating that fruit!"
+	quest.2A5004EB99AE4F96.title: "Tools of the Trade: Spectral Goggles"
 	quest.2A50A687C40DB864.quest_desc: [
 		"&6&lHive Walls&r are the foundation of the &l&6Bumblezone&r. \\n\\nThey are massive walls of &6Honey Combs&r and &eWax&r that go from the floor to the roof. \\n\\nThey also hold &lProductive Bee&r Combs and holes in the &6&lWalls&r where Brood Blocks will spawn."
 		"{image:atm:textures/questpics/bumblezone/bumble_hivewall.png width:200 height:100 align:center}"
@@ -4189,6 +4243,13 @@
 		"{image:atm:textures/questpics/bumblezone/bumble_constructs.png width:200 height:100 align:center}"
 	]
 	quest.2AD13B965611DC86.title: "&7&lHowling Constructs"
+	quest.2AD68066C1948C90.quest_desc: [
+		"That first &eFoliot Crusher&r was cool, but what if I told you that you could summon a demon that gives you 6 dusts per raw ore it crushes?"
+		""
+		"The &9Marid Crusher&r does exactly that. To summon one, you'll need to use &9Fatma's Incentivized Attraction&r. "
+	]
+	quest.2AD68066C1948C90.quest_subtitle: "Maximum Summon"
+	quest.2AD68066C1948C90.title: "&9Fatma's Incentivized Attraction"
 	quest.2AD78E22988A92D3.quest_desc: ["I see you! \\n\\nWhen wearing &2Night Vision Goggles&r you get the ability to see in the dark! Not much else to them..."]
 	quest.2AD78E22988A92D3.quest_subtitle: "Head"
 	quest.2AD78E22988A92D3.title: "&2Night Vision Goggles"
@@ -4214,18 +4275,14 @@
 		""
 		"The heart of this multiblock is the &aController&r, and can be placed on any vertical face as long as it isn't on the frame."
 	]
-	quest.2AFBE48DA832FF02.quest_subtitle: "Tier: &c5"
 	quest.2B0553F307A024F7.quest_subtitle: "Tier: &c5"
 	quest.2B05A29C62676EB2.title: "&l&9Overworld Bounty:&r&e Zombies"
 	quest.2B08B19B35EEBCBA.quest_desc: ["These Relics can be found in &cThe Nether&r!"]
 	quest.2B08B19B35EEBCBA.title: "&cThe Nether"
 	quest.2B0C3AAAA6D0B0D2.quest_desc: ["&aUranium Quad Fuel Rods&r are a combination of multiple different Blast and Radiactive proof Alloys and of course radioactive Materials. \\n\\nThese will all come together to make a wonderful fuel for a reactor! Or &c&lPhilosphers Fuel&r!  "]
 	quest.2B0C3AAAA6D0B0D2.title: "&aUranium Quad Fuel Rods"
-	quest.2B115519A21F9CB7.quest_desc: [
-		"The &d&lEnder Guardian&r is a hulking beast of Endstone, &dPurpur&r, and &5Obsidian&r that waits within the &dVoid Altar&r. \\nIt has 13,320 &4Hearts&r and careful not to get too close or you might be sucked closer to him! \\n\\nHe has a ton of attacks and abilities, one being a very simple punch for those who are too close to his personal space, or a slam which will knock you back. \\n\\nIf you are farther from him, he might close the gap by charging and knocking into you. Or he might stomp and produce &dVoid Runes&r to hit you! He can also send &dShulker Balls&r in a row. \\n\\nAlso remember when I said he can suck you closer to him? Yeah he does that with a thing called a &dVoid Typhon&r, which he can also summon at your Feet to get you stuck. After you are there for too long, it will explode, most likely damaging you in the process. \\n\\nWhen you get him to half &4Health&r, his Mask will break revealing his true Head! In anger he will destroy the floor of the arena taking you both to the lower level. \\n\\nNow he will suck you in more, send more &dVoid Runes&r after you, and attack faster and stronger!"
-		"{image:atm:textures/questpics/cataclysm/cataclysm_guardiuan.png width:100 height:100 align:center}"
-	]
-	quest.2B115519A21F9CB7.title: "&d&lEnder Guardian&r"
+	quest.2B115519A21F9CB7.quest_desc: ["The &dEnder Guardian&r is a hulking beast of endstone,purpur, and obsidian. It has 4995 Hearts and 2 stages. In first stage it will have very basic attacks of punching you, dashing, using shulker orbs, hitting you with Void Runes, and can stunlock you. Once you beat it down half way it's helmet will break exposing it's real head and starting the 2nd stage. To start he will break the floor of the arena exposing the floor below, then he will use the same moves while pulling you closer. (Also he is immune to arrows so I hope you have a good sword!). Once killed it will drop a Gauntlet of Guard and has a chance of dropping its music disc: Eternal."]
+	quest.2B115519A21F9CB7.title: "&dEnder Guardian&r"
 	quest.2B1BAEC5DAAF9DAC.quest_desc: [
 		"Valid Upgrades:"
 		"- Tree Feller"
@@ -4299,14 +4356,14 @@
 	quest.2BB910B217DF3A12.title: "&dEnder&r Upgrade Orb"
 	quest.2BC325DEBDD2F5CA.quest_desc: ["Vibranium Seeds require Magical Soil placed below in order for them to grow."]
 	quest.2BC325DEBDD2F5CA.quest_subtitle: "Tier: &bMagical"
-	quest.2BCB788924BBD849.quest_desc: ["My personal favorite and one of the most powerful. \\n\\nThe &bIncinerator&r can be used just like a normal Sword and Enchanted like one! \\nBut when Holding Right Click it does something no normal Sword does. When you Hold and let go of Right Click for a few seconds, massive flames will strike out of the ground in the direction you are looking at, then they will explode. \\n\\nIt is also massive, which not just looks cool, but also gives better Range!"]
-	quest.2BCB788924BBD849.title: "&bThe Incinerator"
+	quest.2BCB788924BBD849.quest_desc: ["My personal favorite and one of the most powerful. The Incinerator can be used just like a normal sword and enchanted like one. But when holding right click it does something no normal sword does. When you hold and let go of right click for a few seconds, massive flames will strike out of the ground in the direction you are looking at then will explode."]
+	quest.2BCB788924BBD849.title: "The Incinerator"
 	quest.2BD077EFE77B8EBB.quest_desc: ["Zombies have different varients that spawn in other Biomes. \\n\\nHusks- spawn in Deserts. \\nDrowned- spawn Underwater. \\nGelid- spawn in Cold Biomes. \\nThickets- spawn in Jungles."]
 	quest.2BD077EFE77B8EBB.title: "Zombie Variants"
 	quest.2BD4E8494F2F43E9.title: "Alloy Shovel"
 	quest.2BE364CCE684AD45.quest_desc: ["One block stop for powering your multiblocks at IV!"]
 	quest.2BE4B6F1CCAA36AC.quest_desc: ["The mixer takes multiple materials and mixes them into a new material, very useful for higher quality steels and metal mixtures"]
-	quest.2BE538246C672689.quest_desc: ["Once you have the Allthemodium and Vibranium Bees, breed them together to get an Unobtainium Bee.\\n\\nTo breed: Feed the Allthemodium Bee 4 &3Vibranium Ingots&r, then feed the Vibranium Bee 4 &5Unobtainium Ingots&r."]
+	quest.2BE538246C672689.quest_desc: ["Once you have the Allthemodium and Vibranium Bees, breed them together to get an Unobtainium Bee.\\n\\nTo breed: Feed the Allthemodium Bee 4 ingots of Vibranium, then feed the Vibranium Bee 4 ingots of Unobtainium."]
 	quest.2BE538246C672689.quest_subtitle: "Allthemodium + Vibranium"
 	quest.2BE538246C672689.title: "Unobtainium Bee"
 	quest.2BE754C8D2C0C76E.quest_desc: [
@@ -4318,7 +4375,7 @@
 	quest.2BEBF66D7EA594FA.title: "&2Steeleaf Armor"
 	quest.2BF119DD5D977409.title: "Tier 2 Starlight Charger Catalyst"
 	quest.2BF9B347D1FC037A.quest_desc: ["This can be found by &2brushing&r &aSuspicious Clay&r in the &dAncient City&r."]
-	quest.2BF9B347D1FC037A.title: "&6Allthemodium Upgrades&r"
+	quest.2BF9B347D1FC037A.title: "&6AllTheModium Upgrades&r"
 	quest.2C04B3BA507D5673.quest_desc: ["&bPatterns&f are what hold an encoded recipe to be fulfilled by a Pattern Provider. To encode a recipe onto a Pattern, the &bME Pattern Encoding Terminal&f must be used.\\n\\nPatterns can be set to hold either a regular &ecrafting&f recipe, which will require the use of a &eMolecular Assembler&f on the face of its Provider, or a more general '&eprocessing&f' recipe, wherein any input items can be sent out by the provider into some other machine block or specialised processing plant."]
 	quest.2C04B3BA507D5673.title: "Patterns"
 	quest.2C0984E03F308959.quest_subtitle: "Pink Ipe + Luck"
@@ -4410,13 +4467,20 @@
 	quest.2CCAA7C0FEDEB573.title: "Wind Power"
 	quest.2CCFEE98FE3B2E97.quest_desc: ["These machines are used to automate block placing/breaking. This is especially useful when automating latex."]
 	quest.2CCFEE98FE3B2E97.title: "Blocks"
-	quest.2CD58FC229BC0C28.quest_desc: ["The &dGauntlet of the Guard&r is the drop from the &d&lEnder Guardian&r. \\n\\nWhen you hold it in either Hand, you can Hold Right Click to bring all Mobs near you, even closer! \\n\\nYou can also smack Mobs with it in your Main Hand to deal Damage. \\n\\nTry using the pull mechanic with flying to drop Mobs!"]
-	quest.2CD58FC229BC0C28.title: "&dGauntlet of Guard"
+	quest.2CD58FC229BC0C28.quest_desc: ["The Gauntlet of Guard is more of a tool than a weapon, it brings in mobs closer when you hold right click with it. Then you can smack the enemies with it to do a bit of damage."]
+	quest.2CD58FC229BC0C28.title: "Gauntlet of Guard"
 	quest.2CECCA9D05D3EF12.quest_desc: ["The &2Eternal Stella&r is quite expensive. You'll need a Tier 3 Forge first! \\n\\nThen, you'll need &7Stellarite Piece&r which you can mine for. And you have to get 3 &aXpetried Orbs&r which you can no longer mine for. Instead you'll have to feed a Black Hole &aEXP&r to get it! \\n\\nFinally, you'll need an &6AllTheModium Ingot&r to get the &2Eternal Stella&r. It makes sense why it is so expensive as it can be combined with any Tool to make it Invincibile!"]
 	quest.2CECCA9D05D3EF12.title: "&2Eternal Stella"
 	quest.2CF11A70229000AB.title: "Getting Create-ive."
 	quest.2CF6EA138B53CE1B.quest_desc: ["&3Vibranium&r combined with &5Unobtainium&r!"]
 	quest.2CF6EA138B53CE1B.title: "&5Unobtainium&r - &3Vibranium&r Alloy Ingot"
+	quest.2CF96A264EB5522C.quest_desc: [
+		"&9Uphyxes' Inverted Tower&r is the maximum tier of &6Infusion Rituals&r. It doesn't have as many uses as the other three tiers, but it's still nessecary for the \"endgame\" of Occultism. "
+		""
+		"Mainly, it's used to create Dragonyst Dust, which is the main ingredient for Magenta Chalk."
+	]
+	quest.2CF96A264EB5522C.quest_subtitle: "Maximum Infusion"
+	quest.2CF96A264EB5522C.title: "&9Uphyxes' Inverted Tower"
 	quest.2CFEE04BA574921E.quest_desc: [
 		"This interface will place the designated block in the direction it is pointed. "
 		""
@@ -4467,12 +4531,11 @@
 	quest.2DA8CE213AC3869B.quest_desc: ["Starlight Crystals can be found all over and even under the Crystallized Deserts. \\n\\nThey work similar to Amethyst and even sound like it!"]
 	quest.2DB53A77C3CD90F1.quest_desc: ["The Botanist's Pickaxe turns blocks that it interacts with into their mossy variants, assuming they have one."]
 	quest.2DB53A77C3CD90F1.quest_subtitle: "Tier: &b3"
-	quest.2DB81CE6F647D08A.title: "Unobtainium-Allthemodium Alloy"
+	quest.2DB81CE6F647D08A.title: "Unobtainium-AllTheModium Alloy"
 	quest.2DC639C39AE90272.quest_subtitle: "Yellow Meranti + Rose Gum"
 	quest.2DD5F0693780B10A.quest_desc: ["Used with the Extruder MK2, blocks extruded will mimic the actual blocks. Redstone Blocks will emit Redstone, Glowstone will emit light, Grass will act transparent. But only with this Augment! \\nDoesn't work with Block Entities like Furnaces or Enrichment Chambers."]
-	quest.2DDA04088C8220D2.quest_desc: ["Prosperity Shards are a core crafting ingrediant in the mod. To find some Prosperity Ore, go mining."]
-	quest.2DDA04088C8220D2.quest_subtitle: "Can we finally have Prosperity?"
-	quest.2DDA04088C8220D2.title: "&bProsperity Shards"
+	quest.2DDA04088C8220D2.quest_desc: ["Prosperity Shards are a core crafting ingrediant in the mod. To find some, go mining."]
+	quest.2DDA04088C8220D2.title: "Prosperity Shards"
 	quest.2DDA8AC73C2D50B4.quest_desc: [
 		"Styrene + Butadiene + Oxygen or Air in a &eChemical Reactor&r gets you the raw dust of the highest tier of rubber available"
 		""
@@ -4515,7 +4578,6 @@
 		""
 		"Cobaltite can be electrolyzed directly to get arsenic, but that's at MV. Also you'll get more arsenic for your cobaltite by making arsenic trioxide dust and electrolyzing that"
 	]
-	quest.2E37997A065A29F1.quest_subtitle: "Tier: &c5"
 	quest.2E47C92E3E8D826A.quest_desc: [
 		"&c&lStop! Do not pass Go! Do not collect $200!&r&r"
 		""
@@ -4534,6 +4596,8 @@
 	]
 	quest.2E596B5A4EA2ABF4.title: "&3S'Mog&r"
 	quest.2E5EF984B9CE0CB9.quest_desc: ["The all in one, big battery, big range ore/fluid finder"]
+	quest.2E68E1D96B25336D.quest_desc: ["After fighting through a few Demon possessed zombie piglins summoned by &6Abras' Open Commanding Conjure&r, you can use the Demonic Meat dropped by them to craft some Pink Chalk."]
+	quest.2E68E1D96B25336D.title: "&dPink Chalk"
 	quest.2E6D11A5F5626A6C.quest_subtitle: "Tier: &f2"
 	quest.2E6F1C8718EB8C66.title: "&4Blood&r Upgrade Orb"
 	quest.2E6F761585C1FB4D.quest_subtitle: "Ash + Silver Lime"
@@ -4581,9 +4645,17 @@
 	]
 	quest.2EB6088D4E85DA42.title: "Flattening the Land"
 	quest.2EB7784D5296F410.quest_desc: [
-		"Right clicking a functional Flux Network block will give you this UI.\\n\\nEach Plug or Point can be named, have a custom priority level, and have a custom power transfer limit. This allows complete control over all parts of your system.\\n\\n&aBypass Limit&r ignores the limit set.\\n\\nThere are several other tabs to check out, mostly for statistics on your network!\\n"
-		"{image:atm:textures/questpics/basic_power/flux_ui.png width:125 height:150 align:center}"
+		"Right clicking a functional Flux Network block will give you this UI. "
+		""
+		"Each Plug or Point can be named, have a custom priority level, and have a custom power transfer limit. This allows complete control over all parts of your system. "
+		""
+		"&aBypass Limit&r ignores the limit set. "
+		""
+		"There are several other tabs to check out, mostly for statistics on your network!"
+		""
+		"{image:atm:textures/questpics/flux/flux_ui.png width:125 height:150 align:1}"
 	]
+	quest.2EB7784D5296F410.title: "The Flux Networks UI"
 	quest.2EB96FF06627FD9A.quest_desc: ["The Salvager allows you to break down gear into the items they from.\\n\\nFor example: If you put in some Diamond Boots you will get 4 Diamonds back."]
 	quest.2EB96FF06627FD9A.quest_subtitle: "Breaking down (some) items!"
 	quest.2EB96FF06627FD9A.title: "Salvager"
@@ -4646,8 +4718,6 @@
 	]
 	quest.2F4458E9921DEB86.title: "&aGas Pipez&r"
 	quest.2F556E7919582D2D.quest_desc: ["The &bCell Workbench&f allows for cells to be 'partitioned' to hold specific items, i.e. given a whitelist filter. It also allows the cell to be upgraded with certain upgrade cards such as the Inverter Card, which sets the aforementioned whitelist to be a blacklist instead.\\n\\nCells can also be given a higher or lower 'priority' via the workbench, i.e. allow the cell to be the first to receive certain items until full, or made to wait for other higher-priority cells to fill up first."]
-	quest.2F62C290A5CE50F8.quest_desc: ["Wait you're telling me for just a few &eAncient Metal&r we can get a Weapon that does more Damage than a Netherite Sword, has insane Range, and throws &eSandstorms&r!? \\n\\nYep, that's what you get from the &eAncient Spear&r!"]
-	quest.2F62C290A5CE50F8.title: "&eAncient Spear"
 	quest.2F69010E1FA2787D.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks. \\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission. \\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
 	quest.2F71FCE4E576C977.quest_subtitle: "Generates Power using Lava!"
 	quest.2F76D074AEA84A4D.quest_desc: ["By Right Clicking an &dEnder Dragon&r with an empty &bData Model&r, you can make the &dEnder Dragon &bData Model&r. \\n\\nThe Quest needs any version of it, but the &d&lDragon Soul&r needs the &bData Model&r to be &6Self Aware&r. \\n\\nIn order to get it &6Self Aware&r you need to keep killing the &dDragon&r or make a crap-ton of Predictions!"]
@@ -4671,6 +4741,8 @@
 	quest.2FB62AE3C62CA052.quest_subtitle: "&f4.5&r &4Damage&r"
 	quest.2FC15D3916DBF4E4.quest_subtitle: "More Filtering Options"
 	quest.2FC15D3916DBF4E4.title: "&eAdvanced Void Upgrade"
+	quest.2FD22502E6481269.quest_desc: ["Using &dRonaza's Contact&r, you can upgrade your soul gem to create a trinity gem. It's basically just a beefed up version of the soul gem that can capture larger enemies, although it still can't contain most bosses."]
+	quest.2FD22502E6481269.title: "Trinity Gem"
 	quest.2FDACD6F153D5B64.quest_desc: ["Processing Sheldonite and purifying it will allow you to get the highest return on Platinum Group Sludge. This Sludge contains resources you need to progress."]
 	quest.2FDACD6F153D5B64.quest_subtitle: "My Friend Sheldon went to a club on nite."
 	quest.2FE4B7B70D90A455.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks.\\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission.\\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
@@ -4758,6 +4830,8 @@
 		"{image:atm:textures/questpics/bumblezone/bumble_cell.png width:200 height:100 align:center}"
 	]
 	quest.30C12E249F7E2D52.title: "Cell Maze"
+	quest.30C5B597610F4AFB.quest_desc: ["The first and most important item to make using Eziveus' Spectral Compulsion is the Research Fragment Dust. This is used in combination with some crushed emeralds to create lime chalk!"]
+	quest.30C5B597610F4AFB.title: "&aLime Chalk"
 	quest.30CD69FC601F26B5.quest_desc: ["Now just 1 more processing step before you can finally craft the Naquadah Alloy Frame&l"]
 	quest.30CD69FC601F26B5.quest_subtitle: "Naq Alloy Time!"
 	quest.30D97EABFE772604.quest_desc: ["Now we can push 64Amps from our substations at the ZPM tier!"]
@@ -4775,7 +4849,7 @@
 	quest.30E853CE699E669B.quest_subtitle: "Download more RAM"
 	quest.30E9255DEC69C061.title: "&4Supremium Tools"
 	quest.30EA16BB8C169F86.quest_desc: ["This one is a combination of &6Copper&r and &7Tin&r! \\n\\nIt's used a ton in &7&lModern Industrialization&r! But in &8&lIE&r... not that much..."]
-	quest.30EA16BB8C169F86.title: "&6Bronze Ingot"
+	quest.30EA16BB8C169F86.title: "Bronze Ingot"
 	quest.30EB438C66324213.quest_desc: ["A Nether Star will do what the Prismarine Shards do but much better. Players no longer need to be near the spawner. As long as its chunk-loaded it will spawn."]
 	quest.30EB438C66324213.title: "Ignore Players"
 	quest.30F16A6BD3C7F4FC.title: "Cassiterite Vein"
@@ -4943,7 +5017,7 @@
 		"If you want to build the Crusher, navigate to the &aHeavy Machinery&r section in your &eEngineer's Manual&r to learn how to build the multiblock!"
 	]
 	quest.323F39FC300F7E30.title: "Coke Dust"
-	quest.32543DA54C684E4E.quest_desc: ["&cModularium&r, the aptly named, Ingot is what we'll need for getting into &c&lModular Machinery&r. \\n\\nYou'll need a &9&lTier 5 &6Forge&r along with an &6Artisan Relic&r and &3Elementarium&r and Items. These Items being 4 &6Deorum Ingots&r, 4 End Steel Ingots, and an &6Allthemodium Ingot&r! \\n\\nCombine these all together with the needed Essences and you'll get 24 &cModularium Ingots&r"]
+	quest.32543DA54C684E4E.quest_desc: ["&cModularium&r, the aptly named, Ingot is what we'll need for getting into &c&lModular Machinery&r. \\n\\nYou'll need a &9&lTier 5 &6Forge&r along with an &6Artisan Relic&r and &3Elementarium&r and Items. These Items being 4 &6Deorum Ingots&r, 4 End Steel Ingots, and an &6AllTheModium Ingot&r! \\n\\nCombine these all together with the needed Essences and you'll get 24 &cModularium Ingots&r"]
 	quest.32543DA54C684E4E.title: "Building block of &l&cModulary Machinery"
 	quest.325483DEB0C602F8.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks. \\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission. \\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
 	quest.3260EDAD3A619479.quest_desc: ["&5Aethersent Ore&r is found during Meteorite Showers in &5&lEternal Starlight&r. Small ones break on impact, you'll need to wait for big Meteors! \\n\\nOr is it Meteorites? What's the difference?"]
@@ -5061,15 +5135,12 @@
 	quest.339384ADC9CDB944.title: "Knowing"
 	quest.33977CEF056F0A13.quest_subtitle: "Alder + Rowan"
 	quest.339DF320DDCAD98B.title: "Item \\& Fluid Transport"
-	quest.33A0E06FE5CFD8F3.quest_desc: ["The &9Centrifuge&r is used to process Combs from Bees into useful items and honey! While you can definitely just use a regular &9Centrifuge&r in the beginning, getting a &6Powered Centrifuge&r soon after is a must. This is a faster Centrifuge that runs off of power!\\n\\nIf you're looking for the best way to process your Combs, the &cHeated Centrifuge&r is even faster and processes &aComb Blocks&r instead of Combs!\\n\\nThese can all be made faster by using Speed Upgrades."]
+	quest.33A0E06FE5CFD8F3.quest_desc: ["The &9Centrifuge&r is used to process Combs from Bees into useful items and honey! While you can definitely just use a regular &9Centrifuge&r in the beginning, getting a &6Powered Centrifuge&r soon after is a must. This is a faster Centrifuge that runs off of power!\\n\\nIf you're looking for the best way to process your Combs, the &cHeated Centrifuge&r is even faster and can even process &aComb Blocks&r!\\n\\nThese can all be made faster by using Speed Upgrades."]
 	quest.33A0E06FE5CFD8F3.quest_subtitle: "Processing Honeycombs"
 	quest.33AADC1B97E9F7A9.quest_desc: ["Minecarts with Chests are Minecarts with Chests in them. You can't ride in these but they can be useful for transporting items across Rail systems."]
 	quest.33ADE41526C39AFD.quest_desc: ["This behaviour is comparable to something like a Functional Storage drawer, wherein each compartment holds a set number of stacks as opposed to allowing items from one compartment to leak into the others and crowd other kinds of items out."]
-	quest.33B1D3FD4C0B5514.quest_desc: [
-		"The &e&lAncient Remnant&r is master of his domain, of &eSand&r. \\n\\nHe has 3,600 &4Hearts&r and is aided with a &eWadjet&r and a &eKobolediator&r. \\n\\nHe has a few moves and attacks! He can swing his bony tail at you, bite you, or he might stomp on the ground, producing Shockwaves. \\n\\nHe can also summon &eSandstorms&r with a mighty ROAR and even drop &eSand Traps&r on your head. \\n\\nAnother attack he may use to get closer to you is his charge. His charge will hurt you and your FPS as it destroys every Block in his path. \\n\\nHe does have a weakness, the very thing that ressurected him! If you hit his &eNecklace&r he will be knocked down for a little bit, giving you the perfect chance to strike him down and return him to the grave!"
-		"{image:atm:textures/questpics/cataclysm/cataclysm_remnant.png width:100 height:100 align:center}"
-	]
-	quest.33B1D3FD4C0B5514.title: "&e&lAncient Remnant&r"
+	quest.33B1D3FD4C0B5514.quest_desc: ["The &eAncient Remnant&r is master of his domain, sand. He has 4000 Hearts and multiple attacks like smacking you with his claws, slamming the ground, and making sandstorms which will lift you high in the air. It will also dash at you and swing its full body weight at you. Its attacks remain the same through the whole fight and careful of the &eKoboletons&r they got sticky hands. Once put back to the grave it will drop its Skull, Sandstorm in a bottle, and at a chance its music disc: Sands of Dominion."]
+	quest.33B1D3FD4C0B5514.title: "&eAncient Remnant&r"
 	quest.33B8FDDBE3E95108.quest_desc: ["Just gotta process the Liquid down into an ingot. But now that we are in the UV tier, we have the speed and power to do it quickly!"]
 	quest.33B8FDDBE3E95108.quest_subtitle: "Darmstadtium has Ingots?"
 	quest.33D23C65E7274A8F.quest_desc: ["To awaken your Supremium Essence, you'll need to create a new Altar and 4 new Pedestals, as well as 4 &cEssence Vessels&r.\\n\\nThe Essence Vessels will require the starter Element Essences to fill: Fire, Water, Earth, and Air."]
@@ -5099,7 +5170,6 @@
 	quest.3416DB9F58D8AA2C.title: "&3Neptunium Armor"
 	quest.341BB1353A1E45EA.quest_desc: ["Gun Turrets will act as a &d&lRevolver&r with a Computer brain! \\n\\nThey'll need &cEnergy&r from below it, and a &4Redstone Signal&r to turn on. Or use an &6Engineer's Screwdriver&r on it to make it always on. \\n\\nIt uses the same Ammo as a &d&lRevolver&r, that includes Speciality Projectiles! You can &9Input&r Bullets into it and &6Output&r the Casings, or just have them dropped out with the Expel Casing Button. \\n\\nBefore it starts shooting, we'll need to set its targeting. First, it won't attack the person who placed it. We also have a Type Bar we can add any Player or Mob name to Add in. These will make it so it spares them! \\n\\nIt is automatically set to Blacklist, if it is Blacklisted that means it'll Shoot what is listed. We then have Animals which means Passive Mobs. Players means just Players. Neutral stands for any Neutral Mobs and Villagers. Don't worry it was always target Hostile Mobs!"]
 	quest.341DF467E3936E78.quest_desc: ["Kill the &dEnder Dragon&r while wearing a full set of &8B&6e&8e&r Armor! \\n\\nYour name will be remembered for centuries!"]
-	quest.342D1FA0BCBB847A.quest_subtitle: "Tier: &b4"
 	quest.342EEB042DEC2B8C.quest_desc: ["Magma and Geysers both spawn on the bottom of The Abyss. \\n\\nMagma will help you get down below and help keep your breath. \\n\\nGeysers just look cool!"]
 	quest.3446803FB59D8875.quest_desc: ["Gives you Thorns. Not your Armor, you! Like a Pufferfish!"]
 	quest.3446803FB59D8875.quest_subtitle: "Necklace"
@@ -5112,7 +5182,7 @@
 		"Careful when mining."
 	]
 	quest.34592A8F4B661D8D.quest_subtitle: "This Goes Boom Too"
-	quest.3459CAEB59CBD60E.quest_desc: ["Looks like someone flipped the ON switch this time! \\n\\n&4The Prowler&r is a miniboss guarding the &4Ancient Factory&r. He has 640 &4Hearts&r. \\n\\nHe has 3 attacks. The Saw for close up Enemies. And for farther Enemies he has Shoulder Missiles, similar to the WASW, and a Laser from his eye. \\n\\nOn death he'll drop Redstone and Iron. \\n(Tip he's also weak to the EMP attacks)"]
+	quest.3459CAEB59CBD60E.quest_desc: ["&4The Prowler&r is a miniboss guarding the &4Ancient Factory&r. He may look powered down but once you get too close you'll learn that's very wrong. He has 1500 Hearts and has 2 attacks: Shoulder Missiles similar to the WASW and a saw he uses for upclose combat. On death he'll drop Redstone and Iron plus exp. (Tip he's also weak to the EMP attacks)"]
 	quest.3459CAEB59CBD60E.title: "&4The Prowler&r"
 	quest.346860B8EBC4C28C.quest_desc: ["Now that you have all this lava what will you do with it? More early game power! "]
 	quest.346860B8EBC4C28C.title: "Lava Power"
@@ -5204,6 +5274,8 @@
 		"This takes a lot of Cyanite, so start stocking up! You might want to upgrade to a bigger reactor as well. "
 	]
 	quest.354086C858E10154.title: "Reprocessing our Waste"
+	quest.3543563DF036D461.quest_desc: ["To create Dragonyst Dust, you'll need to perform &9Uphyxes' Inverted Tower&r. However, to create Magenta Chalk, you'll also need some materials that you can only get through the &9Marid Crusher&r."]
+	quest.3543563DF036D461.title: "&#AD00C8Magenta Chalk"
 	quest.355244420EA47546.quest_desc: ["Fabricator is the Auto-Crafter. It will take items from the inventory below and make a set recipe.\\n\\nYou can lock recipes with CTRL Click. It will need to pipe out the created items though."]
 	quest.355244420EA47546.quest_subtitle: "Auto-Crafter"
 	quest.356102D5B5F3CA1E.quest_desc: ["An Alloy added by &6&lForbidden \\& Arcanus&r is &5Obsidiansteel&r. \\n\\nIt's created in the &l&bClibano&r, by combining Raw Iron and &5Obsidian&r. \\n\\nYou'll need an Artisan Relic in order to actually make the Alloy! \\n\\nAlso you'll get &6Copper&r as residue, which probably isn't supposed to happen..."]
@@ -5228,17 +5300,27 @@
 	quest.359E1FFAB18FE50F.quest_desc: ["You got tools and Gems so how do we combine them? First, make sure your tool has an open Socket. (For more on Sockets check the Vials and Sigils section). If one is open, you can combine your tool and Gem in a Smithing Table. If you aren't happy with your current Gems then you might need a..."]
 	quest.359E1FFAB18FE50F.title: "Applying Gems (and others)"
 	quest.35A014F1B4506CCA.title: "LV Tier"
-	quest.35ABB0DEE70DF7FD.quest_desc: ["Believe it or not, the &aPowah&r mod has some great options for getting... powwe.\\n\\nMake sure to check out the &cPowah&r qyest chapter to learn more!"]
-	quest.35ABB0DEE70DF7FD.title: "More &aPowah&r!"
+	quest.35ABB0DEE70DF7FD.quest_desc: [
+		"Believe it or not, the &dPowah&r mod has some great options for getting... powah. "
+		""
+		"Make sure to check out the &cPowah&r Chapter to learn more!"
+	]
+	quest.35ABB0DEE70DF7FD.title: "Need more &9Powah&r"
 	quest.35C46E6E27C9CB1A.quest_desc: ["The 10 &2Vanilla&r Logs are wonderful, but they only have so many designs! \\n\\nSo of course &l&bChipped&r, chipped in by adding dozens of new designs for those Logs!"]
 	quest.35C46E6E27C9CB1A.title: "&l&bChipped&r Logs"
-	quest.35CC898E0E49FE58.quest_desc: ["&9Flux Networks&r is a mod that aims to be the solution to all of your wireless power needs.\\n\\nThe mod itself does not have a way to generate power, but it can store and wirelessly transmit power, even across dimensions. It can even charge your items in your inventory.\\n\\nYou can even charge your Jetpacks while you are flying with this mod.\\n\\nTo get started with the mod, you'll need some Flux Dust. Head to Bedrock, then throw some Redstone on top of some Bedrock. Place some Obsidian right above the floating Redstone, then left click the Obsidian."]
+	quest.35CC898E0E49FE58.quest_desc: [
+		"&9Flux Networks&r is a mod that aims to be the solution to all of your wireless power needs. "
+		""
+		"The mod itself does not have a way to generate power, but it can store and wirelessly transmit power, even across dimensions. It can even charge your items in your inventory. "
+		""
+		"You can even charge your jetpack while you are flying with this mod. HOW COOL IS THAT? "
+		""
+		"To get started with the mod, you'll need some Flux Dust. Head to bedrock level, then throw some redstone on top of a block of bedrock. Place a block of obsidian right above the floating redstone, then left click the obsidian."
+	]
 	quest.35CC898E0E49FE58.quest_subtitle: "The Ultimate Wireless Power Solution"
-	quest.35CC898E0E49FE58.title: "&8Flux Networks"
+	quest.35CC898E0E49FE58.title: "Flux Networks"
 	quest.35E399D88D2EDCB6.quest_desc: ["With this Upgrade everyone who attacks you will 1. be Stunned which will stop them for a second 2. hurt them and 3. destroy any Projectiles. \\n\\nI think it's worth the Upgrade!"]
 	quest.35E399D88D2EDCB6.quest_subtitle: "Clash?"
-	quest.35E42F7925CA097A.quest_desc: ["&dVoid Cores&r are drops from the &dEnder Golem&r! \\n\\nThey are weapons, when you Right Click with them, &dVoid Runes&r will spawn from the ground. \\n\\n&dVoid Runes&r act like Evoker Fangs, they go in a line for about 10 Blocks in the direction you are using it toward. \\n\\nThey do about 3 and a half &4Hearts&r of damage for each time they hit a Mob. They also knockback Mobs which Evoker Fangs do not. \\n\\nThis can be used in Crafts for even more &4&lCataclysm&r Weapons!"]
-	quest.35E42F7925CA097A.title: "&dVoid Core"
 	quest.35E8F1CC0080E45E.quest_subtitle: "Feed a Diamond Bee a Ruby"
 	quest.35E8F1CC0080E45E.title: "RuBee"
 	quest.35EAB77C195E594E.quest_subtitle: "Feed a Diamond Bee Amethyst"
@@ -5312,6 +5394,8 @@
 	quest.3663E93E169EF8E3.title: "&2Uranium Hexafluoride"
 	quest.3673893C88EB5EDE.quest_desc: ["Use 3 other crystals to craft this crystal."]
 	quest.3673893C88EB5EDE.quest_subtitle: "Weathering the Storm"
+	quest.367E891A50991436.quest_desc: ["Using &cSevira's Permanent Confinement&r, we can combine several different wither materials and some netherite to create three Witherite Dust. With these, we can create ourselfs the highest form of Foundation Chalk, Black Chalk."]
+	quest.367E891A50991436.title: "Black Chalk"
 	quest.36836AD948F96B9F.quest_desc: [
 		"The simplest of the simplest of &e&lPipes&r, the &eItem Pipe&r. \\n\\nIt will move Items from one Inventory to another. Could be from one Chest to another, could be a Farm to a System, or even a Quarry to a Smelter. \\n\\nVery simple just connect the &ePipes&r to what you want moved, and use your Wrench to configure which side it Pulls from. "
 		"{image:atm:textures/questpics/logistics/pipez_item.png width:200 height:50 align:center}"
@@ -5348,8 +5432,15 @@
 	quest.36CF8D1DD1EF6307.quest_subtitle: "2 Wet Light Green Blocks"
 	quest.36D72D759C4E8823.quest_desc: ["Maybe a little too fast even."]
 	quest.36D72D759C4E8823.quest_subtitle: "Max: 1"
-	quest.36DEA17CBB696CC7.quest_desc: ["If you right-click on the Plug, you'll see the Flux Network UI. On the far top-right corner, click on the + button to create your first network. You'll need to set a password to create the network, but you can also set a color!\\n\\nFrom here, you can go to the Network Selection tab to activate your network on the Plug. If the Plug is attached to a power source, you can now harness that power anywhere in your system using a Flux Point!\\n\\nPro Tip: You can create multiple networks if you want to have different power sources powering different parts of your systems!"]
-	quest.36DEA17CBB696CC7.quest_subtitle: "Becoming a Network Admin!"
+	quest.36DEA17CBB696CC7.quest_desc: [
+		"Right-click on your plug and you'll see the Flux Network UI. On the far top-right corner, click on the + button to create your first network. You'll need to set a password to create the network, but you can also set a color! "
+		""
+		"From here, you can go to the Network Selection tab to activate your network on the plug. If the plug is attached to a power source, you can now harness that power anywhere in your system using a Flux Point! "
+		""
+		"Pro Tip: You can create multiple networks if you want to have different power sources powering different parts of your systems!"
+	]
+	quest.36DEA17CBB696CC7.quest_subtitle: "You're a Network Admin Now!"
+	quest.36DEA17CBB696CC7.title: "My First Network"
 	quest.36DED7099E80ED51.quest_desc: ["This one does as the name suggests, it places Blocks. \\n\\nSet the Direction you want the Block placed, preferably set the Filter, then throw the Module and Blocks into the Router! Once the Redstone is set the Blocks will be placed!"]
 	quest.36DF0D83EBC2B6A9.quest_desc: [""]
 	quest.36DF0D83EBC2B6A9.quest_subtitle: "&oLack of wisdom is a thing of the past with this."
@@ -5454,8 +5545,6 @@
 	quest.37CD9BF281903F56.quest_subtitle: "Feed a Shroombee a Red Mushroom"
 	quest.37CD9BF281903F56.title: "Red Shroombee"
 	quest.37D4E5ACB35D8BF1.quest_subtitle: "Requires Hydrogen to Work!"
-	quest.37E4DECFB6526969.quest_desc: ["The &3Soul Render&r is crafted from &3Cursium&r and Black Steel. \\n\\nIt being a massive weapon (as most in &4&lCataclysm&r are) it has big Range and a ton of Damage... but its special effects are even better! \\n\\nYou can use Right Click to be sent charging forward with the &3Soul Render&r. When you do, &3Phantom Halberds&r will drop from the sky where you went! You can also Shift Right Click to spawn &3Phantom Halberds&r all around you."]
-	quest.37E4DECFB6526969.title: "&3Soul Render"
 	quest.37EBB8E0D6E5F821.quest_desc: [
 		"&6Hostile Neural Networks&r (HNN for short) is a mod based around simulating mob kills for loot!\\n\\nTo do this, you will be collecting \"data\" on mobs, then running simulations from the data to create their drops!\\n"
 		"{image:atm:textures/questpics/hnn.png width:150 height:150 align:center}"
@@ -5467,7 +5556,7 @@
 		"{image:atm:textures/questpics/undergarden/undergarden_rotwalker.png width:100 height:200 align:center}"
 	]
 	quest.380D3212D1CBA593.title: "&cRotwalker&r"
-	quest.38135FFD9ED64395.title: "Vibranium-Allthemodium Alloy"
+	quest.38135FFD9ED64395.title: "Vibranium-AllTheModium Alloy"
 	quest.3813F5C1760C3A79.quest_desc: ["Piglin Brutes being here might cause controversey but I consider them Minibosses. \\n\\nThey spawn in Bastions with regular Piglins but these are Hostile not Neutral. Personally I hate that, especially since if you hit them all Piglins will turn Hostile on you. \\n\\nThey have 50 Hearts and a Golden Axe to hit you. Usually Golden Axes barely do any damage, but when they use it, it is god somehow! \\n\\nThey drop nothing and act more like an obstacle for Bastions!"]
 	quest.3813F5C1760C3A79.title: "Kill A Piglin Brute"
 	quest.38451B61E3FC075B.quest_desc: [
@@ -5484,6 +5573,15 @@
 	quest.3889D0255074CE85.quest_desc: ["&bMacaw&r decided the furniture wasn't enough, he needed his Macaw home to have more than just natural lighting from his &b&lMacaw Windows&r. \\n\\nSo now we have &b&lMacaw's Lights and Lamps&r which adds all sorts of Light Sources. \\n\\nFrom Lamps to Lanterns to Chanderliers!"]
 	quest.3889D0255074CE85.title: "&l&bMacaw's Lights and Lamps&r"
 	quest.38954551309F42A7.quest_desc: ["Sender Module MK2 works similar to MK1 but with less restrictions. \\n\\nMK2 doesn't need direct line of sight or to be on same XYZ axis. \\n\\nWill have to be in the same Dimension though, unless you have..."]
+	quest.38A1295878B68F83.quest_desc: [
+		"No, not that kind."
+		""
+		"&cAfrit Demons&r are Demons of &cFire&r. They are more advanced Demons, which some are friends and some are... not. It all depends on how strongly the ritual can control the &cAfrit&r. "
+		""
+		"Because we don't have access to red chalk yet, all we can summon is an &9unbound&r demon, meaning it cannot be controlled and will be violent."
+	]
+	quest.38A1295878B68F83.quest_subtitle: "Hot Demons!"
+	quest.38A1295878B68F83.title: "&6Abras' Open Conjure"
 	quest.38A77DBAD24C4B53.quest_subtitle: "Tier: &63"
 	quest.38ADDF7FF4E4892D.quest_desc: ["The &7Glass Sword&r deals 40 hearts of damage, but only has 1 durability.\\n\\nYou can make it indestructible if you want to use it.\\n\\nThese are rarely found in loot chests in the &bAurora Palace&r."]
 	quest.38ADDF7FF4E4892D.title: "&7Glass Sword"
@@ -5515,7 +5613,7 @@
 	quest.3912DE46B5F39287.title: "Empty Soul Gem"
 	quest.3917DECAEF56A06A.quest_desc: ["&fTier 2&r is the stone pickaxe level. It's almost only for mining Iron items."]
 	quest.3917DECAEF56A06A.title: "&fHarvest Tier 2"
-	quest.392EAE8BE71510C1.quest_desc: ["The Barren Wasteland of the &5End&r now has 1 more resident. \\n\\nThe other being the &dEnder Dragon&r of course!"]
+	quest.392EAE8BE71510C1.quest_desc: ["The Barren Wasteland of the &5End&r now has 1 more resident. Besides the Ender Dragon though."]
 	quest.392EAE8BE71510C1.title: "&5End&r: Land of 1 lonely boss"
 	quest.392F34FD4FCC794A.quest_desc: ["While they can be expensive they're also plenty stylish!"]
 	quest.392F34FD4FCC794A.title: "&2&lMystical Agriculture&r Blocks"
@@ -5537,6 +5635,15 @@
 	quest.39605F1FEB1A5A1C.title: "AllRightsReserved"
 	quest.39615B8E568E0380.quest_desc: ["Take the Yttrium Barrium Cuprate and make wires."]
 	quest.39615B8E568E0380.quest_subtitle: "Yit-Trium? is the Y silent?"
+	quest.39647A2473F6F7D7.quest_desc: [
+		"Our next step is a foray into &6Infusion Rituals&r. These rituals are used to imbue items with the magic of demons."
+		""
+		"The first tier of &6Infusion Rituals&r is &eEziveus' Spectral Compulsion&r. We'll be using this ritual to create several items that you'll need throughout this mod."
+		""
+		"We reccomend creating this ritual in a separate area from your first one, because the three main types of rituals build off each previous tier."
+	]
+	quest.39647A2473F6F7D7.quest_subtitle: "Put some Demon Dust™ on it!"
+	quest.39647A2473F6F7D7.title: "&eEziveus' Spectral Compulsion"
 	quest.396AA75774059D0B.quest_desc: ["You are too powerful."]
 	quest.396CEB9D05700927.quest_desc: ["To get into the &l&6Bumblezone&r you'll first need a &eBeehive&r. Normal &eBeehives&r and &eAdvanced Beehives&r it's not picky! \\n\\nThen you'll need to either throw an Enderpearl into it or have a Piston push you into it! \\n\\nAnd you'll get into the &eHive&r and enter the &l&6Bumblezone&r!"]
 	quest.396CEB9D05700927.quest_subtitle: "Unbeelievable"
@@ -5725,6 +5832,7 @@
 	quest.3B42CCC19D23EC6D.quest_subtitle: "x4"
 	quest.3B42CCC19D23EC6D.title: "4k Storage Component"
 	quest.3B43DB1A6B0A7B44.quest_desc: ["The Crusher can also break down natural substances into Bio Fuel!"]
+	quest.3B43DB1A6B0A7B44.title: "Bio Fuel"
 	quest.3B4511E7DC788AB3.quest_desc: ["{image:atm:textures/questpics/basicarmor/armor_tenacious.png width:100 height:150 align:center}"]
 	quest.3B4511E7DC788AB3.title: "&dTenacious Petal&r"
 	quest.3B4BF42C55C8BBBF.quest_desc: ["Don't you hate when your breaking something and the Blocks fall just out of your reach! \\n\\nWell worry no more for we have &4Magnets&r! Simply Right Click while holding the &4Magnet&r to turn it on. Then, all dropped Items and Blocks in a 5 Block Radius will come to you. \\n\\nYou can also equip the &4Magnet&r in your Curios to keep using it! \\n\\nIf you don't wish to continue using the &4Magnet&r (I find this happens near Mob Farms) then just Right Click with it again to disable it. \\n\\nIt can also be upgraded to increase the range!"]
@@ -5741,11 +5849,9 @@
 	quest.3B560B2ECE331CAF.title: "Tier 3 Starlight Charger Pillar Cap"
 	quest.3B570B3DB5F6D2CB.quest_subtitle: "x16 Storage Upgrade"
 	quest.3B570B3DB5F6D2CB.title: "&eGold Upgrade&r"
-	quest.3B577572FA7A413E.quest_desc: ["The &3Wrath of the &eDesert&r is a combination of the &3Cursed Bow&r and &eSandstorm in a Bottle&r. \\n\\nThis Bow doesn't shoot Arrows like normal, instead it will shoot &3Cursed &eSandstorms&r! \\n\\nThree of them to be exact! \\n\\nIt also doesn't need Arrows to shoot, which is also nice."]
-	quest.3B577572FA7A413E.title: "&3Wrath of the &eDesert"
 	quest.3B6F1BD64C0C570F.quest_desc: ["Just like wind generation this will give you lots of power without giving it any resources. The only downside here is it has to be daytime. "]
 	quest.3B6F1BD64C0C570F.title: "Solar Power"
-	quest.3B6F723B03C4BF55.quest_desc: ["Digestion (very prude way of processing) is how we change &3Alchemical Niters&r to different forms. \\n\\nFirst we'll need Purified Gold which can be made from putting Gold, &bAlchemical Salt&r, and &9Water&r into the Digestion Vat and Shift Right Click to close it like the Fermentation Vat. \\n\\nThen we can either combine 4 of one &3Alchemical Niter&r with Purified Gold and &dSal Ammoniac&r to get a higher Tier or do the reverse for a lower Tier."]
+	quest.3B6F723B03C4BF55.quest_desc: ["Digestion (very prude way of processing) is how we change &3Alchemical Niters&r to different forms. \\n\\nFirst we'll need Purified Gold which can be made from putting Gold, &bAlchemical Salt&r, and &9Water&r into the Disgestion Vat and Shift Right Click to close it like the Fermentation Vat. \\n\\nThen we can either combine 4 of one &3Alchemical Niter&r with Purified Gold and &dSal Ammoniac&r to get a higher Tier or do the reverse for a lower Tier."]
 	quest.3B6F723B03C4BF55.title: "Digestion Vat"
 	quest.3B7BB08D6AA2E7FE.quest_desc: [
 		"Now the &cRed Super Candles&r finally look in place! We know it's the &cRed one&r by the &cRed Flowers&r and &cRed Luminescent Ancient Wax&r. \\n\\nVenture through the &cfirey red rooms&r to get to the &cRed Essence&r. \\n\\nDozens of different angry Mobs will spawn: Wolves, Polar Bears, and Hoglins. Kill them all to win!"
@@ -5763,7 +5869,6 @@
 	]
 	quest.3B84215240D9F2CB.quest_subtitle: "Secure your grid!"
 	quest.3B84215240D9F2CB.title: "Security Manager"
-	quest.3B884E05AE2EEBFC.quest_subtitle: "Tier: &c5"
 	quest.3B88D58B11B5DC78.quest_subtitle: "Tier: &54"
 	quest.3B9E6FBEDABA4F7E.quest_desc: [
 		"Deep within the &6&lHive Walls&r you may find a &6Honey&r Cave! \\n\\nHere you can find &6Honey Fluid&r, &5Honey Crystals&r, Brood Blocks, and even Beehemoths! \\n\\nEverything &6Honey&r related. "
@@ -5786,10 +5891,16 @@
 	quest.3BD73FEAE853D350.quest_desc: ["Ever hate how slow &bIce&r is unless using a Boat? Which still doesn't make sense to me! &bIce Skates&r change that now you accelerate on &bIce&r while wearing &bIce Skates&r. You can upgrade them to accel faster! \\n \\nAfter upgrading them you can get a Second Ability which allows you to damage Mobs by running into them while wearing &bIce Skates&r."]
 	quest.3BD73FEAE853D350.quest_subtitle: "Found in Villages in Taigas or Snowy Taigas"
 	quest.3BD73FEAE853D350.title: "&bIce Skates"
-	quest.3BDB94F17765EE77.quest_desc: ["If you're looking to generate a ton of power, you can start by scaling up some of the options from the &9Mid Game Power&r section. Make your &aReactors&r bigger. Upgrade your &9Thermo Generators&r to Nitro. Go wild.\\n\\nHowever, you may need even more power."]
+	quest.3BDB94F17765EE77.quest_desc: [
+		"If you're looking to generate a ton of power, you can start by scaling up some of the options from the &9Mid Game Power&r section. Make your &eExtreme Reactors&r bigger. Upgrade your &9Thermo Gens&r to Nitro. Go wild. "
+		""
+		"&9Mekanism&r also has an end game power option that is tough to beat. "
+		""
+		"The &dFusion Reactor&r can produce up to 200MRF/t, and if you want to learn how to build it, make sure to check out the &aMekanism:&r &dAdvanced&r Chapter!"
+	]
 	quest.3BDB94F17765EE77.quest_subtitle: "More Power Than You'll Need"
 	quest.3BDB94F17765EE77.title: "End Game Power Options"
-	quest.3BE5CD0C7CC4BCC6.quest_desc: ["Soul Lava is a part of &6&lAllthemodium&r. It can be found in &b&lThe Other&r very rarely underground, or common in Piglich Villages!\\n\\nWe'll need to feed a Bucket of &9Soul Lava&r to a Ghostly Bee to make a &9Soul Lava Bee&r.\\n\\nThen, you'll need to squish them or poke them for it's DNA to make a Spawn Egg!  "]
+	quest.3BE5CD0C7CC4BCC6.quest_desc: ["Soul Lava is a part of &6&lAllTheModium&r. It can be found in &b&lThe Other&r very rarely underground, or common in Piglich Villages!\\n\\nWe'll need to feed a Bucket of &9Soul Lava&r to a Ghostly Bee to make a &9Soul Lava Bee&r.\\n\\nThen, you'll need to squish them or poke them for it's DNA to make a Spawn Egg!  "]
 	quest.3BE5CD0C7CC4BCC6.title: "&9Soul Lava Bee&r Spawn Egg"
 	quest.3BEDF19CD79D53D5.quest_desc: [
 		"The &aDistillation Tower&r serves as the foundation for &dOil Processing&r which can turn oil into many more useful forms"
@@ -5819,7 +5930,6 @@
 		"This way, we know that the resulting Star can be controlled, and its immense power wont run rampantly out of control."
 	]
 	quest.3BF90C250AC1ADF3.quest_subtitle: "Black Hole Controller"
-	quest.3C2F5AB815A6C949.quest_desc: ["To make an &2Infused Iron Ingot&r place an Iron Ingot on the &2Natural Altar&r.\\n\\nThis process will be quicker than with &6Tainted Gold."]
 	quest.3C322474D2F2BA99.quest_desc: [
 		"The Teleport Pad is used to teleport to 3 new dimensions added by the ATM pack."
 		""
@@ -5829,7 +5939,7 @@
 		""
 		"To get to the &5Beyond&r, use the Teleport Pad in the End."
 	]
-	quest.3C322474D2F2BA99.title: "Allthemodium Dimensions"
+	quest.3C322474D2F2BA99.title: "AllTheModium Dimensions"
 	quest.3C3FE45CEF5E242B.quest_desc: ["While the other &aReprocessor Parts&r have a mandatory spot when building, these three parts can be placed on any vertical face as long as they aren't on the frame!\\n\\nThe &cPower Port&r is used to give power to the multiblock machine to process waste.\\n\\nThe &9Fluid Injector Port&r is used to inject the liquid needed, which will depend on the type of waste injected. For Cyanite, that means water!\\n\\nThe &aOutput Port&r is used to output the reprocessed material. You can right click it to grab the material out by hand, or pipe it out for automation."]
 	quest.3C413D4A210A3BDE.title: "Honey Bee"
 	quest.3C49F2EEDCCAF1DF.quest_desc: [
@@ -5965,8 +6075,6 @@
 	quest.3DCF26B53AE1EBF6.quest_desc: ["Inside the &2Dark Forest&r, you'll find a structure that leads underground.\\n\\nTo enter, you'll need to place one of the boss trophies you've acquired on the nearby pedestal, don't worry about which one you place, you can pick it back up.\\n\\nOn the 3rd layer, you'll find the Knight Phantoms. Defeat these to unlock the next boss."]
 	quest.3DCF26B53AE1EBF6.quest_subtitle: "The Darkest of Forests"
 	quest.3DCF26B53AE1EBF6.title: "&2The Dark Forest"
-	quest.3DD71B6C4B80FB44.quest_desc: ["The &3Eye of Curse&r will lead you to the &3Frosted Prison&r to fight the &3&lMaledictus&r."]
-	quest.3DD71B6C4B80FB44.title: "&3Eye of Curse"
 	quest.3DDB0DDA7571B2C1.quest_desc: ["The &bME Level Emitter&f, when configured with a specific item and quantity of it to respond to, will emit a redstone signal depending on whether that item stored in the network either falls below, goes above or equals the given quantity.\\n\\nThis can be used, for example, to automatically switch certain machines on with redstone to auto-craft a resource when it falls below a given minimum amount."]
 	quest.3DDB0DDA7571B2C1.title: "ME Level Emitter"
 	quest.3DDB7C8E61BA048F.quest_subtitle: "Tier: &a2"
@@ -6079,7 +6187,7 @@
 		"{image:atm:textures/questpics/railcraft/rail_electric.png width:100 height:100 align:center}"
 	]
 	quest.3E8C2E7769DFBF35.title: "&eElectric Locomotive"
-	quest.3E8C7D92F99496BE.quest_desc: ["The &5Eye of Abyss&r will take you to the &5Sunken City&r to fight the &5&lLeviathan&r."]
+	quest.3E8C7D92F99496BE.quest_desc: ["&5The Eye of Abyss&r will take you to the &5Sunken City&r to fight the &5Leviathan&r"]
 	quest.3E8C7D92F99496BE.title: "&5Eye of Abyss&r"
 	quest.3E970E76372AB094.quest_desc: ["The &2Accelerated Planter&r works similar to normal Farmland but with some changes.\\n\\nIt's automatIically watered and it's faster than normal Farmland."]
 	quest.3E970E76372AB094.title: "&2Accelerated Planter"
@@ -6115,7 +6223,7 @@
 	]
 	quest.3EDDF34A71CD78B9.quest_subtitle: "Again?!"
 	quest.3EDDF96EA5056D28.quest_desc: ["&6Copper&r and &7Nickel&r will make &6Constantan&r! \\nFinally this one is used quite a bit in &8&lIE&r, especially in Machines or Items using Heat and Metal, like Generators."]
-	quest.3EDDF96EA5056D28.title: "&6Constantan Ingot"
+	quest.3EDDF96EA5056D28.title: "&6Constantan Ingot&r"
 	quest.3EE95747CA6DFB1A.quest_desc: [
 		"The &7&lMetal Press&r is our Best Friend for all Crafting Recipes with &7Metal&r! \\n\\nIt's very simple, we place our Molds onto the Press, attach some &cEnergy&r to the top, and toss our &eItems&r onto the &eConveyor Belts&r. \\n\\nOur &eItems&r will pass through, get &7&lPressed&r, and become a new &eItem&r that keeps moving on the &eBelt&r! \\n\\nThese can be used to make &cWires&r, &7Plates&r, &8Rods&r, and... &2Melon Slices&r?"
 		"{@pagebreak}"
@@ -6326,7 +6434,6 @@
 	quest.40924F0D64253A38.quest_subtitle: "Gone!"
 	quest.40926361B5A17F74.quest_desc: ["To get Gem Dust you need an Apotheosis Gem and an anvil. Any Apotheosis Gem (Recommended only common and uncommon). Once you get your gems smash them with a falling anvil! Then to make this easier make a Salvaging Table."]
 	quest.40926361B5A17F74.title: "Gem Dust"
-	quest.4092E914B24C52A7.quest_subtitle: "Makes various Starlight Materials"
 	quest.409A92D40F539485.quest_subtitle: "Tier: &e1"
 	quest.40AB457E37919ABE.quest_desc: ["You like Flying? You like Arson? You like both? Then the Blazing Flask is perfect for you! Right Click the Blazing Flask near Fire sources and a circle will be made around it. In the circle you will be granted Creative Flight. The circle can be made bigger through upgrading it in the &6Research Window&r and by adding more Fire!"]
 	quest.40AB457E37919ABE.quest_subtitle: "Found in Ruined Portals, Nether Fortresses, and Bastions"
@@ -6487,6 +6594,7 @@
 	quest.420158B1736A1354.quest_desc: ["...is not implemented.\\n\\nInstead, head to the giant castle in the Final Plateau and grab some door blocks!\\n\\nThere is a Kobold that spawns in as a \"placeholder\" but you will get nothing from killing it."]
 	quest.420158B1736A1354.title: "&cThe Final Boss"
 	quest.4204702AA6FBF40B.quest_desc: ["Standing on this item will charge up any powered item from any mod.\\n\\nThis is also needed for the Robit."]
+	quest.420DA7C40B8EDDDC.quest_desc: ["Thanks to &lATO&r we can use &8Steel&r from any (we can not affirm that all Mods can apply to this statement) Mod. \\n\\nMetallurgic Infuser is probably the easiest and quickest."]
 	quest.420FE84DEE12CCE0.quest_desc: ["The &eGold Furnace&r is better than the Iron ones with a Cooktime of 120 Ticks.\\n\\nIt can be crafted with &7Silver&r or Iron Furnace and is crafted into a &bDiamond one&r!"]
 	quest.420FE84DEE12CCE0.title: "&eGolden Furnace"
 	quest.4221D6CDDF90DACB.quest_subtitle: "Tier: &b4"
@@ -6553,6 +6661,15 @@
 	quest.4295C863C9A81F28.quest_desc: ["The Telsa Coil is a very fun and &cEnergy&r hungry home defence! \\n\\nFirst, power it with &cEnergy&r from any of its Ports. Then, either give it a &4Redstone Signal&r to turn it on, or use a &6Engineer's Screwdriver&r to make it always on! \\n\\nOnce it is on it will be actively using &cEnergy&r and when a Mob comes near it, it will Stun them and hurt them! Hurting Mobs makes it take more &cEnergy&r though. \\n\\nYou can Shift Right Click with an &6Engineer's Screwdriver&r to set it to low power mode. It will take less &cEnery&r but also have less Range and deal less Damage!"]
 	quest.429785E8F64929CE.quest_desc: ["In order to get to the Starlight Dimension you'll need to find Portal Ruins in the Overworld. \\n\\nThere you will find a Gatekeeper, Right Click to initiate a conversation and challenge them to a duel! Careful, they are very tough. \\n\\nOnce you win the duel you'll be gifted a few Items, the Orb of Prophecy being one. Right Click the Portal with the Orb to activate it! Then, walk in to get to the..."]
 	quest.429785E8F64929CE.title: "The Gatekeeper and The Gate"
+	quest.429B5A81DF6C43FE.quest_desc: [
+		"&6Abras' Open Commanding Conjure&r is used to bring an &cAfrit&r demon into a pig. Because this ritual is performed without the use of red chalk, it's only powerful enough to summon an &9unbound&r demon."
+		""
+		"In particular, this ritual will create an &cAfrit&r-possessed zombified piglin, which will drop some demonic meat, which is used to craft pink chalk"
+		""
+		"&l&4WARNING: YOU MAY HAVE TO DO THIS ONE MULTIPLE TIMES TO GET ENOUGH DEMONIC MEAT! "
+	]
+	quest.429B5A81DF6C43FE.quest_subtitle: "How... fleshy..."
+	quest.429B5A81DF6C43FE.title: "&6Abras' Open Commanding Conjure"
 	quest.42AAEC41F2BC2474.quest_desc: ["{image:atm:textures/questpics/basicarmor/armor_glacite.png width:100 height:150 align:center}"]
 	quest.42AAEC41F2BC2474.title: "&bGlacite&r"
 	quest.42AF4EBDA5D6CC36.quest_desc: ["You can make &2Blastproof Alloy&r by combining the three strongest Metals available. &5Tungsten&r, &dTitanium&r, and &7Stainless Steel&r. Yes, stains matter apparently. \\n\\nWith these you can combine them to make the &2Casing&r."]
@@ -6566,9 +6683,13 @@
 		"There is also a ton of rare loot, so make sure to keep an eye out for Intricate Hellforged Parts."
 	]
 	quest.42CDD69527871332.title: "&cThe Demon Realm"
-	quest.42D173B9FF8D16E4.quest_desc: ["Looking for early game power options? These are good ways to get you started with generating power.\\n\\nThese don't produce a ton of power, but they are typically easy or cheap to get in the early game!"]
+	quest.42D173B9FF8D16E4.quest_desc: [
+		"Looking for early game power options? These are good ways to get you started with generating power. "
+		""
+		"These don't produce a ton of power, but they are typically easy or cheap to get in the early game!"
+	]
 	quest.42D173B9FF8D16E4.quest_subtitle: "Starter Power"
-	quest.42D173B9FF8D16E4.title: "&8&lEarly Game Power Options"
+	quest.42D173B9FF8D16E4.title: "Early Game Power Options"
 	quest.42D7C8CD8E6F5CD7.quest_desc: ["By using a Chorus Fruit on a Spawner you suck the souls out the mobs that will be spawned, only leaving a hollow husk of what they used to be. The mobs will lose all AI so they will do basically what an armor stand does. They can't hit you, can't teleport, can't move on their own. They sit there ready to be killed, how exciting!"]
 	quest.42D7C8CD8E6F5CD7.title: "No AI"
 	quest.42E5B5C27799DD93.quest_desc: [
@@ -6654,15 +6775,12 @@
 		"Copper and Nickel together in an alloy smelter make cupronickel, which you'll need to create the Coils for the Electric Blast Furnace"
 	]
 	quest.43A1BC20BB054A14.quest_desc: ["Glitterkelp grows in Ancient and Icy Seas. \\n\\nThey don't do much but Glow and can be crafted into Pie!"]
-	quest.43A5B83862D9E94C.quest_desc: ["The &bEye of Flame&r will take you to the &bBurning Arena&r to fight the &b&lIgnis&r."]
+	quest.43A5B83862D9E94C.quest_desc: ["&bThe Eye of Flame&r will take you to the &bBurning Arena&r to fight the &bIgnis&r"]
 	quest.43A5B83862D9E94C.title: "&bEye of Flame&r"
 	quest.43CDC28DC56BB3E2.quest_subtitle: "128,000mb"
 	quest.43CE45F9FDDB91EE.title: "&6Master of Creation&r"
 	quest.43D3E61FA314E3C3.quest_desc: ["Exchanging heat in any case is usually very expensive in Energy cost. In this case, some Tritainium coils, Ultimate Voltage Coils, and Large Naquadria Batteries will do the trick."]
 	quest.43D3E61FA314E3C3.quest_subtitle: "Thermal Exchange"
-	quest.43D83CFA824B0A70.quest_desc: ["&9Mekanism&r has an end game power option that is tough to beat. The &dFusion Reactor&r can produce up to 80MRF/t, and if you want to learn how to build it, make sure to check out the &aMekanism: &dReactors&r quest chapter!"]
-	quest.43D83CFA824B0A70.quest_subtitle: "Fusion Activate!"
-	quest.43D83CFA824B0A70.title: "&9Mekanism: &dFusion Reactor"
 	quest.43E8912CB307E421.quest_desc: [
 		"Great! We can store items virtually, but how do we see what is on the network? "
 		""
@@ -6699,8 +6817,8 @@
 	quest.4458F8829800A950.quest_desc: ["Polymorphic Fluid is the base of all Fluids / Fuels in JDT. Polymorphic Fluid is crafted by dropping Polymorphic Catalyst into water."]
 	quest.445C21949ADA1FE3.quest_desc: ["Combine an Ancient Codex with an &6Allthemodium Ingot&r and Template in a Smithing Table.\\n\\nYou can get the Template from Brushing Suspicious Clay in an &9Ancient City&r."]
 	quest.445C21949ADA1FE3.title: "&6Allthemodium&r Spell Book"
-	quest.445C9117198936B6.quest_desc: ["The &4Wither Assault Shoulder Weapon (W.A.S.W.)&r is the last weapon you can make from &4Witherite&r. \\n\\nIt has 2 different projectiles it can shoot: &4Wither Missiles&r and &4Wither Howitzers&r. \\n\\nThe &4Wither Missiles&r shoot from just Holding Right Click, and will Damage whatever gets hit by them, with low cooldown. \\n\\nThe &4Wither Howitzers&r are fired when you Shift Hold Right Click, they damage a bigger area and leave an area of Wither Effect, that damages whatever walks in it. They have much longer cooldown though."]
-	quest.445C9117198936B6.title: "&4W.A.S.W. (Wither Assault Shoulder Weapon)"
+	quest.445C9117198936B6.quest_desc: ["The Wither Assault Shoulder Weapon (W.A.S.W.) is the last weapon you can make from Witherite. It has 2 different projectiles it can shoot: Wither Missiles and Wither Howitzers. The Wither Missiles shoot from just holding right click, and will damage whatever hit them with low cooldown. The Wither Howitzers are fired when you shift hold right click, they damage a bigger area and leave an area of wither effect that damages whatever walks in it. They have much longer cooldown though."]
+	quest.445C9117198936B6.title: "W.A.S.W. (Wither Assault Shoulder Weapon)"
 	quest.44688FC2E34FF09F.quest_desc: ["Minecraft already adds hundreds of Blocks, and Mods add hundreds more! But sometimes it is still not enough. \\n\\nWith some Mods we can change the Blocks we already have into ones with different shapes, designs, and even into entirely new Blocks!"]
 	quest.44688FC2E34FF09F.title: "Changing Blocks"
 	quest.446A37C7FCDACF84.quest_desc: ["Voidflame Coal is a new material added by JDT. Voidflame is aquired by performing Goo Spread on Blaze Ember Blocks using tier three goo or higher. Voidflame Coal Ore is affected by fortune."]
@@ -6849,9 +6967,9 @@
 	quest.45EC31812FB9934D.title: "Mechanical Pistons"
 	quest.45F83C2750F70F9B.quest_desc: ["Go ahead, put a Book in a Furnace and smelt it."]
 	quest.45F83C2750F70F9B.quest_subtitle: "Totally won't catch on fire..."
-	quest.45F83C2750F70F9B.title: "Making a Kitchen, with a Book"
-	quest.45FBEABEBA7CC09E.quest_desc: ["Who knows what happened to bring this &5City&r under the &9Water&r, but clearly it is! You'll easily notice it by the Stone Bricks sticking out of the &9Water&r. \\n\\nThe first and biggest room is the City Center, the giant dome! This is where the &5Altar of the Abyss&r is. \\n\\nOff of the rooms you'll find hallways which lead to other buildings in the &5City&r. Prisons holding &5Coralussus&r and even Treasure Rooms holding tons of precious Loot! \\n\\nAll around the &5City&r you will find its inhabitants, the &5Deeplings&r. "]
-	quest.45FBEABEBA7CC09E.title: "&5Sunken City&r: Home of &5&lThe Leviathan&r"
+	quest.45F83C2750F70F9B.title: "Making a Kitchen, with a book."
+	quest.45FBEABEBA7CC09E.quest_desc: ["&5The Sunken City&r is the Dungeon that houses the &5Deeplings&r, &5Coralssus&r, and &5The Leviathan&r. It spawns... well in Oceans. It's big and made of Stone Bricks. Once you get through it's defenses you'll find the Altar of Abyss which brings us to..."]
+	quest.45FBEABEBA7CC09E.title: "&5Sunken City&r: Home of &5The Leviathan&r"
 	quest.45FF08E4DB6F7F0E.quest_desc: ["An upgraded crafter that holds more patterns and has an increased crafting speed."]
 	quest.45FF08E4DB6F7F0E.title: "Iron Crafter"
 	quest.460A8F17F3ED6CAF.quest_desc: ["There comes a point in any playthrough of a large modpack where even the highest standard tier of storage cell doesn't cut it for the amount of items and resources that you may be accumulating.\\n\\nThis is where the &dMEGA Cells&f add-on comes in, extending the available tiers of storage into the megabyte territory. The first of these new tiers is given by the &b1M MEGA Storage Component&f, providing 1024 &okilo&rbytes, or &e1048576&f bytes, of storage."]
@@ -6863,8 +6981,6 @@
 	]
 	quest.461C8F1E88AA58D9.quest_subtitle: "32,000mb"
 	quest.462C1F75A2FB9F02.quest_subtitle: "Where's Willy?"
-	quest.462D173D576A8D91.quest_desc: ["&eAncient Metal&r is a Drop from pretty much everything within the &eCursed Pyramid&r! \\n\\nLike other Ingots it can be Crafted from Nuggets or Blocks and vice versa. \\n\\nYou can use it to make &eBone Reptile Armor&r or the &eAncient Spear&r."]
-	quest.462D173D576A8D91.title: "&eAncient Metal"
 	quest.4632DA3CE9D95064.quest_desc: ["Platinum Group Sludge will process down into a bunch of great resources that will help you moving forward."]
 	quest.4632DA3CE9D95064.quest_subtitle: "Money! *Mister Krabs*"
 	quest.464110726B823072.quest_desc: [
@@ -6891,9 +7007,8 @@
 		"{image:atm:textures/questpics/forbidden/forbidden_tier2.png width:100 height:100 align:center}"
 	]
 	quest.46567ED894E9883C.title: "&e&lTier 3 &6Forge"
-	quest.465B08461B460DAC.quest_desc: ["&dEndermaptera&r live around the &dRuined Citadel&r. \\n\\nThey have 8 &4Hearts&r and only a basic attack of gnawing at you. \\n\\nIf they gnaw at you too much they might break their jaws, to which they won't drop on death anymore. \\n\\nSo make sure to kill them quickly if you want those &dVoid Jaws&r!"]
-	quest.465B08461B460DAC.quest_subtitle: "End Cockroaches"
-	quest.465B08461B460DAC.title: "&dEndermaptera"
+	quest.465B08461B460DAC.quest_desc: ["&dEndermaptera&r are the cockroaches of the End. They live in and around the &dRuined Citadel&r. They have the least health of any Cataclysm mobs at 8 Hearts and only 1 attack. They will drop Void Jaws which can be used to craft Void Scatter Arrows. You can test what they do yourself."]
+	quest.465B08461B460DAC.title: "&dEndermaptera aka End Cockroaches&r"
 	quest.465F4502C4D5DCFE.quest_desc: [
 		"3 Vanadium dust + 1 Gallium dust on &aProgram 1&r makes this stuff"
 		""
@@ -6931,8 +7046,8 @@
 	quest.46B515C90C13A72F.title: "&2Resource Generation&r"
 	quest.46BE62C20C720D10.quest_desc: ["Makes Endermen not get angry at you like Carved Pumpkins."]
 	quest.46BE62C20C720D10.quest_subtitle: "Max: 1"
-	quest.46CC8E7ED59F51D2.quest_desc: ["&5Tidal Claws&r are a confirmed drop from &5&lThe Leviathan&r. \\n\\nIt has two modes, attack and grapple. Attack is with Left Click, Grapple is with Right Click. \\n\\nWhen you use its attack it will launch the claw and go through max of 5 mobs. Dealing damage and giving &5Abyssal Curse&r which will continue to damage them. \\n\\nThe grapple instead will latch on to whatever is in range and pull you toward it. \\n\\nThere's no durability so enjoy it forever!"]
-	quest.46CC8E7ED59F51D2.title: "&5Tidal Claws"
+	quest.46CC8E7ED59F51D2.quest_desc: ["Tidal Claws are a confirmed drop from &5The Leviathan&r. It has two modes, attack and grapple. Attack is with left click, grapple is with right click. When you use its attack it will launch the claw and go through max of 5 mobs. Dealing damage and giving abyssal curse which will continue to damage them. The grapple does similar but will latch on to whatever is in range and pull you toward it. There's no durability so enjoy it forever!"]
+	quest.46CC8E7ED59F51D2.title: "Tidal Claws"
 	quest.46D756F4DC6CC894.title: "&dNetherite Backpack"
 	quest.46DCB235D3FEDA61.quest_desc: ["Similar to Iron Tools just all of these slow down whoever is hit by them. \\n\\nWell besides the Hoe, but do you really care about a simple hoe?"]
 	quest.46DCB235D3FEDA61.title: "&bFroststeel&r Tools"
@@ -7035,8 +7150,15 @@
 	quest.47764EFC822E462A.title: "A Cow in a Jar"
 	quest.47768B1FFD57D56E.quest_desc: ["Don't you just hate &4Redstone&r having to be wired to everywhere? If we can have Wireless FE why not Wireless &4Redstone&r? Finally we can thanks to &c&lLaserIO&r. You can Input a &4Redstone Signal&r with the &4Card&r then use an &4Output Card&r to Output the &4Signal&r somewhere else!"]
 	quest.47768B1FFD57D56E.title: "&4Redstone Card"
-	quest.477B411F84342EEA.quest_desc: ["Mekanism is one of the best mods for energy storage, especially in the early game.\\n\\nThe Basic Energy Cube is easy to configure, easy to craft, and stores a lot of power. It can also be upgraded, and can charge items inside of the interface!\\n\\nTo learn more about upgrading the Energy Cube as well as the mod, head over to the &aMekanism&r quest chapter!"]
-	quest.477B411F84342EEA.title: "&9Mekanism: &aEnergy Cubes"
+	quest.477B411F84342EEA.quest_desc: [
+		"Mekanism is one of the best mods for energy storage, especially in the early game. "
+		""
+		"The Basic Energy Cube is easy to configure, easy to craft, and stores a lot of power. It can also be upgraded, and can charge items inside of the interface! "
+		""
+		"To learn more about upgrading the Energy Cube as well as the mod, head over to the &aMekanism&r questline!"
+	]
+	quest.477B411F84342EEA.quest_subtitle: "Mekanism"
+	quest.477B411F84342EEA.title: "Mekanism's Energy Cubes"
 	quest.478352E24CE1F45F.quest_desc: ["Allows the Mana Bursts to launch festive fireworks when they hit a block."]
 	quest.4785659E5022FEE7.quest_desc: [
 		"Just like a car, you can't fuel a Rocket off of hopes and dreams. But how do we get fuel?"
@@ -7149,9 +7271,15 @@
 	quest.48C68664319B0294.quest_desc: ["To obtain this special Spell Book you'll need to slay the &4&lDead King&r! \\n\\nIt has 10 &3Spell&r Slots but 4 are taken up already. &4Blood Slash&r, &4Blood Step&r, &4Ray of Siphoning&r, and &4Blaze Storm&r come on it already and can't be taken off."]
 	quest.48C68664319B0294.title: "Necronomicom"
 	quest.48D358470A019E7A.title: "Tier 1 Starlight Charger Catalyst"
-	quest.48DC9E8E9D21A2FA.quest_desc: ["Mekanism provides several ways to make power using renewable resources.\\n\\nThe &9Solar Generators&r harness the power of the Sun to provide basic power needs. It does not work during the night, and must have access to the sky. Glass is okay.\\n\\nThe &9Wind Generator&r provides power via the wind. Unless you've figured out a way for your character to manually spin this, the speed it spins is based off of the Y lvl it is placed at. It also needs direct access to the sky without any blocks above it."]
-	quest.48DC9E8E9D21A2FA.quest_subtitle: "The Power of the Sun..."
-	quest.48DC9E8E9D21A2FA.title: "&9Mekanism: &aRenewable Energy"
+	quest.48DC9E8E9D21A2FA.quest_desc: [
+		"Mekanism provides several ways to make power using renewable resources. "
+		""
+		"The &9Solar Generators&r harness the power of the sun to provide basic power needs. It does not work during the night, and must have access to the sky. Glass is okay. "
+		""
+		"The &9Wind Generator&r provides power via the wind. Unless you've figured out a way for your character to manually spin this, the speed it spins is based off of the Y lvl it is placed at. It also needs direct access to the sky without any blocks above it."
+	]
+	quest.48DC9E8E9D21A2FA.quest_subtitle: "Using the Sun"
+	quest.48DC9E8E9D21A2FA.title: "Mekanism: Renewable Energy"
 	quest.48EA6D9923E38B71.quest_desc: ["&n&5Casings&r are used as a crafting ingredient for most blocks."]
 	quest.48EE6C807C1668D4.quest_desc: ["If you need Wires to go either farther or connect to more places, you might need a Connector Node. \\n\\nSimple as that!"]
 	quest.48EE6C807C1668D4.title: "Wires go here, Wires go there"
@@ -7304,6 +7432,7 @@
 	]
 	quest.4AAB3899F530CC19.quest_desc: ["Chutes can take &eItems&r (and some Entities) and drop them without worry of despawning! \\n\\nThey also drop &eItems&r pretty darn quickly. \\n\\nYou can use the &6Engineer's Hammer&r to make a Chute curve to toss the &eItems&r onto a &eBelt&r!"]
 	quest.4AAB3899F530CC19.quest_subtitle: "No Ladders?"
+	quest.4AAB3899F530CC19.title: "Chutes"
 	quest.4AAF27F0C27FBDB3.quest_desc: [
 		"Hydrogen, like chlorine, can come from many sources"
 		""
@@ -7311,9 +7440,12 @@
 		""
 		"Both water and salt water are good sources of hydrogen, and salt water comes with the added benefit of giving you chlorine too!"
 	]
-	quest.4AB0DD227471FDBF.quest_desc: ["This chapter is dedicated to all things power related!\\n\\nHere you'll find the basic ways to generate, store, and transfer power."]
-	quest.4AB0DD227471FDBF.quest_subtitle: "All The Power!"
-	quest.4AB0DD227471FDBF.title: "&cBasic Power"
+	quest.4AB0DD227471FDBF.quest_desc: [
+		"This chapter is dedicated to all things power related! "
+		""
+		"In this section, you'll find the basic ways to generate, store, and transfer power."
+	]
+	quest.4AB0DD227471FDBF.title: "All Things Power!"
 	quest.4ABF0727AA569DD9.quest_desc: [
 		"To fuel our Fusion Reactor, we'll need to create two different gases, this one being &cDeuterium&r."
 		""
@@ -7366,7 +7498,7 @@
 		"- Extinguish"
 		"- Elytra"
 	]
-	quest.4B2146C9527C54E7.quest_desc: ["Obviously now that you are in Chapter 2, you have beaten &2&lVanilla Minecraft&r! \\n\\nBy now you should have &5Netherite&r and have killed all the bosses &2&lMinecraft&r has. So what's next? \\n\\n&6&lAllthemodium&r is what's next! In order to start getting &6Allthemodium&r though you will need &5Netherite&r. Let's start there!"]
+	quest.4B2146C9527C54E7.quest_desc: ["Obviously now that you are in Chapter 2, you have beaten &2&lVanilla Minecraft&r! \\n\\nBy now you should have &5Netherite&r and have killed all the bosses &2&lMinecraft&r has. So what's next? \\n\\n&6&lAllTheModium&r is what's next! In order to start getting &6AllTheModium&r though you will need &5Netherite&r. Let's start there!"]
 	quest.4B2146C9527C54E7.title: "&6&lAllthemodium"
 	quest.4B3F20E5C7E3BCFB.quest_desc: ["Primal Coal is a new material added by JDT. Primal Coal is aquired by performing Goo Spread on Coal Blocks using tier one goo or higher. Primal Coal Ore is affected by fortune."]
 	quest.4B42D962FE910CB3.quest_desc: ["With this added on to your &d&lRevolver&r, your Bullets will give the Mobs you hit the Stunned Effect."]
@@ -7407,8 +7539,7 @@
 	]
 	quest.4B82B3DAB03C1729.quest_subtitle: "Liquid Enriched Naquadah"
 	quest.4B90B3B38E08A218.quest_desc: ["The Steel Ingot. This little thing completely warped human history around it. You can make it in many different ways. Some legends even say there are special bees which can produce it..."]
-	quest.4B90B3B38E08A218.quest_subtitle: "The Most Important Ingot"
-	quest.4B90B3B38E08A218.title: "Steel"
+	quest.4B90B3B38E08A218.title: "The Most Important Ingot"
 	quest.4B95D48D7525FFAD.quest_desc: ["It's time to go to the &2Swamps&r! In the &2Swamps&r, you'll find an odd-looking hill with an entrance on top. This is the &cMinoshroom Labyrinth&r!\\n\\nInside, you'll fight several new enemies that can drop &eMaze Map Focus&r. This is needed to make a &eMaze Map&r.\\n\\nThis is a special map that will map your way around the &cMinoshroom Labyrinth&r. Minimaps have no power here.\\n\\nYou can also find several loot rooms with special loot for the Maze!"]
 	quest.4B95D48D7525FFAD.quest_subtitle: "Where's Shrek?"
 	quest.4B95D48D7525FFAD.title: "&2To the Swamps!"
@@ -7469,7 +7600,7 @@
 		"You'll typically want to mass produce these, and the way to do so is to make a &bFluix Crystal&f by throwing &eNether Quartz&f, &e&oCharged&r&e Certus quartz&r and &eRedstone&f together in a pool of water. This will give you a &eFluix Crystal&r which you can turn to dust in an Inscriber."
 	]
 	quest.4BF0BB763BFFACF0.title: "Fluix"
-	quest.4BF5EB050EC14C80.quest_desc: ["&4The Watchers&r... well they watch the &4Ancient Factory&r. They'll attack anything they see (Player wise) with their 'fricken laser beams!' and Blades if they are close enough. \\n\\nThey have 12 and a half &4Hearts&r, can fly, and are weak to EMP attacks as well. \\n\\nLike &4The Prowler&r they drop redstone and iron on death."]
+	quest.4BF5EB050EC14C80.quest_desc: ["&4The Watchers&r... well they watch the &4Ancient Factory&r. They'll attack anything they see with their 'fricken laser beams!'. They have 12 and a half hearts, can fly, and are weak to EMP attacks as well. Like &4The Prowler&r they drop redstone and iron on death."]
 	quest.4BF5EB050EC14C80.title: "&4The Watchers&r"
 	quest.4C0302FF4F63B52E.quest_desc: [
 		"If you want the ATM bees, it takes a lot of capturing and breeding and feeding."
@@ -7567,6 +7698,8 @@
 		""
 		"&aOak Saplings&r convert to &9Oak Saplings&r but they are not the same. When grown, these will look exactly like a regular Oak tree. However, under the effects of the &bThird Eye&r, you will be able to harvest the Otherworld variant."
 		""
+		"If you have trouble collecting the logs (if they turn into regular Oak logs even with &bThird Eye&r), try collecting them from the top."
+		""
 		"&eDiamonds&r will turn into &dSpirit Attuned Gems&r which are used in several recipes we'll need later down the road."
 	]
 	quest.4C873491F6F0FFAF.title: "&dSpiritfire&r Conversions"
@@ -7582,8 +7715,6 @@
 		"{image:atm:textures/questpics/iron_spells/spells_outfit_electromancer.png width:50 height:100 align:center}"
 	]
 	quest.4CCA1E2AAA9AB9D9.title: "&5Electromancer Outfit"
-	quest.4CCEC13CC5A5772D.quest_desc: ["There's 3 Pets from &4&lCataclysm&r the &eModern Remnant&r, &5Baby Leviathan&r, and &4Netherite Ministrosity&r! \\n\\nBoth the &eModern Remnant&r and &4Netherite Ministrosity&r can be placed in Buckets. \\n\\nThe &5Baby Leviathan&r will need a Water Bucket."]
-	quest.4CCEC13CC5A5772D.title: "Here hold this!"
 	quest.4CD83943865018EA.quest_desc: [
 		"The &9Exporter&r is used to push items from your system into a block from your Network storage. "
 		""
@@ -7593,6 +7724,14 @@
 	]
 	quest.4CD83943865018EA.quest_subtitle: "Importing Items!"
 	quest.4CD83943865018EA.title: "Exporter"
+	quest.4CE571F942461909.quest_desc: [
+		"The Ritual Satchel is nice, but it takes a long time to place all the blocks. Now that you can perform the &cSevira's Permenant Confinement&r ritual, you can create the Artisanal Ritual Satchel!"
+		""
+		"The Artisanal Ritual Satchel functions nearly identically to the regular Ritual satchel, except it instantly places all the nessecary items for the ritual, and has the added ability to right-click on a golden bowl to erase all the chalk runes and collect all the other items (skulls, candles, and crystals) and return them to the satchel. "
+		""
+		"No, it doesn't restore the durability of the chalk."
+	]
+	quest.4CE571F942461909.title: "Tools of the Trade: Artisanal Ritual Satchel"
 	quest.4CE6CABCB2334C0E.quest_desc: ["We have used a bunch of chromium already. But we again need to call on this highly resistive and high hardness metal, except in its liquid form."]
 	quest.4CE6CABCB2334C0E.quest_subtitle: "Liquid Chromium"
 	quest.4CE6EB54B12EF6C5.quest_subtitle: "&f10 &cAttack Damage"
@@ -7637,8 +7776,8 @@
 	quest.4D562F5D72038083.quest_subtitle: "Alder + European Larch"
 	quest.4D62C62B523C69EC.quest_desc: ["The Generator generates FE using burnable fuels like Coal."]
 	quest.4D62C62B523C69EC.quest_subtitle: "Providing Energy!"
-	quest.4D644A9829C240CB.quest_desc: ["You like the &b&lIgnis'&r shield? Well you can make 1 of your own with &bIgnitium&r. \\n\\nThe &bBulwark of the Flame&r can be used like a normal Shield but also has a special effect. \\n\\nWhen Holding Right Click and Shift, letting go will let you charge at whatever is infront of you, like how goats do. \\n\\nWhatever gets hit will take Damage and if pinched against a wall will also get stunned. \\n\\nDefinitely nice to have around!"]
-	quest.4D644A9829C240CB.title: "&bBulwark of the Flame"
+	quest.4D644A9829C240CB.quest_desc: ["You like the &bIgnis'&r shield? Well you can make 1 of your own with Ignitium. The Bulwark of the Flame can be used like a normal shield but also has a special effect. When holding right click and shift, letting go will let you charge at whatever is infront of you, like how goats do. Whatever gets hit will take damage and if pinched against a wall will also get stunned. Definitely nice to have around!"]
+	quest.4D644A9829C240CB.title: "Bulwark of the Flame"
 	quest.4D6885EFA4EE272F.quest_desc: [
 		"You've been remembering to batch craft things, right?"
 		""
@@ -7648,14 +7787,11 @@
 	quest.4D7B6842B9F53459.quest_desc: ["The Effortless Ring gives you a speed boost and step height!"]
 	quest.4D7D4C718837BCA5.quest_desc: ["The main part of the recipe for the Miniature Nether Portal is the &3Hellshelf of Masterful Sight&r. Usually it is used to see what Enchantments you'll get but we're here for the &6&lATM Star&r not for Enchantments. \\n\\nYou'll only need to enchant to an &4Infused Hellshelf&r which you can get from just a few Shelves. Then you need to craft with it to upgrade it even more! \\n\\nAfter that you can craft the Miniature Nether Portal, which no you can't walk through you're too big!"]
 	quest.4D8190E94851C546.quest_desc: ["Live &cWires&r (&cWires&r transporting &cEnergy&r are Live &cWires&r) will hurt you when using a &6&lSkyhook&r on them. \\n\\nUnless you Insulate your Grip!"]
-	quest.4D822D92492E1F53.quest_desc: ["The &3Aptrgangr&r is the mini boss within the &3Frosted Prison&r. \\n\\nThey have 800 &4Hearts&r and will attack you with their giant Axe. \\n\\nThey can swing their Axe like normal, or they might smash it on the ground near you. When they do that, lasers will spawn damaging all in their path. They also have a charge attack similar to the &eKobolediator&r! \\n\\nOn death they will drop Black Steel Ingots and Nuggets, and Rotten Flesh and Bones."]
-	quest.4D822D92492E1F53.title: "&3Aptrgangr"
 	quest.4D836B9D9E3B898F.quest_desc: [
 		"&2Stoneborns&r are the perfect mix of Villagers and Iron Golems. \\n\\nYou can trade with them by Right Clicking them. \\n\\nAnd they will fight off Hostile Mobs (or Players who hit them)."
 		"{image:atm:textures/questpics/undergarden/undergarden_stoneborn.png width:100 height:150 align:center}"
 	]
 	quest.4D836B9D9E3B898F.title: "&2Stoneborn&r"
-	quest.4D8B82FBA0FFD49E.quest_subtitle: "Tier: &63"
 	quest.4D8C9960BB675221.quest_desc: ["It has a funny name!"]
 	quest.4D98D2123BD5BFB3.quest_desc: [
 		"&lAbility Type:&r Passive"
@@ -7722,7 +7858,8 @@
 	]
 	quest.4DE719FC2E4C69AB.quest_subtitle: "And so it begins"
 	quest.4DE719FC2E4C69AB.title: "The Steam Age"
-	quest.4DF23FC932F5EB7D.quest_subtitle: "Tier: &b4"
+	quest.4DF0D7B85065ADC9.quest_subtitle: "Hack and slash!"
+	quest.4DF0D7B85065ADC9.title: "Tools of the Trade: Butcher's Knife"
 	quest.4DF683461225690F.quest_desc: ["{image:atm:textures/questpics/basicarmor/armor_iron.png width:100 height:150 align:center}"]
 	quest.4DF683461225690F.title: "&7Iron&r"
 	quest.4DF7E2149F4BD8CC.quest_desc: ["To insert the desired potion, just right click with the &2Primed Pendant&r in hand to open its inventory."]
@@ -7757,8 +7894,6 @@
 	quest.4E28B67554CBDAB7.quest_desc: ["Second in damage of all Swords. The first in damage does Infinite, and there's no competing with Infinite."]
 	quest.4E28B67554CBDAB7.title: "&6Allthemodium &5Alloy &3Sword"
 	quest.4E297778DCEEC963.quest_desc: ["Advanced Heatsinks are our only &5&lRailgun&r exclusive Upgrades. \\n\\nIt will make it so the &5&lRailgun&r charges up much faster!"]
-	quest.4E2C589C7638390F.quest_desc: ["The &3Cursed Bow&r works similar to a Bow with the Multishot Enchantment! \\n\\nWith normal Arrows, it will shoot 3 at a time! With special Arrows it will only shoot 2. \\n\\nI wonder if you can Enchant it with Multishot as well?"]
-	quest.4E2C589C7638390F.title: "&3Cursed Bow"
 	quest.4E3355FDCB65BB63.quest_desc: ["&aEvokers&r are known as being a powerful and deadly Miniboss of Minecraft. So of course &lIron&r added an even more powerful and deadly version! And yes this &eBook&r is a rare drop from both! \\n\\nIt has 10 Spell Slots but 3 are occupied. &aFang Strike&r, &aFang Ward&r, and &aVex Swarm&r all come with the &eBook&r and can not be moved. \\n\\nAlso gives a boost to &a&lEvocation&r!"]
 	quest.4E3355FDCB65BB63.title: "&aGrimore of Evokation"
 	quest.4E384F9FEF629386.quest_desc: [
@@ -7858,8 +7993,14 @@
 	quest.4EDD96EB60EF5814.quest_desc: ["If you're wondering if it is worth making this upgrade, the answer is yes.\\n\\nThis version can be used to add extra heat to Thermal Evaporation Plants."]
 	quest.4EDD96EB60EF5814.quest_subtitle: "Generates about 410FE/t"
 	quest.4EE482B9D61B5933.quest_desc: ["Of course &2Vanilla&r isn't our max, there's much more and much rarer in Modded! "]
-	quest.4EEAB467C722ECE7.quest_desc: ["These are simple pipes that can be upgraded with Pipe Upgrades.\\\\n\\\\nTo 'extract' power from a block, place the pipe down next to the block, and on the side that is connected, shift+right-click with the pipe wrench to set the pipe to extract.\\\\n\\\\nThe &e&lPipez&r mod also offers ways to transport items, gases, and liquids as well! Or you can make an All-In-One Pipe called the &aUniversal Pipe&r.\\n\\nOther Wrenches work with &e&lPipez&r as well!"]
-	quest.4EEAB467C722ECE7.title: "&9Pipez: &aEnergy Pipes"
+	quest.4EEAB467C722ECE7.quest_desc: [
+		"These are simple pipes that can be upgraded with Pipe Upgrades. "
+		""
+		"To 'extract' power from a block, place the pipe down next to the block, and on the side that is connected, shift+right-click with the pipe wrench to set the pipe to extract. "
+		""
+		"The &9Pipez&r mod also offers ways to transport items, gases, and liquids as well! Or you can make an All-In-One Pipe called the &aUniversal Pipe&r. "
+	]
+	quest.4EEAB467C722ECE7.title: "&9Using Pipez:&r &aEnergy Pipe&r"
 	quest.4EEFECB9D741B371.quest_desc: [
 		"As previously stated, alloys are going to continue to increase in complexity, as it should be expected."
 		""
@@ -7892,6 +8033,8 @@
 	quest.4F1FFC02F4EAA2E6.title: "Tier: &4Nitro"
 	quest.4F2BBB75E5B5EAD8.title: "Salts Vein"
 	quest.4F35D04721DFC9FF.quest_desc: [
+		"The first type of Ritual we'll be performing is the &9Summoning Ritual&r. These rituals are used to summon different types of useful Demons to assist you in crushing, smelting, and tons of other things as you get to higher tiers of rituals."
+		""
 		"For our first Ritual, we want to summon a &aFoliot Crusher&r Demon. This Demon will crush items for us, which is something we'll need to make some of the higher level Chalks!"
 		""
 		"To start with, combine your Unbound Book with your &aDictionary of Spirits&r in a crafting table. This will bind a Demon to the book, which is what we'll need for the Ritual."
@@ -7906,6 +8049,7 @@
 		""
 		"{image:atm:textures/questpics/occultism/aviarcircle_v2.png width:200 height:200 align:1}"
 	]
+	quest.4F35D04721DFC9FF.quest_subtitle: "Aviar's Circle"
 	quest.4F35D04721DFC9FF.title: "&bOur First &dRitual"
 	quest.4F3B4990BE6C2A4A.quest_desc: [
 		"&7Scintlings&r are little innocent Slugs found everywhere in the &2&lUndergarden&r. \\n\\nThey act like Snow Golems as in they leave a trail wherever they walk. Just this one is more Gooey... \\n\\nOn death they drop Scintling Goo, but you can just farm it from their trails, so why kill them!"
@@ -7956,18 +8100,17 @@
 		""
 		"It will show things as rotation speed and stress."
 	]
-	quest.4F9932477EDDCB8E.quest_desc: ["The Advanced Portal Gun is the upgraded version of the Portal Gun that requres both power and portal fluid to operate. Unlike the Portal Gun the Adavanced Portal Gun allows the player to teleport between locations that have been encoded. Using \"V\" (default keybind) the menu used to encode and select desinations for teleportion."]
+	quest.4F9932477EDDCB8E.quest_desc: ["The Advanced Portal Gun is the upgrades version of the Portal Gun that requres both power and portal fluid to operate. Unlike the Portal Gun the Adavanced Portal Gun allows the player to teleport between locations that have been encoded. Using \"V\" (default keybind) the menu used to encode and select desinations for teleportion."]
 	quest.4F9D6109EEA5D26A.quest_desc: ["Breaking &eGolden Leaves&r has a high chance to drop a &eGold Leaf&r, which is needed for &eGold Powder&r. "]
 	quest.4F9D6109EEA5D26A.quest_subtitle: "Aura with Fireflies"
 	quest.4F9D6109EEA5D26A.title: "&eGold Leaves"
-	quest.4FA156C383C9C438.quest_desc: ["&eKoboletons&r are mini Dino Skeletons who serve the &e&lAncient Remnant&r. \\n\\nThey only have 12 and a half &4Hearts&r and attack you with their Khopesh. \\n\\nThey can drop their weapon, along with their Bones, and Ancient Metal Nuggets."]
-	quest.4FA156C383C9C438.quest_subtitle: "Mini Dinos!"
-	quest.4FA156C383C9C438.title: "&eKoboletons"
+	quest.4FA156C383C9C438.quest_desc: ["&eKoboletons&r are mini Dino Skeletons who serve the &eAncient Remnant&r. They only have 12 and a half hearts and 1 attack. They also drop their bones but they only make bonemeal. They're also pretty cute when not attacking you!"]
+	quest.4FA156C383C9C438.title: "&eKoboletons aka Mini Dinos&r"
 	quest.4FA5192164E4A427.quest_desc: ["Fluid doesn't stack like Items do, so its upgrade is a little different. Still moves more just at a different rate."]
 	quest.4FA6BEA4E646B742.quest_desc: ["Before we can start building our reactor, we'll need to smelt some Coal or Charcoal to create &9Graphite Ingots&r.\\n\\nGraphite, coupled with Iron, is one of the main materials when making a Reactor."]
 	quest.4FA6BEA4E646B742.quest_subtitle: "Hardened Carbon"
 	quest.4FA6BEA4E646B742.title: "Graphite for Casings"
-	quest.4FA7774D89171BB3.quest_desc: ["Want another pet from &4&lCataclysm&r? Then the Remnant Skull is what you need! \\n\\nIt's a confirmed drop from the &eAncient Remnant&r and when used will spawn a Modern Revenant. \\n\\nThis one is much smaller and nicer than the &eAncient&r one. You can tame it by feeding it a Sniffer Egg then it will act like a dog. \\n\\nAttacking what attacks you or what you attack. It also has 3 modes: follow, wander, and stay. Follow it will... well follow you. Wander will have it walking around a certain area. And stay will have it lay down in one spot. \\n\\nThey have 2700 &4Hearts&r and I've learned you can feed them &eKoboleton Bones&r to heal them! \\n\\nEnjoy your new dino!"]
+	quest.4FA7774D89171BB3.quest_desc: ["Want another pet from Cataclysm? Then the Remnant Skull is what you need. It's a confirmed drop from the &eAncient Remnant&r and when used will spawn a Modern Revenant. This one is much smaller and nicer than the &eAncient&r one though. You can tame it by feeding it a Sniffer Egg then it will act like a dog. Attacking what attacks you or what you attack. It also has 3 modes: follow, wander, and stay. Follow it will... well follow you. Wander will have it walking around a certain area. And stay will have it lay down in one spot. Enjoy your new dino!"]
 	quest.4FA7774D89171BB3.title: "What shall not be named for my crashing reasons"
 	quest.4FBAB3A0FBF8CE2F.quest_desc: [
 		"Why worry about what's being moved when you can just move everything! &5Universal Pipez&r are even less discriminatory than &cEnergy Pipez&r. They can move &eItems&r, &bFluids&r, or &cEnergy&r. "
@@ -8017,6 +8160,7 @@
 	quest.50429F57480F44DA.title: "&cThermal Springstone Armor"
 	quest.504752A1C9EFED76.quest_subtitle: "Citron + Wild Cherry"
 	quest.5047792C6EF6D2AD.quest_desc: ["When Bio Fuel is combined with Water and Hydrogen in a &aPressurized Reaction Chamber&r it creates Substrates. It also creates Ethylene as a by-product.\\n\\nThese are needed to create HDPE pellets, which are used for end-game crafts like the Meka-suit."]
+	quest.5047792C6EF6D2AD.title: "Substrates"
 	quest.504ADBD7E2476827.quest_desc: ["Allows Mana Bursts to bounce off of walls."]
 	quest.504DEE88DFDBD380.quest_desc: [
 		"Similar to the steam age, this will turn solid metals into their fluid form"
@@ -8068,11 +8212,8 @@
 	quest.50B127137AA9E660.quest_desc: ["Finally &6Copper&r has a real use!"]
 	quest.50B127137AA9E660.quest_subtitle: "13"
 	quest.50B127137AA9E660.title: "&6Copper Armor"
-	quest.50C9CB8FB16E453D.quest_desc: [
-		"The &bBurning Arena&r is a giant Colosseum-esque Arena within the &4Nether&r. \\nYou'll arrive at the peaceful but hot 1st floor, on the 2nd floor you'll find &b|gnited Revenants&r which you'll need to kill for &bBurning Ashes&r. \\n\\nWhich can then be used on the 3rd floor, in the Altar to summon the &b&lIgnis&r! \\n\\nOh yeah and if you're looking for Loot, check above the 3rd floor!"
-		"{image:atm:textures/questpics/cataclysm/cataclysm_arena.png width:200 height:100 align:center}"
-	]
-	quest.50C9CB8FB16E453D.title: "&bBurning Arena&r: Home of the &b&lIgnis&r"
+	quest.50C9CB8FB16E453D.quest_desc: ["Don't worry you won't mistake this one for a Bastion. The &bBurning Arena&r is quite empty besides the &bIgnited Revenants&r and the Altar of Flame. Kill the &bIgnited Revenant&r to get the..."]
+	quest.50C9CB8FB16E453D.title: "&bBurning Arena&r: Home of the &bIgnis&r"
 	quest.50EEDDDE129D2742.quest_desc: ["{atm9.quest.enchant.desc.hellshelf}"]
 	quest.50EEDDDE129D2742.title: "{atm9.quest.enchant.hellshelf}"
 	quest.50F1C4521D282C60.quest_desc: ["The Bulwark are the heavy units of these militants. \\n\\nThey have 12 Hearts with 18 Armor Points! \\n\\nTheir weapon is the &b&lChemthrower&r with a &8&lHeavy Plated Shield&r in the Offhand. \\n\\nIf you somehow kill one you will get &aEmeralds&r and Masterwork Shader Bags!"]
@@ -8208,7 +8349,6 @@
 	quest.520EFA7F446AFBF2.quest_desc: ["&3Lubricant&r can be used to make Drill Bits."]
 	quest.520EFA7F446AFBF2.quest_subtitle: "Producing Lube!"
 	quest.520EFA7F446AFBF2.title: "Lubricant"
-	quest.5210DC0095996B62.quest_subtitle: "Tier: &b4"
 	quest.5212A4D67B1851EF.quest_desc: ["These fun little &7&lKeys&r, act similar to Wolverine Claws, which they look very similar to! \\n\\nWhen holding them a Circle will appear around a Target, use Left Click to TP onto the Target and Hit them! \\n\\nThis can be used for a huge distance! (Over a hundred Blocks is what I found). \\n\\nIt does around same Damage as an Iron Sword."]
 	quest.5212A4D67B1851EF.title: "&7&lKeys of Proximity Projection"
 	quest.521656D425E2FDBA.quest_desc: ["Goes even faster than Tier II."]
@@ -8305,12 +8445,9 @@
 	quest.5303509A1C2B1CCD.quest_desc: ["The &3Pneumatic Jackhammer&r uses pressure to mine, it can be upgraded to be amazing!"]
 	quest.5303509A1C2B1CCD.quest_subtitle: "Sorry Jack!"
 	quest.5311404799117060.quest_subtitle: "Tier: &b4"
-	quest.53154550397E9704.quest_desc: [
-		"The &c&lNetherite Monstrosity&r lives up to his name, he's a beast of &cNetherite &fand &cLava&r. \\n\\nHe can have up to 48,000 &4Hearts&r but when I first met him he was only at around 9,500 &4Hearts&r. He will regenerate &4Hearts&r when no Player is nearby.\\n\\nHe has a few Melee attacks like smacking you with his massive arms and ground pounding on you. He can also throw blocks in the Air causing a Shockwave. \\n\\nIf you get farther from him he might charge at you or leap at you. Honestly he looks like he weighs 100 Tons, I wouldn't want him doing either to me! \\n\\nThe worst of his attacks are definitely the Ranged ones though... he can shoot &cMagma Balls&r at you and where they drop, &cLava&r will spawn. He can also shoot &cFireballs&r from his hands, these will cause &cFire Spouts&r to come out of the ground."
-		"{image:atm:textures/questpics/cataclysm/cataclysm_monstrosity.png width:100 height:100 align:center}"
-	]
-	quest.53154550397E9704.title: "&c&lNetherite Monstrosity&r"
-	quest.5316DF321B45D2CA.quest_desc: ["Welcome to &dOccultism&r!\\n\\nThis mod aimes to help the player in many different ways by enlisting the help of &c&mDemons&r &bSpirits&r! Don't worry, they are friendly. &oMostly&r.\\n\\nTo get started, you'll need to get some &aDemon's Fruit Seeds&r."]
+	quest.53154550397E9704.quest_desc: ["The &cNetherite Monstrosity&r lives up to his name, he's a beast of Netherite and lava and has 15000 Hearts. It has very basic attacks, if you get close he'll ground slam you, if you're farther he'll shoot lava at you which creates lava source blocks. He only has 1 stage, kinda boring. When killed he'll drop the Infernal Forge, Monstrous Horn, and maybe a music disc: vs Titans."]
+	quest.53154550397E9704.title: "&cNetherite Monstrosity&r"
+	quest.5316DF321B45D2CA.quest_desc: ["Welcome to &dOccultism&r!\\n\\nThis mod aimes to help the player in many different ways by enlisting the help of &c&mDemons&r &bSpirits&r! Don't worry, most of them are friendly. &oMost&r.\\n\\nTo get started, you'll need to get some &aDemon's Fruit Seeds&r."]
 	quest.5316DF321B45D2CA.title: "&dDreaming of &cDemons"
 	quest.531E3FF1F2865C67.quest_subtitle: "For Transferring Heat"
 	quest.532229D285CA4858.quest_desc: [
@@ -8409,10 +8546,16 @@
 		"Similar to the overworld->Nether, there is a block ratio of 1:50 for the End->Beyond"
 	]
 	quest.53DD784E75965947.title: "The Beyond"
+	quest.53DEA3DFEDC4809E.quest_desc: [
+		"Don't worry, this is the last of the Abras series of rituals. It is used to summon a &9Marid&r demon, but even though it uses Red Chalk, it's not powerful enough to &9bind&r the demon. This means that, unfortunately, you're going to have to fight it."
+		""
+		"By the way, this ritual uses a trident as a sacrifice, which is confusing because most sacrifices are living creatures. So instead of killing a mob on top of the completed ritual circle, you simply throw the trident at the center bowl to start the ritual."
+	]
+	quest.53DEA3DFEDC4809E.quest_subtitle: "Is it a bird? Is it a plane? No, it's an unbound &9Marid&r!"
+	quest.53DEA3DFEDC4809E.title: "&4Abras' Fortified Conjure"
 	quest.53E2BEA626B35BFC.quest_desc: ["Quite expensive recipe but most definitely worth it! \\n\\nUsing the &6Spectral &4Eye&r will give you the &4Spectral Vision Effect&r. This Effect gives &eGlowing&r to every Mob within a 100 Block radius in every direction! \\n\\nPerfect for finding structures underground, or Bastions in the &c&lNether&r, or even finding your friends hidden Axolotl farm!"]
 	quest.53E2BEA626B35BFC.quest_subtitle: "Very popular in ATM6!"
 	quest.53E2BEA626B35BFC.title: "&6Spectral &4Eye &7Amulet"
-	quest.53E5A8F2B05C2989.quest_subtitle: "Tier: &63"
 	quest.53EC96FA0E7C4ED4.quest_desc: [
 		"Every Tech Mod needs &cEnergy&r, whether it's FE, RF or something else! &cEnergy Pipez&r don't discriminate, it just moves! \\n\\nSome Machines have strict IO ports for &cEnergy&r so make sure to check for those!"
 		"{image:atm:textures/questpics/logistics/pipez_energy.png width:200 height:50 align:center}"
@@ -8452,6 +8595,11 @@
 	quest.542C6D76B579886C.quest_desc: ["Using our Enchanting Apparatus structure, we'll want to craft our first seed, the &5Magebloom Seed&r. \\n\\nThis will be used to create us some magical clothing!"]
 	quest.5436157FDFC9633E.quest_desc: ["With the Infused &dPatrick &aStar&r, 5 &6Star Fragments&r, &5Corrupti Dust&r, &cMundabitur Dust&r, and the Lens of the &4Killer&r we can rebuild &6&lATM Stars&r, 100% automated! \\n\\nNow these &5Creative&r Items will be a breeze to craft!"]
 	quest.5436157FDFC9633E.title: "Fully Automated &6&lATM Star"
+	quest.54378277B8D28B1D.quest_desc: [
+		"An \"upgrade\" to the Rainbow Chalk, for those who don't like the rapid color-switching runes ruining their tediously crafted aesthetic. "
+		""
+		"Has the same function as the Rainbow Chalk, except all the runes will show up as white."
+	]
 	quest.543F00603790AD3E.quest_desc: ["The (Log) Stripper strips Logs automatically using Axes put in the machine."]
 	quest.543F00603790AD3E.quest_subtitle: "Please don't"
 	quest.543F00603790AD3E.title: "Stripping"
@@ -8665,7 +8813,11 @@
 	]
 	quest.56A5C102BDD74ED8.title: "Vibranium Ore"
 	quest.56B58CAFCB707565.quest_subtitle: "Tier: &63"
-	quest.56B6ABF3D6EA0D84.quest_desc: ["With our Plug set up, we can now tap into the power from our network. The &9Flux Point&r does exactly that. It points the power from your network to whatever block it is attached to, including Pipes or Cables, or just directly on machines!\\n\\nOnce you've placed your Point on the machine or block you want to power, right-click on it and select your network in the \"Network Selection\" tab. Just like the Plug, you can adjust how much power the Point pulls, priority level, etc."]
+	quest.56B6ABF3D6EA0D84.quest_desc: [
+		"With our plug set up, we can now tap into the power from our network. The &9Flux Point&r does exactly that. It points the power from your network to whatever block it is attached to, including pipes or cables, or just directly on machines! "
+		""
+		"Once you've placed your point on the machine or block you want to power, right click on it and select your network in the Network Selection tab. Just like the plug, you can adjust how much power it pulls, priority level, etc."
+	]
 	quest.56B6ABF3D6EA0D84.title: "Accessing Network Power"
 	quest.56B7CC072B8E9B48.quest_desc: [
 		"Sodium Hydroxide Dust is useful yet again! &eChemical React&r it with the Epichlorohydrin and Bisphenol A to make liquid Epoxy"
@@ -8685,10 +8837,12 @@
 	quest.56DA46DC82F6665D.quest_desc: ["The Wilden Chimera is a Boss added by Ars Nouveau and is needed for progressing through it. \\n\\nHe needs to be summoned through a ritual then fought!"]
 	quest.56DA46DC82F6665D.title: "Kill The Wilden Chimera"
 	quest.56E30438AE512475.quest_desc: ["Let's get these flames burning! \\n\\nThe Preheater is a very simple addition to the &l&4Improved Blast Furnace&r. \\n\\nSimply place them on the Left and Right of the &l&4Improved Blast Furnace&r. Then, connect power to the top of it and it will start speeding up the &l&4Improved Blast Furnace&r."]
+	quest.56EC79AF11B0869E.quest_desc: ["&9Xeovrenth Adjure&r is the maximum tier of &5Possession Rituals&r. It only has two uses: creating Cruelty Essence, the main ingredient in Brown Chalk, and creating an Iesnium Golem, which is basically just an Iron golem that's immortal and does more damage."]
+	quest.56EC79AF11B0869E.quest_subtitle: "Maximum Possession"
+	quest.56EC79AF11B0869E.title: "&9Xeovrenth Adjure"
 	quest.56FB82DEB944F758.quest_desc: ["Works like the &aMace of Distortion&r, except it causes an AoE explosion instead."]
 	quest.570223A03231DF8C.quest_desc: ["Overhauled Endermen is a similar Mod to Overhauled Creepers! Just with Endermen of course! \\n\\nYou'll find all these Endermen in all different Biomes and each are unique in their own ways! Some have different attacks, some drop different Pearls, and they all look different!"]
 	quest.570223A03231DF8C.title: "Overhauled Endermen"
-	quest.5703EDAFCF9E7719.quest_subtitle: "Tier: &63"
 	quest.57167FE67CFAC255.quest_subtitle: "Used to add Bees to a Filter"
 	quest.5716E84828EC0C23.quest_desc: ["Plastic Construction Bricks are Blocks made through &l&7PneumaticCraft: Repressurized&r. \\n\\nJust like their real life counter parts they hurt to step on! \\n\\nSo either wear Shoes or smooth down the Bricks."]
 	quest.5716E84828EC0C23.title: "Plastic Construction Bricks"
@@ -8883,7 +9037,7 @@
 	quest.589EB4602E3F9EEE.quest_desc: ["Tin Bees are made by breeding a Crystalline Bee with an Ashy Mining Bee."]
 	quest.589EB4602E3F9EEE.quest_subtitle: "Ashy Mining + Crystalline"
 	quest.589EB4602E3F9EEE.title: "Tin Bee"
-	quest.589F1D502F680075.quest_desc: ["Perfect for Pool Parties! \\n\\nBesides looking cute and funny the &dHelium Flamingo&r allows you to swim in Air. Yes you heard me! Swim... in... Air... \\n\\nWhen in the Air, like jumping, you can press CTRL to start Swimming in Air. You can move around just like in the Water: Swim up, Swim down, Swim all around!"]
+	quest.589F1D502F680075.quest_desc: ["Perfect for Pool Parties! \\n\\nBesides looking cute and funny the &dHelium Flamingo&r allows you to swim in Air. Yes you heard me! Swim... in... Air... \\n\\nWhen in the Air, like jumping, you can press Jump again to start Swimming in Air. You can move around just like in the Water: Swim up, Swim down, Swim all around!"]
 	quest.589F1D502F680075.quest_subtitle: "Belt"
 	quest.589F1D502F680075.title: "&dHelium Flamingo&r"
 	quest.589F47DE51213920.quest_desc: [
@@ -9006,7 +9160,7 @@
 		"- Lava Immunity"
 	]
 	quest.5A1DCD6C7F712A78.title: "Neptunium Fishing Rod"
-	quest.5A23107C363A209E.quest_subtitle: "Makes various End Materials"
+	quest.5A23107C363A209E.quest_desc: ["Makes various End materials."]
 	quest.5A26738AC904DC39.quest_desc: ["13 Spellslots!"]
 	quest.5A26738AC904DC39.title: "&6Allthemodium Spell Book"
 	quest.5A2908437EC43AC6.quest_subtitle: "Tier: &54"
@@ -9031,7 +9185,7 @@
 	quest.5A6670364ADE0858.quest_subtitle: "&f29 &cAttack Damage"
 	quest.5A6831E0BD2F6AB5.quest_desc: ["You'll need a lotta &8Dark Gems&r!"]
 	quest.5A6831E0BD2F6AB5.title: "2 &4Piercing Vengeance Focuses"
-	quest.5A6FF0D4BA894306.quest_desc: ["The poster child of &6&lForbidden \\& Arcanus&r, the &aEternal Stella&r. \\n\\nFor 1 &6Allthemodium&r Ingot, 3 &aXpetrified Orbs&r, and a &2Stellarite Piece&r we can make one of the most overpowered Items in this Modpack! \\n\\nYou can use the &aEternal Stella&r with an Item and an Apply Item Modifier to make Items lose their Durability. No, wait I mean lose their need for Durability! Basically Indestructible Items. \\n\\nThis can be used on almost every Item with Durability from &bDiamond Axes&r, to Fishing Rods, to even &eRefined Glowstone Armor&r! \\n\\nThere are some limitations, it only works with Items with Durability not uses: like Infusion Crystals or Energy: like Meka-Tool!"]
+	quest.5A6FF0D4BA894306.quest_desc: ["The poster child of &6&lForbidden \\& Arcanus&r, the &aEternal Stella&r. \\n\\nFor 1 &6AllTheModium&r Ingot, 3 &aXpetrified Orbs&r, and a &2Stellarite Piece&r we can make one of the most overpowered Items in this Modpack! \\n\\nYou can use the &aEternal Stella&r with an Item and an Apply Item Modifier to make Items lose their Durability. No, wait I mean lose their need for Durability! Basically Indestructible Items. \\n\\nThis can be used on almost every Item with Durability from &bDiamond Axes&r, to Fishing Rods, to even &eRefined Glowstone Armor&r! \\n\\nThere are some limitations, it only works with Items with Durability not uses: like Infusion Crystals or Energy: like Meka-Tool!"]
 	quest.5A6FF0D4BA894306.title: "&aEternal Stella"
 	quest.5A7FF6D0AED656DC.quest_desc: ["Decreases the amount of time that it takes for a Mana Burst to start losing its Mana, but will also decrease its rate of loss."]
 	quest.5A84A64CB3D3E6F5.quest_subtitle: "White Willow + Oak/Birch/Silver Lime"
@@ -9040,7 +9194,6 @@
 	quest.5A912903E09F664F.quest_desc: ["Tip: Use the Ritual Tablet on the brazier first, then right click with one of each of the Wilden mob drops, then activate the ritual to summon the Wilden Chimera."]
 	quest.5A912903E09F664F.title: "Summoning Wilden Chimera"
 	quest.5A94A2664BFDD7B9.quest_desc: ["Welcome to the Basic Storage Chapter!\\n\\nYou'll find all of the basic ways to store items without needing power, as well as useful items for your storage needs!"]
-	quest.5A94A2664BFDD7B9.title: "Basic Storage"
 	quest.5A955C0F53AED3ED.quest_desc: ["The &bChain of Souls&r works similar to a Grappling Hook. \\n\\nYou can Right Click for it to send a &bChain&r which will drag you toward the Block you shot it at. You can Right Click again to release it. Plus it has a Range of 90 Blocks give or take a few. \\n\\nTo make it you'll need a &bTrapped Soul&r, 2 &5Tenacious Vines&r, and a &9Tenacious Petal&r. \\n\\nThe first two you can get as drops from a &5Tangled Hatred&r while the last you'll need to kill a &9Lunar Monstrocity&r. "]
 	quest.5A955C0F53AED3ED.title: "&bChain of Souls"
 	quest.5A9C646718EE92C2.quest_desc: ["{image:atm:textures/questpics/basicarmor/armor_vibranium.png width:100 height:150 align:center}"]
@@ -9054,6 +9207,28 @@
 	quest.5AAF6CA41209B365.title: "&3Vibranium Tools"
 	quest.5AC1BE754210429E.quest_desc: ["If you want to create a team for you and your friends, use the command &a/ftbteams party create (name of team)&r to create the team!"]
 	quest.5AC497F76A086A5C.title: "&l&9Overworld Bounty:&r&e Witches"
+	quest.5ACE97EE75813006.quest_desc: [
+		"This quest is your main source of information on &dRituals&r. Here's the basics:"
+		""
+		"&lTiers of Rituals:&r"
+		""
+		"Rituals have (basically) four tiers based on how powerful the demon that you're invoking is. The first tier is &eFoliot&r, then &aDijini&r, &cAfrit&r, and &9Marid&r. Some rituals fall into in-between tiers, such as the &6Unbound Afrit&r tier."
+		""
+		"T&lypes of Rituals:&r"
+		""
+		"There are five main types of rituals, but we'll only need four for progression. The main three are &9Summoning Rituals&r, &5Possession Rituals&r, and &6Infusion Rituals&r. Each one will be explained the first time that they appear in this questbook. The fourth type of ritual is a sort of &dDemon-less&r &dRitual&r, meaning that it uses bits and pieces from all three types to preform a special action without the direct usage of a demon. "
+		""
+		"The fifth type, &eFamiliar Rituals&r, are not needed for progression. But they can still be summon some useful friends to help you out!"
+		""
+		"&lChalks:&r"
+		""
+		"There are two types of chalks: Foundation Chalks, and Colored Chalks."
+		""
+		"Foundation chalks are used in every single ritual, and each tier higher gets a shade darker, starting with white chalk and ending with black chalk. "
+		""
+		"Colored Chalks are the most commonly used, but the color of the chalk doesn't directly corelate to its power the same as Foundation Chalks."
+	]
+	quest.5ACE97EE75813006.title: "The Basics of Rituals"
 	quest.5AD09CCEEDC0B50F.quest_desc: ["Now these are super helpful, you should definitely check them out! \\n\\nThe actual Light Source is the Feral Flare Lantern. It will place invisible Light Sources around 20 Blocks or more around it. \\n\\nThe Mega Torch is different: it doesn't emit Light but it does Block all Hostile Mob spawns with 64 Blocks of it! Useful for those using Night Vision. \\n\\nThe Dread Lamp does the opposite, it blocks Passive Mob spawns in the same area."]
 	quest.5AD09CCEEDC0B50F.title: "&l&eTorchmaster&r"
 	quest.5AD33290313151D6.quest_desc: [
@@ -9064,6 +9239,17 @@
 	quest.5AD33290313151D6.quest_subtitle: "Liquid Americium"
 	quest.5AD80D3242DD3F60.quest_desc: ["One of the hardest materials to get in the mod!\\n\\nThis is also used to create the &6ATM Star&r!"]
 	quest.5AD80D3242DD3F60.title: "&dInsanite Block"
+	quest.5AE80FF518B1BBA6.quest_desc: [
+		"Tired of lugging around chalks, candles, skulls, and crystals? Just make a ritual satchel!"
+		""
+		"By sneak + right-clicking with the ritual satchel in your hand, you can fill it with all the materials you need to draw a ritual circle."
+		""
+		"Once you've loaded up the satchel, simply right-click any preview block to begin (slowly) automatically placing all the runes for the selected ritual. "
+		""
+		"If a piece of chalk inside the bag falls under 40% durability, the enchantment glint on this item will dissapear to signal that it may be time to repair or replace some of your chalks."
+	]
+	quest.5AE80FF518B1BBA6.quest_subtitle: "Pocket Ritual!"
+	quest.5AE80FF518B1BBA6.title: "Tools of the Trade: Ritual Satchel"
 	quest.5AEE86EB39FD4087.quest_desc: ["The &3Vortex Tube&r seperates pressure into hot and cold air. The cold air goes to the blue side and the hot air goes to the red side."]
 	quest.5AEE86EB39FD4087.quest_subtitle: "Still not RF..."
 	quest.5AEE86EB39FD4087.title: "Heat Production"
@@ -9121,9 +9307,9 @@
 	quest.5B95C5B5B3A9CB2E.title: "&dLoot Chests&r"
 	quest.5B9F933ECD6B24FD.quest_desc: ["Allows you to jump higher than with Tier II."]
 	quest.5B9F933ECD6B24FD.quest_subtitle: "Max: 1"
-	quest.5BA84F6282D9CAF1.quest_desc: ["&6Allthemodium Armor&r but with buffs to &e&lIron's Spells&r Spells!"]
+	quest.5BA84F6282D9CAF1.quest_desc: ["&6AllTheModium Armor&r but with buffs to &e&lIron's Spells&r Spells!"]
 	quest.5BA84F6282D9CAF1.quest_subtitle: "24"
-	quest.5BA84F6282D9CAF1.title: "&6Allthemodium Mage Outfit"
+	quest.5BA84F6282D9CAF1.title: "&6AllTheModium Mage Outfit"
 	quest.5BA986D7928BF09F.quest_desc: ["The Piglich is a Boss added by &6&lAllthemodium&r. \\n\\nHas he 1000 Hearts and currently has no attacks but trust me when he does they will be devastating! \\n\\nWhen killed he'll drop his Heart which will be needed for Alloys and the ATM Star! \\n\\n(Look into ways of farming them like with HNN or EnderIO!)"]
 	quest.5BA986D7928BF09F.title: "Piglich Boss"
 	quest.5BB7648DC10E1E08.quest_desc: ["Has 27 more filter slots and is 6x faster than the regular Exporter. Also has the Stack Upgrade integrated."]
@@ -9181,9 +9367,13 @@
 	quest.5C3FF43CF16BCF30.quest_desc: ["With Source Gems, you can get started crafting the various machines by creating &5Sourcestones&r."]
 	quest.5C3FF43CF16BCF30.quest_subtitle: "Formerly \"Arcane Stones\""
 	quest.5C3FF43CF16BCF30.title: "Sourcestone"
-	quest.5C47935A3B2877FF.quest_desc: ["Mekanism offers a nice looking Cable to transfer your power.\\\\n\\\\nIf the machine you are connecting to already pulls or pushes power, you will not need to configure the Cable. Otherwise, you'll need a &9Configurator&r to configure the Cable. Shift right-clicking will change the Cable to pull or push mode."]
+	quest.5C47935A3B2877FF.quest_desc: [
+		"Mekanism offers a nice looking cable to transfer your power. "
+		""
+		"If the machine you are connecting to already pulls or pushes power, you will not need to configure the cable. Otherwise, you'll need a &9Configurator&r to configure the pipe. Shift+right-clicking will change the cable to pull or push mode. "
+	]
 	quest.5C47935A3B2877FF.quest_subtitle: "Mekanism's Energy Transfer Pipe"
-	quest.5C47935A3B2877FF.title: "&9Mekanism: &aUniversal Cables"
+	quest.5C47935A3B2877FF.title: "&9Using Mekanism:&r &a Basic Universal Cable&r"
 	quest.5C5546A5103BCF55.quest_desc: ["This one is supposed to shoot Chemicals like &bFluids&r or Gases... but it won't do it for me. \\n\\nIt can hold 2 Upgrades atleast! Those work!"]
 	quest.5C5546A5103BCF55.title: "&b&lChemical Thrower"
 	quest.5C56452BE7879D0A.quest_desc: ["{atm9.quest.enchant.desc.negative}"]
@@ -9197,8 +9387,6 @@
 		"- Celestigem"
 		"- Void Flame"
 	]
-	quest.5C6C4AD0F60BECCA.quest_desc: ["The &eKhopesh&r is the Weapon and Drop of &eKoboletons&r. \\n\\nIt does the same damage as an Iron Sword but can't be Enchanted or Repaired. \\n\\nGuess they didn't plan on you using them that much..."]
-	quest.5C6C4AD0F60BECCA.title: "&eKhopesh"
 	quest.5C6F8FE4BA28807E.quest_desc: ["Some Advanced Computers."]
 	quest.5C6F8FE4BA28807E.quest_subtitle: "Advanced Computers"
 	quest.5C73247A48E72FB3.quest_desc: ["If you want to remove a specific enchant from Enchantment Pool, you can use this bookshelf. Right-click on that bookshelf with enchanted book with an enchantment you don't want in the pool"]
@@ -9295,8 +9483,6 @@
 	quest.5D64250B940BC8FD.title: "Compressed Iron Armor"
 	quest.5D71ED16FD4E725A.quest_desc: ["Makes Piglins Passive (same as wearing Gold Armor), you only need to put the Upgrade on one piece."]
 	quest.5D71ED16FD4E725A.quest_subtitle: "Max: 1"
-	quest.5D74D73092ACD2F2.quest_desc: ["&5Coral Golems&r spawn within the &5Sunken City&r. \\n\\nThey are similar to their bigger counterparts: &5Coralssus&r but have less &4Hearts&r at 110 and can't be ridden by &5Deeplings&r. \\n\\nThey have more attacks than their counterparts though! Like jumping at you and smashing the ground next to you. And it can smack you. \\n\\nOn death they will drop Crystallized Coral Fragments, which can be crafted into Crystallized Coral. Those can be made into the &5Abyssal Sacrifice&r."]
-	quest.5D74D73092ACD2F2.title: "&5Coral Golem"
 	quest.5D7B34761E8FD212.quest_desc: [
 		"The &3Electrostatic Compressor&r generates a lot of pressure from Lightning Strikes.\\n\\nFor more info check out the \"Information\" tab in JEI.\\n"
 		"{image:pneumaticcraft:textures/patchouli/electrostatic_compressor.png width:100 height:100 align:left fit:true}"
@@ -9376,10 +9562,12 @@
 		""
 		"It will drain the life force of the mob to become Saturated Tau."
 	]
-	quest.5E3263ACE170A8E3.quest_desc: ["The &dGauntlet of &eMaelstorm&r is made with the &dGauntlet of Guard&r and &eSandstorm in a Bottle&r in a &4Mechanical Fusion Anvil&r. \\n\\nThis one is unique from all Weapons I've seen from &4&lCataclysm&r. \\n\\nWhen you Hold Right Click, a &dVoid &eVortex&r will spawn where you are aiming. \\n\\nThe &dVoid &eVortex&r will suck in all Entities nearby, then after a few seconds, it will close and explode! Dealing Damage to all near it."]
-	quest.5E3263ACE170A8E3.title: "&dGauntlet of &eMaelstorm"
-	quest.5E41363F9AE243F3.quest_desc: ["You can't power your base off of Coal forever! If you've got a decent amount of resources available, it's time to upgrade your power setup!\\n\\nThese options usually require a little setting up, but produce enough power to carry you far into your playthrough."]
-	quest.5E41363F9AE243F3.title: "&b&lMid Game Power Options"
+	quest.5E41363F9AE243F3.quest_desc: [
+		"You can't power your base off of Coal forever! If you've got a decent amount of resources available, it's time to upgrade your power setup! "
+		""
+		"These options usually require a little setting up, but produce enough power to carry you far into your playthrough."
+	]
+	quest.5E41363F9AE243F3.title: "Mid Game Power Options"
 	quest.5E45D2A2FDD67495.quest_desc: ["This goes in the right side of the forge."]
 	quest.5E45D2A2FDD67495.quest_subtitle: "Experience in a bottle"
 	quest.5E45D2A2FDD67495.title: "&aBottle O' Enchanting"
@@ -9418,7 +9606,7 @@
 	quest.5E799B92358A8732.quest_desc: ["In the &cNether&r, you'll run into &6Ancient Debris&r. This can be smelted down into Scraps that can be combined with Gold to create &6Netherite Ingots&r, which is an endgame metal use to craft some of the strongest tools and armor in the game."]
 	quest.5E799B92358A8732.title: "&dAncient Metals"
 	quest.5E7CCDE9229A646A.quest_desc: ["{image:atm:textures/questpics/basicarmor/armor_allthemodium.png width:100 height:150 align:center}"]
-	quest.5E7CCDE9229A646A.title: "&6Allthemodium&r"
+	quest.5E7CCDE9229A646A.title: "&6AllTheModium&r"
 	quest.5E7E35CCAF1C88EE.quest_desc: ["The &bME Import Bus&f periodically sucks items in from whatever external storage the bus is facing. It can optionally be filtered to only take in certain items from said inventory."]
 	quest.5E7E35CCAF1C88EE.quest_subtitle: "The I"
 	quest.5E90EF7FF530C477.quest_desc: [
@@ -9452,9 +9640,9 @@
 	quest.5ED368C926E5F32C.quest_desc: ["There is a final class of &3Spells&r I forgot to mention. Well all knowledge of these &9Spells&r have been forgotten so it's not just me. \\n\\nIn order to regain memories we need to walk, quietly, down memory lane. Which happens to be the &9Ancient City&r."]
 	quest.5ED368C926E5F32C.title: "The Last Class..."
 	quest.5ED6634F52CAC058.title: "Making a New Weapon"
-	quest.5EDB5A2D744CE415.quest_desc: ["The &4Laser Gatling&r is a weapon you can make from &4Witherite&r. \\n\\nBy using Redstone in your inventory, you can shoot Lasers which start fires and do 3 and a half &4Hearts&r of damage. \\n\\nIt shoots 50 Lasers per 1 redstone which I think is a good deal."]
+	quest.5EDB5A2D744CE415.quest_desc: ["The Gatling Laser is a weapon you can make from Witherite. By using Redstone in your inventory you can shoot lasers which start fires and do damage. It shoots 50 lasers per 1 redstone which I think is a good deal."]
 	quest.5EDB5A2D744CE415.quest_subtitle: "Straight outta Fallout"
-	quest.5EDB5A2D744CE415.title: "&4Laser Gatling"
+	quest.5EDB5A2D744CE415.title: "Laser Gatling"
 	quest.5EE1DF1C8F0C1FF9.quest_desc: [
 		"After building the &l&5Lightning Coil&r we can have Lightning Strike the &8Steel Fences&r, which will then become &cEnergy&r in its own &cEnergy&r resevior. \\n\\nThe more &8Steel Fences&r the higher chance of Lightning! \\n\\nI wonder if we can use other Mods to summon Lightning?"
 		"{@pagebreak}"
@@ -9486,13 +9674,21 @@
 	quest.5EFC63CF97D97AB5.title: "Mortem Armor"
 	quest.5F00A66CC1FE1F9F.quest_desc: ["Honestly the only difficult part of this recipe is the Bat Wing, how many times are you killing Bats let alone Farming them? \\n\\nThis one is pretty new and doesn't combine with Armor, it is only used for the end game!"]
 	quest.5F0482CDD3FC667D.title: "Dirt 6X"
-	quest.5F078A574A783B02.quest_desc: ["The first item you'll need to start your Flux Network is a &9Flux Plug&r.\\n\\nThe Plug is used to \"draw\" power from the block it is attached to. Aside from a small buffer, the Plug does not store any power itself, so don't worry about it zapping up all of your power.\\n\\nIt is suggested to place the Plug on a power storage block like an Energy Cube. It can connect to Cables, Pipes, or the output of any power producing machine.\\n\\nTo learn how to set up your first network, check the next quest!"]
-	quest.5F078A574A783B02.quest_subtitle: "Just plug it in!"
+	quest.5F078A574A783B02.quest_desc: [
+		"The first item you'll need to start your Flux Network is a &9Flux Plug&r. "
+		""
+		"The Plug is used to 'draw' power from the block it is attached to. Aside from a small buffer, the Plug does not store power itself, so don't worry about it zapping up all of your power. "
+		""
+		"It is suggested to place the Plug on a power storage block like an energy cube. It can connect to cables, pipes, or the output of any power producing machine. "
+		""
+		"To learn how to set up your first network, check the next quest!"
+	]
 	quest.5F078A574A783B02.title: "Starting Your Network"
 	quest.5F080CFA1DC7F435.quest_subtitle: "Spawned using a Soul Sand Nest in the Nether."
 	quest.5F080CFA1DC7F435.title: "Ghostly Bee"
 	quest.5F09F75A97C6C6DB.quest_desc: ["With 29 Bricks, the Steam Blast Furnace, as well as the Item Input Hatch, Item Output Hatch, and Fluid Input Hatch, you'll be able to make the Steam Blast Furnace. This furnace is great at turning your Uncooked Steel Dust into Steel Dust. It's slow, and you'll want tons of steel so you should probably look at making a few of these. Note that you can share sides, which makes each additional one cost significantly less Fire Clay Bricks!"]
 	quest.5F0C9D4344046F5E.quest_subtitle: "Just Bee a little happier"
+	quest.5F0C9D4344046F5E.title: "We Know You Hate It"
 	quest.5F1218CF8EFC607B.quest_desc: [
 		"&c&lLaserIO&r is DireWolf's continuation of &a&lEnderIO&r's &lLogistics&r."
 		""
@@ -9756,7 +9952,7 @@
 	quest.616ED6C49C37EB91.quest_desc: ["&b&lPaths and Pathways&r adds tons of different Carpet like Blocks (and full Blocks and Slab versions). \\n\\nThese are obviously used as Paths, they just look much nicer than the &2&lMinecraft&r Path Block. "]
 	quest.616ED6C49C37EB91.title: "&b&lMacaw's Paths and Pavings"
 	quest.616F9B78B16B42A5.quest_desc: ["The recipe for the &6Tesla Coil&r might seem complicated, especially in a recipe tree, but we can break it down to be simpler!\\n\\nThe &7Aluminum Plates&r are very simple, just needing to use a Hammer on Ingots or the Metal Press Multiblock.\\n\\nThe &8Iron Mechanical Component&r is simple as well, just a few Iron Plates and a &6Copper Ingot&r.\\n\\n&eElectrum Coil Block&r will need a bunch of &eElectrum Ingots&r cut up into Wires. &eElectrum&r is an alloy of &eGold&r and Silver.\\n\\nThe &6Advanced Electronic Component&r is a whole array of using the Engineers Workbench and &9Blueprints&r. It's Duroplast Sheet requires a lot of refining and fermenting with Multiblock Machines!\\n\\nThe last item, the &cHV Accumulator&r needs some simple Items like &8Steel&r, &7Aluminum Plate&r, &cRedstone Acid&r, and &4Treated Wood&r. It also needs a more complicated Item called &8HOP Graphite Ingot&r."]
-	quest.616F9B78B16B42A5.title: "&6Tesla Coil"
+	quest.616F9B78B16B42A5.title: "&6Telsa Coil"
 	quest.61768CFEDA041E4D.quest_desc: ["Once you enter the &6&lBumblezone&r you might need to return to the &2Overworld&r. Like incase you left your Stove on! \\n\\nTo get out the &6&lBumblezone&r you can mine either down or up past the &eBeehive Beeswax&r in order to enter the Void. \\n\\nThis Void won't kill you, instead it will teleport you back to where you were in the &2Overworld&r!"]
 	quest.61768CFEDA041E4D.quest_subtitle: "Let me outta here!"
 	quest.61768CFEDA041E4D.title: "Escaping"
@@ -9765,6 +9961,17 @@
 	quest.61847F47CCA225D9.title: "Silver Furnace"
 	quest.618F1434757C8E69.quest_desc: ["&lGenerator's Galore&r adds very simple Generators. The most basic ones act like Furnaces with &3Augment&r: Generator. They'll take Fuel and make it into Energy! \\n \\nYes you have to start with &6Copper Generator&r."]
 	quest.618F1434757C8E69.title: "&6Copper Generator&r"
+	quest.61999669BDE127F9.quest_desc: [
+		"If you haven't noticed already, making and re-making rituals over and over again is very taxing on the durability of your chalks. "
+		""
+		"If you're worried about your chalk breaking, but don't feel like doing the entire ritual to create a new chalk over again, then this ritual is for you!"
+		""
+		"Using the power of a &aDijinni&r, you can repair any color of chalk to it's maximum!"
+		""
+		"Alternatively, you could use something like the &aEternal Stella&r from the Forbidden Arcanus mod to permenantly preserve your chalks!"
+	]
+	quest.61999669BDE127F9.quest_subtitle: "You break it, &mwe&r Demons fix it!"
+	quest.61999669BDE127F9.title: "Chalk Repair"
 	quest.61A22707DBC83818.quest_desc: ["The Storage Access Point acts as a Storage Controller when linked to it, being able to be pushed into or pulled from. Basically a entry point for the Drawers."]
 	quest.61A8FAEC4FF18449.quest_desc: ["These can be used to charge items in your inventory, or can be used to increase the overall power capacity of an &7Ender Network&r channel."]
 	quest.61AD2207E770CD7F.quest_desc: ["Allows you to pickup items and experience from furthur away."]
@@ -9794,7 +10001,7 @@
 	quest.61D6C9461F10CCF1.title: "&dEvilCraft&r"
 	quest.61D9E67FFA14A8F8.quest_desc: ["We have seen many liquids that are the result of processing by the Fusion Reactor."]
 	quest.61D9E67FFA14A8F8.quest_subtitle: "Nitrogen Plasma"
-	quest.61DA3D61D7103647.quest_desc: ["&eAlchemical Sulfurs&r can be made from practically anything and can be made into practically anything! \\n\\nThere's a few different groups of Items in &eAlchemical Sulfurs&r which might be explained more in another Quest. \\n\\nThere's 3 different paths you can take with processing &eAlchemical Sulfurs&r. 1. Fermentation and Digestion for making Niter. 2. Incubation for making those Items again and 3. Changing the Item with Reformation."]
+	quest.61DA3D61D7103647.quest_desc: ["&eAlchemical Sulfurs&r can be made from practically anything and can be made into practically anything! \\n\\nThere's a few different groups of Items in &eAlchemical Sulfurs&r which might be explained more in another Quest. \\n\\nThere's 3 different paths you can take with processing &eAlchemical Sulfurs&r. 1. Fermentation and Disgestion for making Niter. 2. Incubation for making those Items again and 3. Changing the Item with Reformation."]
 	quest.61DA3D61D7103647.title: "&eAlchemical Sulfurs"
 	quest.61DCECE1FC38E151.title: "Reactor (Nitro)"
 	quest.61E2FC5D363A5CA4.quest_subtitle: "Increases Efficiency at the cost of Speed"
@@ -9806,8 +10013,6 @@
 		"There are 2 other processing methods, but neither of them produce Trinium, which is a vital resource in moving through the ZPM Tier. "
 	]
 	quest.6206EE9A045553CC.quest_subtitle: "Increasing the RPM's"
-	quest.62089E9E6D596DA7.quest_desc: ["&3The &bImmolator&r is an &3Annihilator&r upgraded with an &bIgnitium Ingot&r within the &4Mechanical Fusion Anvil&r. \\n\\nThese do more Damage to Mobs with &bBlazing Brand&r afflicted on them, so &bBlazing Grips&r work pretty well with it! \\n\\nIf you have &3The &bImmolator&r in each Hand, you can Hold right Click to summon a &bFlame Strike&r beneath you. This will Damage all Mobs in it and explode when done as a final farewell!"]
-	quest.62089E9E6D596DA7.title: "&3The &bImmolator"
 	quest.620C406CC24F179C.quest_desc: [
 		"This bad boy unlocks a cheaper rubber crafting recipe!"
 		""
@@ -9881,7 +10086,7 @@
 		"You &ndon't need&r Diodes if you use &cEnergy Converters&r because an Energy Converter is... clean?"
 	]
 	quest.62BBF61C9849CA26.quest_subtitle: "Squeaky Clean"
-	quest.62C32905C33E2D88.quest_desc: ["The &dEye of Void&r will take you to the &dRuined Citadel&r to fight the &d&lEnder Guardian&r."]
+	quest.62C32905C33E2D88.quest_desc: ["&dThe Eye of Void&r will take you to the &dRuined Citadel&r to fight the &dEnder Guardian&r"]
 	quest.62C32905C33E2D88.title: "&dEye of Void&r"
 	quest.62C60FF24B2F7290.quest_desc: ["&bArcane Crystals&r can spawn from Y Level 14 to -40. \\n\\nIt is fairly common; but trust me, you'll need a lot of it, so be thankful! \\n\\nLike &bDiamonds&r there is a Y Level that it spawns most common at, for &bArcane Crystals&r that Y Level is -13."]
 	quest.62C60FF24B2F7290.title: "&bArcane Crystals"
@@ -9896,8 +10101,6 @@
 	quest.62D572BAB055F56F.quest_subtitle: "Tier: &e1"
 	quest.62DDE5B1287BEB36.quest_desc: ["Another part of the &6&lATM Star's&r juicy insides is the &6Awakened &5Unobtainium&f-&3Vibranium&r Alloy Block, which I am going to just called &6Awakened Alloy&r block. \\nTo get this you'll need a Star Altar multiblock, (check out Crafting the Star Quest for more info!) \\n\\nThere you'll need to input the &5Unobtainium&f-&3Vibranium&r Block, 4 Unbreaking I Books, 4 &6Awakened Supremium Gemstones&r, and 4 &6Awakened Supremium Essence&r. \\n\\nYou'll then need to give it 85 Million FE... After that, your Alloy should now be Awakened!"]
 	quest.62DDE5B1287BEB36.title: "&6Awakened &5Unobtainium&f-&3Vibranium&r Alloy Block"
-	quest.62DF58D36B739EA0.quest_desc: ["The &eWadjet&r is similar to the &eKobolediator&r as it lies within the &eCursed Pyramid&r waiting for a Player to come near. \\n\\nThe &eWadjet&r has 1050 &4Hearts&r and thankfully won't give you Mining Fatigue! \\nShe has many attacks, the most basic is when you are close she will swing her weapon at you. If you get farther she might throw a Sandstorm at you or drop Sand Blocks from the roof on top of you. \\n\\nI'm going to be honest, I don't know which attack is worse! \\n\\nOn death they will only drop Ancient Metal Ingots."]
-	quest.62DF58D36B739EA0.title: "&eWadjet"
 	quest.62E7B8817D22678F.quest_desc: [
 		"That's right, another recipe for the &eChemical Reactor&r"
 		""
@@ -9926,7 +10129,7 @@
 	quest.6313B18820445882.title: "The &9Industrial Turbine"
 	quest.6314B892B569A0A5.quest_desc: ["The Starlight! \\n\\nA Dimension where it is constantly Dusk, and no you can't change that. \\n\\nThere is dozens of Biomes, Mobs, Bosses, and even just Blocks to find! Can you discover them all?"]
 	quest.6314B892B569A0A5.title: "Eternal Starlight"
-	quest.631796E7615C04FA.quest_desc: ["The &2Amethyst Crab&r lives in the Lush Caves with the Axolotls. \\n\\nIt has 2800 &4Hearts&r and is initially neutral. That means it won't attack first but it will hit you back. \\n\\nIt has a few attacks one being just smacking you with its claws. It can also throw Amethysts at you and burrow under the ground. \\n\\nOn death it'll drop its meat and shells. Its meat can be blessed in an Altar of Amethyst to be better. The Shells can be crafted together to make Bloom Stone Pauldrons which have similar stats to Netherite Chestplate but can do similar abilities as the &2Crab&r itself."]
+	quest.631796E7615C04FA.quest_desc: ["The &2Amethyst Crab&r lives in the Lush Caves with the Axolotls. It has 2000 hearts and is initially neutral. That means it won't attack first but it will hit you back. It has a few attacks one being just smacking you with its claws. It can also throw Amethysts at you and burrow under the ground. On death it'll drop its meat and shells. Its meat can be blessed in an Altar of Amethyst to be better. The Shells can be crafted together to make Bloom Stone Pauldrons which have similar stats to Netherite Armor but can do similar abilities as the Crab itself."]
 	quest.631796E7615C04FA.title: "&2Amethyst Crab&r"
 	quest.632BC46928CC9A8C.quest_desc: ["The &9Enchanter's Mirror&r will apply a self spell when used. \\n\\nSpells cast with this mirror are discounted and gain additional bonus duration. \\n\\nTo apply a spell, use a Scribe's table. Create a spell without using a form."]
 	quest.6335DC1E7517E940.quest_desc: ["Integrating Organics into our Non-Organic components, in the proper configuration with the proper organics will allow us to have infinite processing ability!"]
@@ -10197,7 +10400,7 @@
 	quest.6648BC7D14233006.title: "&lAugments"
 	quest.665B4A8FF5277316.quest_desc: ["Makes gravity affect a Mana Burst, making it move in an arc. It also slightly increases the time before it starts to lose mana."]
 	quest.665C3A14C987E9C6.quest_subtitle: "&f5.5&r &4Damage&r"
-	quest.666EA8B8F13EB292.quest_desc: ["This item is used to capture Demons for transport or storage. It's also needed for the &6ATM Star&r."]
+	quest.666EA8B8F13EB292.quest_desc: ["This item is used to capture mobs for transport or storage. It's also needed for the &6ATM Star&r."]
 	quest.666EA8B8F13EB292.title: "&dEmpty Soul Gem"
 	quest.6674270897997BF7.quest_desc: ["Allows you to jump higher than usual and makes you springy, making for faster travel.\\n\\nYou can only have one level of these Upgrades in the Leggings at a time."]
 	quest.6674270897997BF7.quest_subtitle: "Max: 1"
@@ -10223,7 +10426,6 @@
 		""
 		"Increases area mined at once. When installed on higher tier tools the maximum area mined is increase. Mined area can be configured in the menu."
 	]
-	quest.66AADD32A528A56D.quest_subtitle: "Tier: &63"
 	quest.66B503EB65475B98.quest_subtitle: "Tier: &63"
 	quest.66B5A8D259E12BF5.quest_desc: ["Wait so you're telling me it has the same stats as &cNetherite&r? Plus Spell Boosts? And doesn't need Smithing Templates to craft? \\n\\nWhy would anyone want regular &cNetherite&r!"]
 	quest.66B5A8D259E12BF5.quest_subtitle: "20"
@@ -10292,13 +10494,6 @@
 	quest.674F28BCA2E4A3C8.quest_desc: ["When moving items Routers can get pretty greedy, taking every single item they can get their grubby antennas on! \\n\\nWith Regulator Augment you can limit how much is moved."]
 	quest.6751F2651063B3A5.quest_desc: ["Blood Mushrooms can be found within their Bogs. \\n\\nThey are shaped like Dark Oak Trees and are mostly White with only some blocks having Blood spots on them!"]
 	quest.6754612E9AD4B9C0.title: "Reactor (Blazing)"
-	quest.676BC41C19BEF1FC.quest_desc: [
-		"That first Foliot Demon was cool, but what if I told you that you could summon a demon that gives you 6 dusts per raw ore it crushes?"
-		""
-		"The &5Marid Crusher&r does exactly that. To summon them, you'll need to use the &cFatma's Incentivized Attraction&r pentacle. This is an advanced ritual, requiring Red, White, and Gold Chalk as well as a lot of space."
-	]
-	quest.676BC41C19BEF1FC.quest_subtitle: "The Fastest Crushing On This Side of the Mississippi"
-	quest.676BC41C19BEF1FC.title: "The &5Marid Crusher"
 	quest.67704F7341EDCC49.title: "&bDiamond Backpack"
 	quest.677365A816994C8B.quest_desc: [
 		"The &9Player Transmitter&r will charge a player's items wirelessly. You must first bind this to a player using a &9Binding Card&r. This is the basic card which allows the transmitter to only work in the same dimension. You can upgrade this by using a &dBinding Card (Dimensional)&r instead. "
@@ -10331,6 +10526,13 @@
 	quest.6786B08C30D26037.quest_subtitle: "Spawns in a nest that has an Ashy Mining Bee"
 	quest.6786C701B7C4980B.quest_desc: ["The Gravistar is another very important component for our high tier machines were going to be making."]
 	quest.6786C701B7C4980B.quest_subtitle: "Stars have Lots of Gravity"
+	quest.67884BFA27870CCE.quest_desc: [
+		"&dOsorin's Unbound Calling&r is the second tier of &dDemon-less rituals&r. The first tier isn't useful for progression at all, it's only used for reviving familiars and turning vexes into allays. "
+		""
+		"This ritual is used to create a ton of rare-ish blocks, items, and materials that you might not be able to (or it's hard to) get normally."
+	]
+	quest.67884BFA27870CCE.quest_subtitle: "For the less trial-chamber-inclined of us"
+	quest.67884BFA27870CCE.title: "&dOsorin's Unbound Calling"
 	quest.678BA300CED48E5E.quest_desc: ["Lets make a bunch of these Yttrium Barium Cuprate Bolts, as we can utilize them to significantly reduce the cost of our IV Processors!"]
 	quest.678BA300CED48E5E.quest_subtitle: "Cost Reduction "
 	quest.67940C0774E73217.quest_desc: ["&eItem Router&r will &9Input &eItems&r and &6Output&r them to certain locations based on the Filtering set in its UI! \\n\\nThese can be set to &eBelts&r, Crates, or other Inventories."]
@@ -10406,10 +10608,13 @@
 	quest.681A3F31FB242555.quest_desc: ["&3Ethanol&r can be used to make Biodiesel."]
 	quest.681A3F31FB242555.title: "Ethanol"
 	quest.682034C680FDEDC2.quest_desc: [
-		"&9Mekanism's&r &aInduction Matrix&r is the ultimate way to store your power.\\\\n\\\\nIf you're looking for the best power storage in the game, check out the &aMekanism:&r &dReactors&r quest chapter.\\n"
-		"{image:atm:textures/questpics/mek/mek_induction_matrix_small.png width:125 height:150 align:center fit:true}"
+		"&9Mekanism's&r &aInduction Matrix&r is the ultimate way to store your power. "
+		""
+		"If you're looking for the best power storage in the game, check out the &aMekanism:&r &dAdvanced&r Chapter."
+		""
+		"{image:atm:textures/questpics/mek/mek_induction_matrix_small.png width:125 height:150 align:1}"
 	]
-	quest.682034C680FDEDC2.title: "More Power Storage"
+	quest.682034C680FDEDC2.title: "Need more storage?"
 	quest.6827836C8E675A94.quest_desc: ["Skeletons have different varients, like Zombies do! \\n\\nStrays- spawn in Cold Biomes. \\nBogged- spawn in Swamps and Trial Chambers. \\nMurks- spawn underwater in Coral Reefs. \\nVerdants- spawn in Jungles."]
 	quest.6827836C8E675A94.title: "Skeleton Variants"
 	quest.6829D2769ACC1BDB.quest_desc: ["ME Fluid Output! Takes the resulting fluids, or outputting byproduct fluids directly back to the ME system! Streamlined for sure!"]
@@ -10426,8 +10631,8 @@
 	]
 	quest.6832C9E6D2E2949E.quest_subtitle: "The Guardian of the Everdawn Tower"
 	quest.683B58B699D4D381.quest_subtitle: "Spawns in a nest that has a Blue Banded Bee"
-	quest.683C260C854C5AA3.quest_desc: ["The &4Mechanical Fusion Anvil&r will be needed to make combinations of &4&lCataclysm&r Items. \\n\\nYou can place it down like a normal Anvil, but this one doesn't have Durability... thankfully! \\n\\nCheck JEI for Recipes, you place 1 Item in the Left Slot and the other in the Middle Slot to get the final product in the Right Slot."]
-	quest.683C260C854C5AA3.title: "&4Mechanical Fusion Anvil"
+	quest.683C260C854C5AA3.quest_desc: ["The Mechanical Fusion Anvil will be needed to make the void and fused weapons. It places like a normal anvil but does not have durability."]
+	quest.683C260C854C5AA3.title: "Mechanical Fusion Anvil"
 	quest.68498ADEF9765F81.quest_desc: ["To make Crystallized Menril Chunks you first need to place some Menril Logs in a Squeezer. Jump on the Squeezer to turn them into Menril Resin.\\n\\nYou can empty the Squeezer by giving it a Redstone signal."]
 	quest.684BB9D2F2AC87A6.quest_subtitle: "Wenge + Cocobolo"
 	quest.68526BA198AADD8E.quest_desc: ["If you cannot find &belectrotine&r in the Nether, you can create it by mixing electrum and redstone in a &eMixer&r on &aProgram 1&r"]
@@ -10435,12 +10640,6 @@
 	quest.6852BEFDD4DE4E4B.title: "&9Soul-Touched Deepshelf"
 	quest.6856A5572B239D10.quest_subtitle: "&f16&r &4Damage&r"
 	quest.685C4A646E092A82.title: "&6Awakened Supremium Armor"
-	quest.686AEC3EF1140D15.quest_desc: [
-		"Most of the items we've needed from the &3Otherworld&r so far just needed some Spiritfire. However, we will need to use the help of the &3Third Eye&r to find the Ore of the &3Otherworld&r."
-		""
-		"We'll also need a special pickaxe to be able to mine it. For this, we'll need to Infuse a Demon into a &dSpirit Attuned Pickaxe Head&r to create a pickaxe that can break this new kind of ore."
-	]
-	quest.686AEC3EF1140D15.title: "New Tools for New Ores"
 	quest.686B25F2E9D8CC97.quest_desc: ["At the time of writing this it's the end of July so I've got about 3 months until Halloween. But it's never to early to start getting Spooky! Just like Spirit Halloween we can get Spooky 3 months before it actually starts. This time by Right Clicking a Furnace with the Spook-alator! Once it's time to start getting ready for Thanksgiving Shift Right Click them to Un-Spook-Alate!"]
 	quest.686B25F2E9D8CC97.quest_subtitle: "\"This is Halloween\""
 	quest.686EB173C94301C0.quest_desc: ["&e&lIron's Spells&r &bIce Armor&r!"]
@@ -10467,8 +10666,8 @@
 	quest.688C911ECFB2F134.title: "&cTears of Fire"
 	quest.68972BA647FDCF8F.quest_desc: ["If you know &l&6Productive Bees&r you should know LobsterJonn. He made &l&6Productive Bees&r and &lGenerator's Galore&r (along with many others). The &6Honey Generator&r is a good way of connecting both these mods! &6Honey Generator&r uses &6Liquid Honey&r to make Energy. "]
 	quest.68972BA647FDCF8F.title: "&6Honey Generator"
-	quest.689F32883C4E9502.quest_desc: ["&4&lCataclsym&r is a mod which adds new bosses, dungeons, and of course loot! \\n\\nThere is no certain pattern of which bosses to kill first, but some are stronger than others, and some give loot that will help against the others. \\n\\nCheck out the Eyes to find the specific Structures you'll need to locate!"]
-	quest.689F32883C4E9502.title: "&4&lCataclysm"
+	quest.689F32883C4E9502.quest_desc: ["Cataclsym is a mod which adds new bosses, dungeons, and of course loot! There is no certain pattern of which bosses to kill first but some are stronger than others and some give loot that will help against the others. This mod also has two items necessary to building the ATM Star!"]
+	quest.689F32883C4E9502.title: "Cataclysm"
 	quest.68B0B3DAF1145191.quest_desc: ["Two of the very first things you will need to get started in AE2 are the &bCharger&f and the &bInscriber&f.\\n\\nThe &bCharger&f, when supplied with power, will take &eCertus Quartz Crystals&r and charge them. These &eCharged Certus Crystals&r can then be used in the production of &eFluix&f, another important resource in the mod. It can also be used to charge any item that stores power.\\n\\nThe &bInscriber&f can be used to turn the various quartz crystals in AE2 into their dust form, but more importantly is used to fabricate special &ePrinted Circuits&f and &eProcessors&f, as will become clearer in the next quest."]
 	quest.68B0B3DAF1145191.quest_subtitle: "First Things First"
 	quest.68B0B3DAF1145191.title: "First Things First"
@@ -10517,6 +10716,12 @@
 	]
 	quest.6904EC449FBEE387.quest_subtitle: "Connecting The System"
 	quest.6904EC449FBEE387.title: "Cables"
+	quest.690B89D23134B624.quest_desc: [
+		"Grab your chalks, draw your &dRonaza's Contact&r ritual, and get ready to create the ULTIMATE CHALK!"
+		""
+		"Instead of having to lug around a full set of 16 chalks, you can use the rainbow chalk to paint a color-changing rune that counts as any of them! "
+	]
+	quest.690B89D23134B624.title: "&cR&6a&ei&an&9b&5o&dw&r Chalk"
 	quest.690CFF61CE787D43.quest_desc: ["Plastic is the main resource of &bIndustrial Foregoing&r, you now have access to some very useful machines!"]
 	quest.690DB8BEF80617E5.quest_desc: ["{image:atm:textures/questpics/basicarmor/armor_utherium.png width:100 height:150 align:center}"]
 	quest.690DB8BEF80617E5.title: "&cUtherium&r"
@@ -10527,8 +10732,6 @@
 	quest.692C9BA71EA0F0A7.quest_desc: ["You need this tier of Mixer to make &3Tungstensteel Dust&r as well as &dVanadium Gallium Dust&r"]
 	quest.692C9BA71EA0F0A7.quest_subtitle: "Where's the dough hook?"
 	quest.69383DA579901E7E.quest_subtitle: "Let me Axe you this"
-	quest.69439426534EBDC4.quest_desc: ["&bBlazing Grips&r are another Item we can make with &bIgnitium&r! \\n\\nIt is a Curios Item that goes on your Hands. \\n\\nWhen worn, all attacks have a chance of giving the recipient &bBlazing Brand&r. \\n\\nI don't re\\ally know what it does, but it sucks to get from the &b&lIgnis&r."]
-	quest.69439426534EBDC4.title: "&bBlazing Grips"
 	quest.694D7CD9EC663355.quest_subtitle: "Mace I interest you in this?"
 	quest.6950FC974624C6AA.quest_subtitle: "Tier: &63"
 	quest.695A0DC585FB6E97.quest_desc: [
@@ -10593,7 +10796,6 @@
 	quest.69E96EE9A9A2F423.title: "&cBlood Magic&r"
 	quest.69F11A94D44AB5CF.quest_subtitle: "Too much light!"
 	quest.69F11A94D44AB5CF.title: "&fLight Xychorium Gems"
-	quest.69F63F3B48E4344E.quest_subtitle: "Tier: &63"
 	quest.6A07D09831428CB9.quest_desc: ["&bSeashelves&r are your introduction to &5Arcana&r, they give &53% Arcana&r and &a3 Eterna&r. Better than normal shelves right? You're going to need atleast 4 of them for the next step."]
 	quest.6A07D09831428CB9.title: "&bSeashelves"
 	quest.6A0D1E9D534958B8.title: "Chalcopyrite Vein"
@@ -10684,7 +10886,7 @@
 		"{image:atm:textures/questpics/theurgy/theurgy_vessel_2.png width:100 height:125 align:center}"
 	]
 	quest.6A8E748B642DD16F.title: "&bSalt&r Vessel"
-	quest.6A962535CD68713E.quest_desc: ["&e&lPipez&r move more! \\n\\nAll Upgrades increase the amount the &e&lPipez&r move but each grant more options to use with the &e&lPipe&r. \\n\\nBasic Upgrade allows Redstone Activation with &e&lPipez&r.\\n\\nImproved Upgrade allows you to change distribution either:Closest First, Farthest First, Round-Robin, or Random.\\n\\nAdvanced Upgrade gives you option to add Filters.\\n\\nUltimate doesn't grant anything new it just moves a lot!"]
+	quest.6A962535CD68713E.quest_desc: ["&e&lPipez&r move more! \\n\\nAll Upgrades increase the amount the &e&lPipez&r move but each grant more options to use with the &e&lPipe&r. \\n\\nBasic Upgrade allows Redstone Activation with &e&lPipez&r. \\nImproved Upgrade allows you to change distribution either:Closest First, Farthest First, Round-Robin, or Random. \\nAdvanced Upgrade gives you option to add Filters. \\nUltimate doesn't grant anything new it just moves a lot!"]
 	quest.6AAB831CB3FB536A.quest_desc: [
 		"We'll want to infuse Life Essence (aka LP or Blood) into some stone."
 		""
@@ -10732,7 +10934,7 @@
 	quest.6B511C8B572E8940.quest_desc: ["In the bottom left of your screen, you'll see a bar. This bar is your mana pool! \\n\\nThere are several ways to increase your mana pool, or increase the efficiency of your spells as you progress through the mod. Upgrading your spellbook can also increase your mana!"]
 	quest.6B511C8B572E8940.quest_subtitle: "Mage Power"
 	quest.6B511C8B572E8940.title: "Mana"
-	quest.6B5BC33667C782EC.quest_desc: ["The &dEnder Golem&r keeps guard of the &dRuined Citadel&r, well multiple of them do. \\n\\nTechnically you don't need to fight them to fight the &dEnder Guardian&r but you definitely should to get the &dVoid Core&r. \\n\\nThe &dEnder Golem&r has 5250 &4Hearts&r and will regenerate them when left alone. \\n\\nHe has a few attacks like being able to punch you and smashing the ground. When he smashing the ground, &dVoid Runes&r will spawn, hurting any Player or Mob that touches them."]
+	quest.6B5BC33667C782EC.quest_desc: ["The &dEnder Golem&r keeps guard of the &dRuined Citadel&r, well multiple of them do. Technically you don't need to fight them to fight the &dEnder Guardian&r but you definitely should. The &dEnder Golem&r has 3000 Hearts and a few attacks. It attacks like a normal Iron Golem but also has Void Core attacks. The Void Core works like the Evoker jaws with things coming out of the ground to deal damage."]
 	quest.6B5BC33667C782EC.title: "&dEnder Golem&r"
 	quest.6B671CB07D046BEC.quest_desc: ["{image:atm:textures/questpics/basicarmor/armor_diamond.png width:100 height:150 align:center}"]
 	quest.6B671CB07D046BEC.title: "&bDiamond&r"
@@ -10745,9 +10947,11 @@
 	quest.6BA2BC09E23B34A9.title: "&l&dTier 4 &6Forge"
 	quest.6BB9490E23CBD287.quest_desc: ["Vials and Sigils are items used to change your weapons sockets, whether to add more or free them up. All are used with your item in a Smithing Table."]
 	quest.6BB9490E23CBD287.title: "Vials and Sigils"
+	quest.6BBF35D29E70FDD4.quest_desc: ["Cataclysm isn't just about bosses, there's plenty of minibosses and mobs that help the bosses as well! Okay maybe it is just about bosses."]
+	quest.6BBF35D29E70FDD4.title: "Other Enemies"
 	quest.6BC0904E03683190.quest_desc: ["Breed &8B&6e&8e&6s&r to get 8 new &8B&6e&8e&6s&r."]
-	quest.6BC3CF8937DEDE89.quest_desc: ["Combine an &cInfernal Forge&r with a &dVoid Core&r to make the &dVoid &cForge&r! \\n\\nIt is still a Pickaxe, with same Mining Tier and Speed. \\n\\nJust now we can Right Click with it, on the ground to summon &dVoid Runes&r in a fan shape, to hurt all Mobs with it. \\n\\nThey really don't focus much on the Pickaxe part do they?"]
-	quest.6BC3CF8937DEDE89.title: "&dVoid &cForge"
+	quest.6BC3CF8937DEDE89.quest_desc: ["The Void Forge is not much different from the Infernal Forge. Same attack damage and speed, same pickaxe tier, just summons Void Runes when attacking. Can be crafted by combining an Infernal Forge and a Void Core in a Mechanical Fusion Anvil."]
+	quest.6BC3CF8937DEDE89.title: "Void Forge"
 	quest.6BC78AF7C9D93F11.quest_desc: ["Even Glazed versions!"]
 	quest.6BC78AF7C9D93F11.title: "&l&bChipped&r Terracotta"
 	quest.6BD348735C27BB44.quest_desc: [
@@ -10819,9 +11023,9 @@
 		"This ones a funny one; you can either find it, craft it, or trade for it.\\n\\nThen you can dye it whatever color you want and of course wear it on your Head!\\n\\nThe &6B&8e&6e&8s&r will then think that you are a Flower and will follow you.\\n\\nIt also makes you look like Daffy from \"Duck Amuck\"."
 		"{image:atm:textures/questpics/bumblezone/bumble_duckamuck.png width:100 height:100 align:center}"
 	]
-	quest.6C5F9D0D447EFB9C.quest_desc: ["What you think &l&2Vanilla&r was all we got? \\n\\n&6Allthemodium Armor&r has more Armor Points and Armor Toughness, plus increased Protection against Magic and other buffs you can read about in &6&lAllthemodium&r Quest Page! \\n\\nBTW you will need &cNetherite&r to craft it."]
+	quest.6C5F9D0D447EFB9C.quest_desc: ["What you think &l&2Vanilla&r was all we got? \\n\\n&6AllTheModium Armor&r has more Armor Points and Armor Toughness, plus increased Protection against Magic and other buffs you can read about in &6&lAllTheModium&r Quest Page! \\n\\nBTW you will need &cNetherite&r to craft it."]
 	quest.6C5F9D0D447EFB9C.quest_subtitle: "24"
-	quest.6C5F9D0D447EFB9C.title: "&6Allthemodium Armor"
+	quest.6C5F9D0D447EFB9C.title: "&6AllTheModium Armor"
 	quest.6C6F4EB5CBE2FBC2.quest_desc: ["The Iron Divination Rod is a slight bit higher, being able to find Ores that an Iron Pickaxe can mine! So Diamonds, Redstone, and Gold."]
 	quest.6C706326381CE611.title: "Creative Pressure"
 	quest.6C76AB8A6110C0C7.quest_desc: ["The &4Blazing Hellshelf&r is an upgrade to the &4Infused Hellshelf&r. It increases max &aEterna&r to &a30&r. The negative Enchanting Clue makes it a little worse for normal Enchanting, instead we can use it for better Infusion."]
@@ -10887,7 +11091,7 @@
 	quest.6D124ACF4AE80490.quest_desc: ["With Micromissiles you can shoot explosions from far away! Now nobody can escape!\\n\\nTheses are needed to craft the &6ATM Star&r."]
 	quest.6D124ACF4AE80490.quest_subtitle: "Firing Explosions from afar!"
 	quest.6D14ACECD2084456.quest_subtitle: "Wenge + Oak"
-	quest.6D1E8399AD39FFC8.quest_desc: ["The &7Paradox Machine&r can, for a price of a lot of Power and &aTime Fluid&r, will take a Snapshot of blocks and entities in the designated area; then it can duplicate it. \\n\\nLots of Blocks and Entities are blacklisted by configs so no duplicating Bees!"]
+	quest.6D1E8399AD39FFC8.quest_desc: ["&7Paradox Machine&r can, for a price of a lot of Power and &aTime Fluid&r, will take a Snapshot of blocks and entities in the designated area; then it can duplicate it. \\n\\nLots of Blocks and Entities are blacklisted by configs so no duplicating Bees!"]
 	quest.6D1E8399AD39FFC8.title: "&7Paradox Machine"
 	quest.6D232F6D8E8DA546.quest_desc: [
 		"Very popular around Halloween!"
@@ -10910,9 +11114,13 @@
 		""
 		"You need a higher tier cutter to cut the higher tier chips to achieve higher tiers of power"
 	]
-	quest.6D6E07564D8FDD8D.quest_desc: ["&aExtreme Reactors&r offers multi-block Reactors that are completely customizable in size, efficiency, and more.\\n\\nTo learn more about getting started with Extreme Reactors, check out the quest chapter for the mod!"]
+	quest.6D6E07564D8FDD8D.quest_desc: [
+		"&9Extreme Reactors&r offers multi-block reactors that are completely customizable in size, efficiency, and more. "
+		""
+		"To learn more about getting started with Extreme Reactors, check out the questline for the mod!"
+	]
 	quest.6D6E07564D8FDD8D.quest_subtitle: "Customizable Reactors!"
-	quest.6D6E07564D8FDD8D.title: "&9Extreme Reactors: &aReactors"
+	quest.6D6E07564D8FDD8D.title: "Extreme Reactors"
 	quest.6D738730B371B152.quest_desc: ["The &l&7Mining Dimension&r is a Superflat world with absolutely nothing on the surface. \\n\\nBelow the surface is almost every single Ore. \\n\\nThe &7&lMining Dimension&r has no Caves, no Mob Spawns, and nothing to get in your way. It's just Stone types and Ores! \\n\\nOre spawns differ for the Y Level and layer in the &7&lMining Dimension&r.\\n\\nI recommend setting up a Quarry."]
 	quest.6D738730B371B152.title: "&l&7Mining Dimension"
 	quest.6D750A38944E9B68.quest_desc: [
@@ -10976,7 +11184,7 @@
 	quest.6E05B62A40D5A891.title: "&3&lIntegrated Dynamics"
 	quest.6E0624750DF8CD18.quest_desc: ["Can't craft these anymore now you need to upgrade &5Netherite&r to it always. \\nYes, it saves Enchantments and Repairs it!"]
 	quest.6E0624750DF8CD18.title: "&6Allthemodium Tools"
-	quest.6E08D4E6BC3FB99F.quest_desc: ["The &5Deeplings&r are an ancient race of sea monsters who live and guard the &5Sunken City&r. They have their own rankings: Anglers, Brutes, Priests, and Warlocks. \\n\\n&5Deeplings&r are the most basic, only having 13 &4Hearts&r and a Coral Spear. \\n\\n&5Deepling Anglers&r are the next ones, they have 15 &4Hearts&r and hold a Fishing Rod with a &5Lionfish&r attached. The &5Lionfish&r will attack you and give you Poison, they have 6 &4Hearts&r. \\n\\n&5Deepling Brutes&r have 60 &4Hearts&r and hold a Coral Bardiche, which they will use to charge at you in the Water. \\n\\n&5Deepling Warlocks &fand &5Priests&r both have 45 &4Hearts&r and both hold Athame. The &5Priests&r have a ranged attack they can use, while &5Warlocks&r do not!"]
+	quest.6E08D4E6BC3FB99F.quest_desc: ["The &5Deeplings&r are an ancient race of sea monsters who live and guard the &5Sunken City&r. They have their own rankings: Anglers, Brutes, Priests, and Warlocks. Each carrying different weapons which they can drop. The &5Deepling Priest&r drops the Athame which we need for the Abyssal Sacrifice."]
 	quest.6E08D4E6BC3FB99F.title: "&5Deeplings&r"
 	quest.6E093D16B12E12B3.quest_subtitle: "Chocolate Mining + Digger"
 	quest.6E0D16C7036E81C1.quest_desc: ["Or, make a durability exchange and toss strong (but not too strong, no chisels because the mod normalizes things to around a netherite shovel in terms of durability)"]
@@ -11078,7 +11286,7 @@
 	quest.6ED2CDD01659FD10.quest_desc: ["This armor set has same Armor Points as Iron but is better in both Toughness and Knockback Resistance."]
 	quest.6ED2CDD01659FD10.quest_subtitle: "15"
 	quest.6ED2CDD01659FD10.title: "&7Compressed Iron Armor"
-	quest.6ED61438A8A1EAA4.quest_desc: ["Witherite is a drop from &4The Harbinger&r, it will always drop 1 block which can be made into 9 ingots. \\n\\nWitherite is used to craft 3 Weapons and the &4Mechanical Fusion Anvil&r which can be used to combine &4&lCataclysm&r Items!"]
+	quest.6ED61438A8A1EAA4.quest_desc: ["Witherite is a drop from &4The Harbinger&r, it will always drop 1 block which can be made into 9 ingots. Witherite is used to craft 3 weapons and the Mechanical Fusion Anvil."]
 	quest.6ED61438A8A1EAA4.quest_subtitle: "= Witherite"
 	quest.6ED61438A8A1EAA4.title: "Wither plus Netherite = ...?"
 	quest.6EDAB29FBD3C60A3.quest_desc: ["This biome was introduced in the Wild Update!\\n\\nBe careful! You might accidentally summon a new friend.\\n\\nP.S. - He's not friendly."]
@@ -11142,7 +11350,7 @@
 	quest.6F709652A2B88C78.quest_desc: ["The energy transmitter provides power to blocks within it's working range, it can only accept power from the bottom."]
 	quest.6F71FD826C29C31A.quest_desc: ["This one might be new to ones returning from earlier versions. By using a turtle egg on a spawner, it will only spawn in baby versions of the mobs in it. This only works with Vanilla baby versions of mobs, not modded."]
 	quest.6F71FD826C29C31A.title: "Youthful"
-	quest.6F76DA3BBAE8337B.quest_desc: ["The greatest Armor we can get from &6&lAllthemodium&r, &5Unobtainium&r! \\n\\nNow with 100% Knockback Resistance and higher stats everywhere! \\n\\nAlso needs &3Vibranium Armor&r to make it."]
+	quest.6F76DA3BBAE8337B.quest_desc: ["The greatest Armor we can get from &6&lAllTheModium&r, &5Unobtainium&r! \\n\\nNow with 100% Knockback Resistance and higher stats everywhere! \\n\\nAlso needs &3Vibranium Armor&r to make it."]
 	quest.6F76DA3BBAE8337B.quest_subtitle: "40"
 	quest.6F76DA3BBAE8337B.title: "&5Unobtainium Armor"
 	quest.6F7AC41B703028CC.quest_subtitle: "Silver + Copper"
@@ -11179,8 +11387,8 @@
 	quest.6FBE5B5D5027B32C.quest_subtitle: "Head"
 	quest.6FBE5B5D5027B32C.title: "&7Cowboy Hat"
 	quest.6FBF112811FB707C.quest_subtitle: "Ash + Birch"
-	quest.6FC4146E534C51DA.quest_desc: ["You can combine a Netherite Upgrade Template, a Netherite Helmet, and a &cMonstrous Horn&r to make the &cMonstrous Helm&r. \\n\\nIt has the same stats but when you're at half health it'll Knockback everything close to you and increase defense stats."]
-	quest.6FC4146E534C51DA.title: "&cMonstrous Helm"
+	quest.6FC4146E534C51DA.quest_desc: ["By combining a Netherite Upgrade Template, a Netherite Helmet, and a Monstrous Horn to make the Monstrous Helm. It has better stats and when you're at half health it'll do knockback everything close to you and increase defense stats."]
+	quest.6FC4146E534C51DA.title: "Monstrous Helm"
 	quest.6FC55CF56BE22866.quest_subtitle: "531,441 Dirt"
 	quest.6FC7DC1F856A748D.quest_desc: ["Okay this is a long one just stick with me. First Ability allows two modes,  &6Sancity&r and &7Unholiness&r. &6Sancity&r takes some of your Healing and uses it as Damage against enemies. &7Unholiness&r does the opposite, it takes the enemies Healing to help you deal more damage. Mobs like &dEnder Dragon&r and &5Wither&r both regenerate Health. \\n \\nThe Second Ability is Repentance, while active it will Burn Undead Mobs (Zombie, Skeleton, and their cousins). \\n \\nThe Third Ability grants a small time period of Invincibility."]
 	quest.6FC7DC1F856A748D.quest_subtitle: "Found in all Villages"
@@ -11197,12 +11405,20 @@
 	]
 	quest.6FD65139CD50A8C0.quest_desc: ["Is that even possible?\\n\\nIf you wish to automate this process you can use &eProductive Bees&r or &aMystical Agriculture&r. Or I guess you could automate it, with...explosions."]
 	quest.6FD65139CD50A8C0.quest_subtitle: "Tired of blowing stuff up?"
+	quest.6FEED25FFAC4101F.quest_desc: ["Using &aStrigeor's Higher Binding&r, you can create Gray Paste. Smear this on a piece of impure white chalk to create Gray Chalk."]
+	quest.6FEED25FFAC4101F.title: "&8Gray Chalk"
 	quest.6FF04DD735346BED.quest_desc: ["Turns Latex into Dry Rubber."]
 	quest.6FF116239EACA390.title: "End Stone 5X"
 	quest.6FF20C2FB977C142.quest_desc: ["Steam is the foundation to your early progression through MI. Take a bucket of water and put it into the furnace with fuel to turn it into steam!"]
 	quest.6FF54B5D953E1797.quest_desc: ["If you know the term '&4Berserk&r' in most gaming, that will help you understand what the &cRage Glove&r does. If you don't know, the basics of &4Berserk&r is when someone gets low health or takes lots of damage, usually they will deal higher damage and be faster. That's what happens with First Ability, when you take damage you accumulate points which can be exchanged for higher damage and speed! \\n \\nThe Second Ability does that passively, and gives you Regeneration per the amount of health you lost. \\n \\nThe Third Ability is an active one, when using it (Alt Tab) you will dash and attack any mob you are looking at. When hit it'll set them on &cFire&r, give them Bleeding, and any accumulated &4Berserk&r points deal extra damage with it!"]
 	quest.6FF54B5D953E1797.quest_subtitle: "Found in Ruined Portals, Nether Fortresses, and Bastions"
 	quest.6FF54B5D953E1797.title: "&cRage Glove"
+	quest.6FFFAE334DFAAAAB.quest_desc: [
+		"As you've probably noticed, rituals tend to be... a little slow. But not anymore! Using &cSevira's Permanent Confinement&r, you can create the &bIesnium Ritual Bowl&r. "
+		""
+		"When using this in place of a Golden Ritual Bowl, it greatly reduces how long it takes to perform a ritual, taking it down to one fourth of its original time!"
+	]
+	quest.6FFFAE334DFAAAAB.quest_subtitle: "Super-speed rituals!"
 	quest.700F3FF7C23D0C0F.quest_desc: ["The &5Ender Cell&r will store power for a channel in your &7Ender Network&r. To increase the power capacity of the network, right click on the Ender Cell to open up the interface, then add either a &aBattery&r or an &9Energy Cell&r to increase the overall capacity."]
 	quest.70112194DFFD15D3.title: "&5Tyr Armor"
 	quest.7026E46FD8B3A81D.quest_desc: ["The &9Hydra&r is the infamous multi-headed beast from Greek Mythology.\\n\\nRanged attacks aren't as effective, meaning you'll need to get up close and personal.\\n\\nOnce defeated, you'll be able to find the next boss in the &2Dark Forest&r."]
@@ -11320,11 +11536,8 @@
 	]
 	quest.70CCE558E03227AB.quest_subtitle: "Crafting the &l&6ATM Star"
 	quest.70CCE558E03227AB.title: "&l&6Runic Star Altar"
-	quest.70CDA5F1593DB4B2.quest_desc: [
-		"&eThe Cursed Pyramid&r spawns in deserts and it's very hard to miss. A massive pyramid with huge pillars by the entrance. \\n\\nEnter within and you will find traps all around, &eKoboletons&r, and mini-bosses! \\n\\nDon't worry there's also Chests, Pots, and even Suspicious Sand which you will need for the..."
-		"{image:atm:textures/questpics/cataclysm/cataclysm_pyramid.png width:200 height:100 align:center}"
-	]
-	quest.70CDA5F1593DB4B2.title: "&eCursed Pyramid&r: Home of &e&lAncient Remnant&r"
+	quest.70CDA5F1593DB4B2.quest_desc: ["&eThe Cursed Pyramid&r spawns in deserts and it's very hard to miss. A massive pyramid with huge pillars by the entrance. In it you'll find a lot of traps, husks, and loot! Once you get to the bottom you'll find many &eKoboletons&r and a sleeping giant. To wake it up you'll need a..."]
+	quest.70CDA5F1593DB4B2.title: "&eCursed Pyramid&r: Home of &eAncient Remnant&r"
 	quest.70D2C5FAC661E01A.quest_desc: ["The &bHeart-Forged Seashelf&r is another upgrade to the &bInfused Seashelf&r. It's a little expensive but gives the &5Arcana&r we'll need for Infusion and later Enchanting."]
 	quest.70D2C5FAC661E01A.title: "&bHeart-Forged Seashelf"
 	quest.70D60687AAB145FE.quest_subtitle: "Common"
@@ -11337,11 +11550,6 @@
 		"{image:atm:textures/questpics/undergarden/undergarden_rotbeast.png width:100 height:100 align:center}"
 	]
 	quest.70FD8856BFCD9AEE.title: "&cRotbeast&r"
-	quest.71055E7BBB337C4D.quest_desc: [
-		"The &3&lMaledictus&r can be brought back from Valhalla or whatever the Norse version of Hell is, by Right Clicking the &3Cursed Tombstone&r. \\n\\nHe has 50,400 &4Hearts&r and massive Wings. \\n\\nHe will swing at you with his 2 &3Annihilators&r and can even ground pound you with them, making a Shockwave of course! \\n\\nHis Wings allow him to manevure and do many more attacks. He can charge at you, breaking all Blocks in his way or even dodge attacks! \\n\\nHe can fly into the air and from there can either shoot at you with his &3Cursed Bow&r or drop down with his &3Soul Render&r. The &3Cursed Bow&r will shoot 4 Arrows at you. With his &3Soul Render&r he will bring a shower of &3Phantom Halberds&r down on you."
-		"{image:atm:textures/questpics/cataclysm/cataclysm_maledictus.png width:125 height:100 align:center}"
-	]
-	quest.71055E7BBB337C4D.title: "&3&lMaledictus"
 	quest.71060904C6A86C68.quest_desc: [
 		"These Naquadah Frames will have a lot of uses as a component and building block. "
 		""
@@ -11361,7 +11569,7 @@
 		"- Night Vision"
 	]
 	quest.7154D73516548149.quest_desc: ["&6&lAllthemodium&r is a mod added specifically by the &6AllTheMods Team&r to add more content after Netherite! \\n\\nYou'll need to adventure through it to get some Items needed for the &6&lATM Star&r. \\n\\nThere is a Quest page now that you can follow for it!"]
-	quest.7154D73516548149.title: "&l&6Allthemodium"
+	quest.7154D73516548149.title: "&l&6AllTheModium"
 	quest.71581992E8E4C43E.quest_desc: ["Throw a few &8Wither Skeleton Skulls&r and an &dAbjuration Essence&r to make a &8Wither &3Glyph&r! \\n\\nIf it didn't work you might need more &aEXP&r."]
 	quest.71581992E8E4C43E.title: "&3Glyph of &8Wither"
 	quest.715B86DC82EA636B.quest_desc: [
@@ -11477,17 +11685,14 @@
 	quest.7255B9A6E1319DCA.quest_subtitle: "Sapphires"
 	quest.7255B9A6E1319DCA.title: "Almandine Vein"
 	quest.72569275EDE9FA23.quest_desc: ["Breed 6 &6Honey Slimes&r together with Sugar."]
-	quest.7256CDA3F759F786.title: "Bronze"
 	quest.7270A37E31A70C91.quest_desc: ["&6&lHoly&r is for all the Medic/Support players. It's mostly meant for healing and helping. \\n\\n&6&lHoly's&r Focus Material is &6Divine Pearls&r which are crafted. You can make Runes with those or kill the &6&lPriest&r to get &6Holy Runes&r. \\n\\n&6Holy Scrolls&r are &fWhite&r with &6Gold&r texts."]
 	quest.7270A37E31A70C91.title: "&6&lHoly"
-	quest.7270FA5C48AF7280.quest_desc: ["&3Cursium Armor&r is an upgrade to Netherite Armor. Combine Netherite Gear, with a &3Cursium Ingot&r, and a &3Cursium Upgrade Template&r. You can Craft those don't worry! \\n\\nThe &3Cursium Helmet&r can be used with the Key: C to see Mobs through Blocks! Like the Spectral Eye. \\n\\nThe &3Cursium Chestplate&r works as a built in Totem of Undying. After you die you will be saved. It has a 6 minute Cooldown though... \\n\\nThe &3Cursium Leggings&r are working with propability... not sure how that works in &2&lMinecraft&r though! \\n\\nThe &3Cursium Boots&r allow you to get sent backwards in a leap with the Key: V. They also reduce Fall Damage but a lot (but not completely!)"]
-	quest.7270FA5C48AF7280.title: "&3Cursed Armor"
 	quest.72717D1135486D7F.quest_desc: ["Let's gather some seeds."]
 	quest.72717D1135486D7F.quest_subtitle: "Block Hand 1, Block Grass 0"
 	quest.72717D1135486D7F.title: "Punch the Grass"
 	quest.7279700A93E8630B.quest_desc: ["{image:atm:textures/questpics/basicarmor/armor_unobtainium.png width:100 height:150 align:center}"]
 	quest.7279700A93E8630B.title: "&5Unobtainium&r"
-	quest.728BE1816DA23DC0.quest_desc: ["The Ender Dragon is the Boss that guards The End. \\n\\nWhen you enter an End Portal you'll arrive at the End Island where she spawns. \\n\\nShe has 200 Hearts and can attack with Fireballs or ramming into you. \\n\\nYou'll have to break the End Crystals on the pillars as they heal her, in order to kill her! \\n\\nOnce you do kill her, she'll drop: Arcane Essence, Epic Shaderbags, Dragonskin, Dragon Scales from two different mods, and a bunch of experience! \\n\\nThen the Portal will open up so you can return to the Overworld, or you can find an End Gateway to explore the outer islands. You'll also find a Dragon Egg on the Portal."]
+	quest.728BE1816DA23DC0.quest_desc: ["The Ender Dragon is the Boss that guards The End. \\n\\nWhen you enter an End Portal you'll arrive at the End Island where he spawns. \\n\\nHe has 200 Hearts and can attack with Fireballs or ramming into you. \\n\\nYou'll have to break the End Crystals on the pillars as they heal him, in order to kill him! \\n\\nOnce you do kill him he'll drop: Arcane Essence, Epic Shaderbags, Dragonskin, Dragon Scales from two different mods, and tons of EXP! \\n\\nThen the Portal will open up so you can return to the Overworld, or you can find an End Gateway to explore the outer islands. You'll also find a Dragon Egg on the Portal."]
 	quest.728BE1816DA23DC0.title: "Kill The Ender Dragon"
 	quest.72917C96C322A922.title: "La Bee-da Loca"
 	quest.7297391D026EE9A6.quest_desc: ["Want something exciting and new to make Energy? What about using &dPotions&r for it! That's what the &dPotion Generator&r does, it will take your &dPotions&r and make Energy out of it depending on its strength and duration."]
@@ -11556,7 +11761,7 @@
 	quest.72DB967E59EEA729.title: "&3&lGlassential&r"
 	quest.72DC025BC059DF96.quest_desc: ["Mixing &6Nitric Acid&r with &cSulfuric Acid&r makes a &eNitration Mixture&r"]
 	quest.72DCE154E1714890.quest_desc: ["The &n&5Saw&r will harvest trees in front of it. It can also be used as a Sawmill. If it has a connected inventory, the items will be stored in it."]
-	quest.72DDA413D73E3235.quest_desc: ["Much higher stats in everything with the next in line for &6&lAllthemodium&r Armors, &3Vibranium&r! \\n\\nYou will need &6Allthemodium Armor&r to create it."]
+	quest.72DDA413D73E3235.quest_desc: ["Much higher stats in everything with the next in line for &6&lAllTheModium&r Armors, &3Vibranium&r! \\n\\nYou will need &6AllTheModium Armor&r to create it."]
 	quest.72DDA413D73E3235.quest_subtitle: "32"
 	quest.72DDA413D73E3235.title: "&3Vibranium Armor"
 	quest.72DEF9BA758BCDC0.quest_desc: ["Once the ritual has started you will notice the Lake being made. It will grow to about a 20x20 block area full of murky water. The Murky Water will not kill you unless you forget to go for air."]
@@ -11574,9 +11779,9 @@
 		""
 		"Replace the Cupronickel Coils on your &aEBF&r with this stuff"
 	]
-	quest.72EA25D05C46D39A.quest_desc: ["&9Integrated Dynamics&r provides a simple power storage system. The Batteries can be combined in a crafting grid to increase the overall storage!"]
-	quest.72EA25D05C46D39A.quest_subtitle: "Batteries Included"
-	quest.72EA25D05C46D39A.title: "&9Integrated Dynamics: &bEnergy Battery"
+	quest.72EA25D05C46D39A.quest_desc: ["&9IntegratedDynamics&r provides a simple power storage system. The batteries can even be combined in a crafting grid to increase the overall storage!"]
+	quest.72EA25D05C46D39A.quest_subtitle: "Integrated Dynamics"
+	quest.72EA25D05C46D39A.title: "Energy Battery"
 	quest.72F57D77C3FB366D.quest_desc: ["Blocks of Crystallized Menril can be crafted into Crystallized Menril Chunks. These chunks are the main crafting ingredient of ID."]
 	quest.72F57D77C3FB366D.quest_subtitle: "The Main Crafting Ingredient"
 	quest.72F57D77C3FB366D.title: "Crystallized Menril Chunks"
@@ -11594,7 +11799,7 @@
 	quest.730F2D3329C4FF88.quest_desc: ["&nFermentation&r: \\nThe chemical process by which molecules such as glucose are broken down anaerobically. \\n\\nAKA &9Water&r and time change thing! \\n\\nTo use the Fermentation Vat put the Items and Fluid into the Vat then Shift Right Click to close it. \\n\\nAfter awhile it should ferment! This is how we turn &eAlchemical Sulfur&r into &3Alchemical Niter&r which can be turned into more Items!"]
 	quest.730F2D3329C4FF88.title: "Fermentation Vat"
 	quest.73110103EF23BFDF.quest_desc: ["A mix of &6Copper&r and &7Zinc&r. \\n\\nNot really used for much in &8&lIE&r... You can make Signs with it I guess..."]
-	quest.73110103EF23BFDF.title: "&6Brass Ingot"
+	quest.73110103EF23BFDF.title: "Brass Ingot"
 	quest.731686C758AD9A99.quest_desc: [
 		"&dAllthemodium&r is the core mod in all Allthemods modpacks. This mod adds endgame ores to the world that amplify your modded experience."
 		""
@@ -11705,6 +11910,8 @@
 	quest.74015945716FD10A.quest_subtitle: "A configurable hopper"
 	quest.7408CCF998D9CD37.quest_desc: ["A Craftable &eSpell Book&r... yeah it's not easy to craft. \\n\\nHardest to get would be the Ruined Book, which you can find in &9Ancient City&r Chests. &4Blood Vials&r can be obtained from either putting a Mob (or even yourself) into a Cauldron above a Campfire or an Alchemical Cauldron. &5Bottle O' Lightning&r comes from using a Bottle on a Charged Creeper. \\n\\nOnce you do all that you can craft the Ancient Codex. Its 12 &3Spell&r Slots is very helpful!"]
 	quest.7408CCF998D9CD37.title: "Ancient Codex"
+	quest.74130EB1E4B8586D.quest_desc: ["Using &aIhagan's Enthrallment&r, you can sacrifice an allay, bat, bee, or parrot to summon the &6Possessed Bee&r. Upon defeating it, it will drop cursed honey, the main ingredient for making orange chalk!"]
+	quest.74130EB1E4B8586D.title: "&6Orange Chalk"
 	quest.7413BB136EF9D6C5.quest_desc: ["The Mechanical Drying Basin uses energy to dry"]
 	quest.74200A48498DD7F8.quest_desc: ["Generates power from the sun!"]
 	quest.74200A48498DD7F8.quest_subtitle: "Generates about 51FE/t"
@@ -11739,11 +11946,8 @@
 		"Valid Upgrades:"
 		"- Invulnerability"
 	]
-	quest.746DE905D45A396C.quest_desc: [
-		"&5&lThe Leviathan&r is the reason people fear the Ocean. \\n\\nShe has 30,000 &4Hearts&r, sharp teeth, and strong tentacles and is invincible outside of &9Water&r. \\n\\nShe has a huge array of powers she will use against you. She can summon underwater &5Mines&r, shoot a Godzilla like &5Atomic Beam&r, and even just chomp on you. \\n\\nThe worst comes from the &5vortexs&r though! And I don't mean the &6&lATM Dev&r! \\n\\nShe can use her tentacles to break open a &5Water Vortex&r which will suck in all Entities nearby as bait for her. She can also summon &5Lasers&r from &5vortexs&r on the Ocean floor which will shoot upward. \\n\\nOnce you bring her beneath half &4Health&r she will become enraged! When enraged she will use her &5Lasers&r much more than before and attack relentlessly until the Oceans only have one being swimming in them."
-		"{image:atm:textures/questpics/cataclysm/cataclysm_leviathan.png width:100 height:100 align:center}"
-	]
-	quest.746DE905D45A396C.title: "&5&lThe Leviathan&r"
+	quest.746DE905D45A396C.quest_desc: ["&5The Leviathan&r is the reason people fear the Ocean. It has 12000 Hearts, sharp teeth, and strong tentacles. It can chomp on you, smack you with its tentacles, or can hold you still and fire a Godzilla like beam at you. When brought below half health its beams become much more used and much more dangerous. It will fire beams all around it and will randomly fire them from its mouth at you. If you some how kill it you'll be granted a Tidal Claw, an Abyssal Egg, and could be a music disc: Endless Storm."]
+	quest.746DE905D45A396C.title: "&5The Leviathan&r"
 	quest.74726A2DD4BBDA7B.quest_desc: [
 		"Titanium mixed with Duranium. "
 		""
@@ -11752,17 +11956,14 @@
 		"But thatll come a bit later. Were not there yet."
 	]
 	quest.74726A2DD4BBDA7B.quest_subtitle: "Now thats Stronk"
-	quest.747B62A955D0C629.quest_desc: [
-		"&4The Ancient Factory&r lies deep underground in the &2Overworld&r. \\n\\nYou'll find many Redstone Items like Levers, Powered Rails, and EMPs... I wonder if those will be useful soon? \\n\\nYou'll also find some Redstone Machines trying to kill you! Like the &4Watchers &fand &4Prowlers&r! \\n\\nEven with the danger there's still tons of Loot and Blocks you can steal from here, especially Redstone."
-		"{image:atm:textures/questpics/cataclysm/cataclysm_factory.png width:200 height:100 align:center}"
-	]
-	quest.747B62A955D0C629.title: "&4Ancient Factory&r: Home of &4&lThe Harbinger&r"
+	quest.747B62A955D0C629.quest_desc: ["&4The Ancient Factory&r lies deep underground in the &2Overworld&r. With many redstone machines including &4The Watchers&r, &4The Prowler&r, and &4The Harbinger&r. You'll also find EMPs which when powered with redstone will damage things around it."]
+	quest.747B62A955D0C629.title: "&4Ancient Factory&r: Home of &4The Harbinger&r"
 	quest.747BA0DB44A49A4F.quest_subtitle: "Red Delicious Apple + Sand Pear"
 	quest.748A01B5607C475B.quest_desc: ["Holds Talismans... not much else. Might also hold your Pants up but haven't tested it yet."]
 	quest.748A01B5607C475B.quest_subtitle: "Found in Mineshafts or Strongholds"
 	quest.748A01B5607C475B.title: "&6Leather Belt"
-	quest.74ACCEB6DC9EF6F7.quest_desc: ["The &dVoid &4Assault Shoulder Weapon &d(V.&4A.S.W.)&r is just like the Wither version but better! \\n\\nNow it only shoots &dVoid &4Howitzers&r which will do more Damage and cause &dVoid Runes&r to come out of the ground, in the area the &4Howitzer&r hit. \\n\\nJust at the cost of the long cooldown, but we've got time to wait. \\n\\nIt can crafted by combining the &4W.A.S.W.&r and a &dVoid Core&r in the &4Mechanical Infusion Anvil&r."]
-	quest.74ACCEB6DC9EF6F7.title: "&dV.&4A.S.W. &d(Void &4Assault Shoulder Weapon)"
+	quest.74ACCEB6DC9EF6F7.quest_desc: ["The Void Assault Shoulder Weapon (V.A.S.W.) is just like the Wither version but better. Now it only shoots Void Howitzers which will do more damage and cause void runes to come out of the ground in the area the Howitzer hit. Just at the cost of the long cooldown, but we've got time to wait. It can crafted by combining the WASW and a Void Core in the Mechanical Infusion Anvil."]
+	quest.74ACCEB6DC9EF6F7.title: "V.A.S.W. (Void Assault Shoulder Weapon)"
 	quest.74AE214747A3DB1A.quest_desc: ["Increases how much pressure things can hold."]
 	quest.74AE214747A3DB1A.quest_subtitle: "Turn it up!"
 	quest.74B0308336F5E017.quest_desc: ["The &cBlood Chest&r can be used to repair items using &cBlood&r.\\n\\nHowever, items repaired might become &dCursed&r..."]
@@ -11808,7 +12009,6 @@
 		"You may want to figure a way to passively produce these..."
 	]
 	quest.754229E1F1D2DA8A.quest_subtitle: "I prefer the window seat"
-	quest.754500BB7FD8C413.quest_subtitle: "Tier: &b4"
 	quest.75560045ED084900.quest_desc: [
 		"Most seeds are simple to make, but to make &9Mob Seeds&r, you'll need to head to the Nether to pick up some &8Soulium&r. "
 		""
@@ -11898,7 +12098,6 @@
 	quest.76406EFFF8CBA6B4.title: "We've Struck &bDiamonds&r!"
 	quest.764609E41957DA69.quest_subtitle: "6,561 Emerald Blocks"
 	quest.7649D648A3688D4A.quest_desc: ["The Puller Upgrade allows Drawers to pull in items from any side."]
-	quest.76516C997B63905A.quest_subtitle: "Tier: &b4"
 	quest.76558D23A70AFF78.title: "&bIce&r Upgrade Orb"
 	quest.7655E1C6C5E5469F.quest_subtitle: "Range: &a18&r Blocks"
 	quest.7655E1C6C5E5469F.title: "&2Prudentium Growth Accelerator"
@@ -11911,12 +12110,12 @@
 	quest.7666D2DA3D0C3F00.quest_desc: ["The ZPM Mixer is needed to craft the Uranium Rhodium Dinaquadide that we need for our Fusion Reactor Mk.II."]
 	quest.7666D2DA3D0C3F00.quest_subtitle: "Mixin' it up!"
 	quest.766C80E5D7B7A916.quest_subtitle: "Pick one!"
-	quest.766EEB89C6DF3575.quest_desc: ["Eternal Stella can be used to either make an Item Unbreakable by combining it with the Item in a Smithing Table. Or you can use it to craft Alloy Tools! \\n\\nFirst, you'll need a Tier 3 Forge with plenty Materials in it. \\n\\nThen, you'll need 3 Xpetrified Orbs. Which you need to feed a Black Hole Items to get. \\n\\nPlus, a Stellarite Piece which you need to Mine for! And &6Allthemodium Ingot&r which is the same."]
+	quest.766EEB89C6DF3575.quest_desc: ["Eternal Stella can be used to either make an Item Unbreakable by combining it with the Item in a Smithing Table. Or you can use it to craft Alloy Tools! \\n\\nFirst, you'll need a Tier 3 Forge with plenty Materials in it. \\n\\nThen, you'll need 3 Xpetrified Orbs. Which you need to feed a Black Hole Items to get. \\n\\nPlus, a Stellarite Piece which you need to Mine for! And &6AllTheModium Ingot&r which is the same."]
 	quest.7671AFAA1EFD287F.quest_desc: ["You want to slowly automate &bAureal&r for your &6&lForge&r? Then, you'll need 2 &bArcane Crystal Blocks&r, &6Arcane Polished Darkstone&r, and &cMundabitur Dust&r! \\n\\nPlace down the &6Arcane Polished Darkstone&r, then on top of it place both &bArcane Crystal Blocks&r. \\n\\nOnce you get this 1x3x1 Structure, Right Click it with &cMundabitur Dust&r to make the &bObelisk&r! \\n\\nYou can place these, where the Pedestals usually go, in the &6&lForge Multiblock&r in order to automate &bAureal&r!"]
 	quest.7671AFAA1EFD287F.title: "&bArcane Crystal Obelisk"
 	quest.7678B5DD1339833E.quest_desc: ["The Solar Panel generates FE when given direct access to the sun. However, you can use a &7Lens of Ender&r to ignore blocks in its way."]
 	quest.767E4FC03B6F6534.quest_desc: ["Invar Ingots are made with &7Iron&r and &7Nickel&r. \\n\\nLike a lot of these Alloys they aren't useful in &8&lIE&r."]
-	quest.767E4FC03B6F6534.title: "&7Invar Ingot"
+	quest.767E4FC03B6F6534.title: "Invar Ingot"
 	quest.768951FBE8A5C934.quest_desc: [
 		"If we needed something that could ensure the transmission of every tier, with the highest level of efficiency, what would we get?"
 		""
@@ -11956,7 +12155,7 @@
 	quest.76E94639E90FEB4E.quest_subtitle: "Spawned with empty Beehives in the Dark"
 	quest.76E94639E90FEB4E.title: "Skeletal Bee"
 	quest.76EA017B12E8F01B.quest_desc: ["This section shows you different ways to store your power!"]
-	quest.76EA017B12E8F01B.title: "&f&lStoring Power"
+	quest.76EA017B12E8F01B.title: "Storing Power"
 	quest.76ECB0EF7A5E410A.quest_desc: [
 		"Electrolyzers are important, but they are also small, and we use them for quite a few processing lines. "
 		""
@@ -11975,7 +12174,7 @@
 	quest.773543FFEF631C5E.quest_subtitle: "Basic Building Blocks"
 	quest.77382D4114E901CB.quest_desc: ["The &n&5Hose Pulley&r is a pump that can extract liquids or place liquids in the world."]
 	quest.7741905EA8380B25.quest_desc: ["&aArmor Trims&r are items used to add trims to your armor! This can be done in Smithing Tables.\\n\\nWhile they do have a recipe, most of the trims are rare finds in from loot chests or archaeology digs. Once you find one, you can dupe the Template by using the recipe to create more!"]
-	quest.7741905EA8380B25.title: "&dArmor Trims"
+	quest.7741905EA8380B25.title: "&dArmor Trims&r"
 	quest.7744BEC5CD328262.quest_desc: ["In order to mine Blocks &bunderwater&r you'll need this Upgrade. \\n\\nIt also gives you Aqua Affinity! (That means being in &bWater&r doesn't slow down your Mining.)"]
 	quest.7749703A10B78AB1.quest_desc: ["First Ability with &8Drowned Belt&r is in the name, it's a Belt, it holds Talismans. \\n \\nThe Second one works with swimming in the &9Water&r. Ever get jealous of how the Drowned move through the &9Water&r as if it were their home? Well with this Ability you can get similar! \\n \\nThe Third one works like Impaling, you'll do increased Damage in the &9Water&r. \\n \\nAnd the Last Ability also works with Trident Enchanting, you can now use Channeling anywhere regardless of how wet!"]
 	quest.7749703A10B78AB1.quest_subtitle: "Found in Shipwrecks and Ocean Ruins"
@@ -11986,7 +12185,7 @@
 		"HSLA steels vary from other steels in that they are not made to meet a specific chemical composition but rather specific mechanical properties."
 	]
 	quest.7759519157B8C1D8.quest_subtitle: "Anti-Acidic Steel"
-	quest.775AB10F8196F27B.quest_desc: ["The &4Eye of Mech&r will take you to the &4Ancient Factory&r to fight &4&lThe Harbinger&r."]
+	quest.775AB10F8196F27B.quest_desc: ["&4The Eye of Mech&r will take you to the &4Ancient Factory&r to fight &4The Harbinger&r"]
 	quest.775AB10F8196F27B.title: "&4Eye of Mech&r"
 	quest.775D176081DD75F5.quest_desc: [
 		"Right-clicking on a Turbine Controller when it is fully built will show you the Turbine Interface.\\n\\nHere, you can see all of the stats for the Turbine. Hovering over each will tell you more info about each one.\\n\\nOn the bottom left, you'll have 2 arrows to control the &9Flow Rate&r. This controls how much heated vapor is pumped into the Turbine. To know how much you should set this to, check your reactor's &dVapor Production Rate&r as a starting point. "
@@ -12058,8 +12257,7 @@
 		"Wondering why you would use this? Imagine having a Builder or Quarry pump Silk-Touched Ores into your system. You can have a Constructor place these ores, then a Destructor with Fortune on it to break it for even more raw ores."
 	]
 	quest.787415570026FFAA.title: "Destructor Upgrade"
-	quest.7878F190BC8ADC82.quest_desc: ["The best of the best. From Diamonds, to the Nether Star, to Allthemodium. This Rod finds only the best Items!"]
-	quest.787E714014EC2C02.quest_subtitle: "Tier: &63"
+	quest.7878F190BC8ADC82.quest_desc: ["The best of the best. From Diamonds, to the Nether Star, to AllTheModium. This Rod finds only the best Items!"]
 	quest.78840993C7832E89.quest_desc: [
 		"Valid Upgrades:"
 		"- Tree Feller"
@@ -12142,7 +12340,8 @@
 		""
 		"You will still need to be under the effects of the &3Third Eye&r to be able to harvest the Otherworld block."
 	]
-	quest.78ECC28DD4BA9696.title: "Hunting For &dOtherworld&r Materials"
+	quest.78ECC28DD4BA9696.quest_subtitle: "Hunting for &dOtherworld&r Materials"
+	quest.78ECC28DD4BA9696.title: "Tools of the Trade: Divination Rod"
 	quest.78FEDE6FA4845585.quest_desc: ["Some infusions need very very exact amounts of &aEterna&r, &cQuanta&r, or &5Arcana&r to get these you might need one of these shelves. Each lowers the amount of its respective amounts."]
 	quest.78FEDE6FA4845585.title: "&cNegative amounts"
 	quest.790EC3EDC2DB1FB0.quest_desc: ["Like it was mentioned before. This mod adds a ton of fun ways to generate power that require specific builds."]
@@ -12174,7 +12373,6 @@
 		"We arent at the top tier yet, but still, you will notice that these machines are running processes from previous tiers at incredible rates!"
 	]
 	quest.7936FF3ED75DCA59.quest_subtitle: "New Tier, New Machines!"
-	quest.7940E814260C556F.title: "&bReinforced Alloy"
 	quest.7941938014E97A30.quest_desc: ["Have you ever wanted to fly on a bee?\\n\\nBumble Bees naturally spawn in the world, and they can be used as mounts!\\n\\nMake yourself a &6Treat on a Stick&r, slap a saddle on a Bumble Bee, and take to the skies!"]
 	quest.7941938014E97A30.quest_subtitle: "Spawns in the Overworld from Bumble Bee Nests"
 	quest.7941938014E97A30.title: "Bumble Bee"
@@ -12233,7 +12431,11 @@
 	quest.7992C63F063BE908.title: "&7Scroll of Explosive Mana Condensation"
 	quest.799CC9FEEDE471B1.quest_subtitle: "Mango + Star Anise"
 	quest.79A19D0B2F94EFDC.quest_desc: ["Allows a Mana Burst to home in on any nearby blocks that can receive Mana. This also slightly decreases the speed of the burst."]
-	quest.79AD74A863EA43CB.quest_desc: ["Flux Networks does provide a way to store the power you generate for your network!\\n\\nThese hold massive amounts of power overall, and can be upgraded to store even more!"]
+	quest.79AD74A863EA43CB.quest_desc: [
+		"Flux Networks does provide a way to store the power you generate for your network! "
+		""
+		"These hold massive amounts of power overall, and can be upgraded to store even more!"
+	]
 	quest.79AD74A863EA43CB.quest_subtitle: "Storing Power"
 	quest.79AD74A863EA43CB.title: "Flux Storage"
 	quest.79AF63E77AD70A93.quest_desc: ["Bookshelves are your starting point, but definitely not your end point. Atleast not normal bookshelves. With only normal bookshelves you can only get &aEterna&r up and to a max of 30. (I will explain the Enchantment Levels soon but just know you need them up)"]
@@ -12352,8 +12554,6 @@
 	quest.7A89560F303A8BE6.quest_subtitle: "Tier: &63"
 	quest.7A93F07BE2E6EC97.quest_desc: ["When it's raining, throwing in a &aWeather Container&r will harness the power of the rain.\\n\\nWith this, you can create an &9Infinite Water Bucket&r, or an &9Infinite Water Source Block&r. These are both incredibly useful items to have!\\n\\nYou can also just do this to get rid of the rain!"]
 	quest.7A93F07BE2E6EC97.title: "&aStop the &9Rain!"
-	quest.7A979BEB20C9591E.quest_desc: ["Flux Dust can be automated using &6Productive Bees&r!\\n\\nRedstone Bee Spawn Eggs can be converted to Flux Dust Bee Spawn Eggs using an Obsidian Bee."]
-	quest.7A979BEB20C9591E.title: "Automated Flux Dust"
 	quest.7A9AE63998BB41FF.quest_desc: ["To determine when the Spawner will spawn it picks a random number between maximum and minimum spawn delay. The Minimum can be as low as 20 to as high as 32,767. Each piece of sugar modifies the min delay up or down by 10."]
 	quest.7A9AE63998BB41FF.title: "Minimum Spawn Delay"
 	quest.7AADB58621BC1254.quest_desc: ["The Forge Hammer and the Hammer will save you a lot of resources early game by allowing you to turn ingots into plates and other different shapes at a reduced cost! Eventually you'll use STEAM to do this for you, but early on this will help you save costs while you work towards your automation."]
@@ -12384,11 +12584,9 @@
 	quest.7AE6AF0B5D3390E7.quest_desc: ["So much of the work that has been done was directly to support being able to construct the &n&l&5Star Forge!&r&r&r"]
 	quest.7AE6AF0B5D3390E7.quest_subtitle: "Crafting the Cosmos"
 	quest.7AE85F4FF4DDF4F2.quest_desc: ["The Windmill is another option we can use with the Kinetic Dynamo! \\n\\nThese will automatically start moving and with its speed we get Energy, so more speed more Energy. \\n\\nHow do we get speed? Well for one, it needs space in front of it to work. The less blocks in front of it, the quicker it goes! \\n\\nAnother factor into speed is Windmill Sails. You can add 8 Windmill Sails in total by Right Clicking the middle Windmill Block with the Sails in hand."]
-	quest.7AED8FD7FB023AD8.quest_desc: ["To power up &4&lThe Harbinger&r you'll need a Nether Star, which you get from killing the Wither. \\n\\nIt's a &2&lVanilla&r mechanic I shouldn't have to explain. \\n\\nPlus it's in Chapter 1."]
-	quest.7AED8FD7FB023AD8.quest_subtitle: "Powering The Harbinger"
+	quest.7AED8FD7FB023AD8.quest_desc: ["To power up &4The Harbinger&r you'll need a Nether Star, which you get from killing the Wither. It's a vanilla mechanic I shouldn't have to explain."]
+	quest.7AED8FD7FB023AD8.quest_subtitle: "Powering The Harbringer"
 	quest.7AED8FD7FB023AD8.title: "Nether Star"
-	quest.7AEE4BE3AB41ED3E.quest_desc: ["Just combine an &bIgnitium Chestplate&r with an Elytra... that simple!"]
-	quest.7AEE4BE3AB41ED3E.title: "&bIgnitium Elytra Chestplate"
 	quest.7AEFF81E7C8CF300.quest_desc: ["Using Shift Right Click when holding a JDT tool or wand will open the configuration menu where the player can configure and toggle abilities."]
 	quest.7AFEEC895FB293D6.title: "Kyanite Vein"
 	quest.7B0764DDE94E73D0.quest_desc: [
@@ -12467,6 +12665,8 @@
 	quest.7BC616DDB5933479.quest_desc: ["This one can be created with a &5Blood Vial&r and normal ingrediants for Scrolls. \\nYou will need to make sure it is Level 10 and &6Legendary&r which you can upgrade it to."]
 	quest.7BC616DDB5933479.title: "&4Wither Skull Scroll"
 	quest.7BC8F50A89A3BE1A.quest_desc: ["These are just used to Connect &cLaser Nodes&r to each other and to Connectors. Not too important I just wanted to keep with the theme of Wrenches. \\n\\nIt does work as a Wrench for other Configs!"]
+	quest.7BCD4A425CF6199B.quest_desc: ["After slaying the Goat of Mercy summoned from &9Xeovrenth Adjure&r, you'll find yourself one Cruelty Essence richer. Combine this with some cocao beans to create Brown Chalk."]
+	quest.7BCD4A425CF6199B.title: "&#4E2C00Brown Chalk"
 	quest.7BCE96070C36D547.quest_subtitle: "&f7.5 &cAttack Damage"
 	quest.7BFC24607189B6D0.quest_desc: ["Makes you swim faster."]
 	quest.7BFC24607189B6D0.quest_subtitle: "Max: 1"
@@ -12513,7 +12713,7 @@
 	quest.7C79BCE482A06199.title: "&b&lIce"
 	quest.7C7C0D3D7FCB0297.quest_desc: ["Can be found in structures in the &6&lBumblezone&r or traded for with the &5Bee Queen&r! \\n\\n&6B&8e&6e&8s&r have quite an interesting way of finding and communicating with each other. I don't know how they do it so I'm just going to guess their Antennas give and receive radio signals. \\n\\nWhile wearing the Stingless Bee Helmet you can Shift to highlight all &6B&8e&6e&8s&r around you. \\n\\nAlso while wearing it, poison and nausea will go away quicker."]
 	quest.7C83735C2D746162.quest_subtitle: "Increases Generation Rate at the Cost of Efficiency"
-	quest.7C848C7011726470.quest_desc: ["The &cEye of Monstrous&r will take you to the &cSoul BlackSmith&r to fight the &c&lNetherite Monstrousity&r."]
+	quest.7C848C7011726470.quest_desc: ["&cThe Eye of Monstrous&r will take you to the &cSoul BlackSmith&r to fight the &cNetherite Monstrousity&r"]
 	quest.7C848C7011726470.title: "&cEye of Monstrous&r"
 	quest.7C8CDD259495A31A.quest_desc: ["The &n&5Tunnels&r can be placed on belts and they will filter items that pass through them. You can link multiple tunnels by placing them next to each other."]
 	quest.7C8D74692C963000.quest_desc: [
@@ -12550,7 +12750,7 @@
 	quest.7CA60DC31447E57A.quest_subtitle: "&f7 &cAttack Damage"
 	quest.7CB3FCD789747EF5.quest_desc: ["This block enables smelting recipes in your kitchen multi-block!"]
 	quest.7CB3FCD789747EF5.title: "Honey, there's a Furnace in the Kitchen"
-	quest.7CBEBBCB9D95D11A.quest_desc: ["The &5Abyssal Egg&r is also a drop from &5&lThe Leviathan&r, because apparently you killed a pregnant one. \\n\\nPlace the &5Egg&r down in Water, then wait awhile and you'll have your own baby &5Leviathan&r. \\n\\nOnce its hatched you can feed it a ton of Tropical Fish to tame it. \\n\\nThe &5baby&r has 2400 &4Hearts&r and can heal by feeding it Tropical Fish. \\n\\nOnce tamed, like the &eModern Remnant&r it can be set with Shift Right Click to follow or stay or wander."]
+	quest.7CBEBBCB9D95D11A.quest_desc: ["The Abyssal Egg is also a drop from &5The Leviathan&r, because apparently you killed a pregnant one. Place down the Egg and wait awhile and you'll have your own baby Leviathan. Like its mother it'll attack other sea creatures. Unlike its mother it won't attack you first."]
 	quest.7CBEBBCB9D95D11A.title: "Abyssal Egg"
 	quest.7CC2D826CA6BBDDB.quest_desc: [
 		"The &9Alchemy Table&r can craft various objects, catalysts, and more by using LP from a player's Soul Network (aka using a Blood Orb)."
@@ -12596,11 +12796,8 @@
 	quest.7D43016926E77150.title: "&9Imperium Armor&r"
 	quest.7D49A41E4D63A596.quest_subtitle: "Reduces Catalyst Usage"
 	quest.7D52DD751DDADA1B.quest_desc: ["The basic cables for transferring power."]
-	quest.7D57A14810BC0CBE.quest_desc: [
-		"Once you use the &bBurning Ashes&r on the &bAlter of Flame&r you'll get the &b&lIgnis&r. \\nHe has 11,250 &4Hearts&r and has a massive &bSword &fand &bShield&r. \\n\\nThe &bShield&r will block damage you give and the &bSword&r can be used to slice and stab you. Once stabbed, you can't move, you can only attack. \\n\\nHe can also pounce on you, when he does, he will slam his &bShield&r down, making a Shockwave which will toss Blocks and you into the Air. He can do the same with his &bSword&r just without the need to pounce. \\n\\nAnother attack he has is &bFireballs&r. He will throw 3 &bFireballs&r into the Air, then they will be sent flying toward you! Hit them back at him as if they were a Ghast Fireball. \\n\\nOnce you beat his &4Health&r to around 7,500 &4Hearts&r he will change colors to a &bLight Blue color&r. Now he will Attack quicker, deal more Damage, and get Lifesteal. \\n\\nHis &bFireballs&r will also not be able to be reflected and he can now make different types of Shockwaves!"
-		"{image:atm:textures/questpics/cataclysm/cataclysm_ignis.png width:100 height:100 align:center}"
-	]
-	quest.7D57A14810BC0CBE.title: "&b&lIgnis&r"
+	quest.7D57A14810BC0CBE.quest_desc: ["Once you use the Burning Ashes on the Alter of Flame you'll get the &bIgnis&r. He has 6750 Hearts and has a massive sword and shield. The shield will block damage you give and the sword can be used to stab you. Once stabbed, you can't move you can only attack. He can also pounce on you and throw fireballs at you. Once you beat his health halfway he will start stage 2. At stage 2 he will change colors to a light blue and will get many more attacks with his sword and shield. Also throughout the fight all damage he gives to you, heals him. Once defeated he'll drop 1 Ignitium which you can use to craft your own versions of his weapons. He also might drop his music disc: God of Blaze."]
+	quest.7D57A14810BC0CBE.title: "&bIgnis&r"
 	quest.7D5F805A6F2551F0.quest_desc: [
 		"Passiving oxygen early on is highly recommended, as it is used a lot"
 		""
@@ -12760,12 +12957,15 @@
 	quest.7EFBAF3E281D2EBE.quest_subtitle: "The spare chest"
 	quest.7EFBFF5D0DA018E7.quest_desc: ["Adds a filter for items you want to auto-delete in the Backpack."]
 	quest.7EFBFF5D0DA018E7.quest_subtitle: "Adds a filter for items you want to auto-delete in the backpack."
-	quest.7EFEE009212A4FD4.quest_subtitle: "Tier: &63"
 	quest.7F042DED357DEF3C.quest_desc: ["Bookshelves are your starting point, but definitely not your end point. Atleast not normal bookshelves. With only normal bookshelves you can only get &aEterna&r up and to a max of 15. (I will explain the Enchantment Levels soon but just know you need them up)"]
 	quest.7F042DED357DEF3C.title: "Vanilla Max is just the start"
 	quest.7F076FC4F2187692.quest_subtitle: "&f8 &cAttack Damage"
-	quest.7F09F8F98C13F11B.quest_desc: ["What is a Demonic Ritual without a &cSacrifice&r! :D\\n\\nMost of the time, Demons just like items so don't be too afraid yet. However, if you have a favorite Cow, you might need to be worried. Sorry Betsy.\\n\\n&aSacrifical Bowls&r are used to place items needed for Rituals. These can be placed anywhere within the Ritual, as long as it isn't convering up any of the required Chalk.\\n\\nThe &6Golden Sacrificial Bowl&r is used in the middle of the Ritual to activate it, and also usually needs a Book of Binding for the Ritual in it."]
-	quest.7F09F8F98C13F11B.title: "Preparing for a Ritual: &dCrystals"
+	quest.7F09F8F98C13F11B.quest_desc: [
+		"What is a Demonic Ritual without a &cSacrifice&r! :D\\n\\nMost of the time, Demons just like items so don't be too afraid yet. However, if you have a favorite Cow, you might need to be worried. Sorry Betsy.\\n\\n&aSacrifical Bowls&r are used to place items needed for Rituals. These can be placed anywhere within the Ritual, as long as it isn't convering up any of the required Chalk. "
+		""
+		"For now, you'll only need four, but later on you'll need upwards of ten bowls for each ritual!\\n\\nThe &6Golden Sacrificial Bowl&r is used in the middle of the Ritual to activate it, and also usually needs a Book of Binding for the Ritual in it."
+	]
+	quest.7F09F8F98C13F11B.title: "Preparing for a Ritual: &6Bowls"
 	quest.7F0B2D58361FB00E.quest_desc: ["Just Dire Things is a jack of all trades mod. Just Dire Things adds a new crafting mechanic called Goo Spread, along with machines that assist in the automation of Goo Spread and other utilities."]
 	quest.7F0B2D58361FB00E.title: "Just Dire Things"
 	quest.7F0D59EC1573FDC0.quest_desc: ["The &n&5Depot&r is used to store items, mainly for the Spout."]
@@ -12782,10 +12982,10 @@
 	quest.7F2D696AC9F4C4E4.quest_desc: ["'&bMirror Mirror&r on the wall how do I get back to my Respawn Point from my travels?' \\n \\n'After setting the &bMagic Mirror&r to a Bed by right clicking with it, you can hold right click for the &bMagic Mirror&r to teleport you back to your bed!' \\n \\n'Thank you &bMirror&r!'"]
 	quest.7F2D696AC9F4C4E4.quest_subtitle: "Found in Mineshafts or Strongholds"
 	quest.7F2D696AC9F4C4E4.title: "&bMagic Mirror"
-	quest.7F3B96033AB7A21E.title: "Allthemodium Apple"
-	quest.7F4963FCAE5337EC.quest_desc: ["Because just fighting the &b&lIgnis&r isn't hard enough, you'll have to fight the &bIgnited Revenant&r first to get &bBurning Ashes&r. \\n\\nOnce you have them, use them on the Altar of Fire to summon the &b&lIgnis&r."]
+	quest.7F3B96033AB7A21E.title: "AllTheModium Apple"
+	quest.7F4963FCAE5337EC.quest_desc: ["Because just fighting the &bIgnis&r isn't hard enough, you'll have to fight the &bIgnited Revenant&r first to get Burning Ashes. Once you have them use them on the Altar of Fire to summon the &bIgnis&r."]
 	quest.7F4963FCAE5337EC.quest_subtitle: "Relighting the Ignis"
-	quest.7F4963FCAE5337EC.title: "&bBurning Ashes"
+	quest.7F4963FCAE5337EC.title: "Burning Ashes"
 	quest.7F4B734CFB0F0306.quest_desc: ["These new &7Carts&r are similar to the special &2Vanilla&r &7Carts&r. The &7Minecart with a Tank&r will hold and move any Liquid held in it. The &7Minecart with an Energy cell&r will instead hold and move Energy!"]
 	quest.7F4B734CFB0F0306.title: "New Carts"
 	quest.7F59941D62E672B0.quest_desc: [
@@ -12838,7 +13038,7 @@
 	quest.7FA79ED5DABCF998.quest_subtitle: "Mix it up!"
 	quest.7FA85713C86166DA.quest_desc: ["Allows you to access your fluid grid wirelessly."]
 	quest.7FA85713C86166DA.title: "Wireless Fluid Grid"
-	quest.7FABB77A60E7962C.quest_desc: ["By infusing Obsidian with &bDiamonds&r we can get Refined Obsidian Dust! \\n\\nThen, we can compress &7Osmium&r into it to get it in Ingot form. \\n\\nAfter that, we can turn those Ingots into Armor with better stats than even &6Allthemodium Armor&r!"]
+	quest.7FABB77A60E7962C.quest_desc: ["By infusing Obsidian with &bDiamonds&r we can get Refined Obsidian Dust! \\n\\nThen, we can compress &7Osmium&r into it to get it in Ingot form. \\n\\nAfter that, we can turn those Ingots into Armor with better stats than even &6AllTheModium Armor&r!"]
 	quest.7FABB77A60E7962C.quest_subtitle: "31"
 	quest.7FABB77A60E7962C.title: "&5Refined Obsidian Armor"
 	quest.7FB12EC3A5888123.quest_desc: ["The &3Tube Junction&r gives you more control over the transportation of your pressure by allowing you to move your Pressure Tubes in more directions."]
@@ -12857,9 +13057,13 @@
 	quest.7FE273141D3DFFFD.title: "Fusilier"
 	quest.7FE2EED58AB791E8.quest_desc: ["Note: This accepts Tree Oil, Creosote Oil, and Refined Fuel."]
 	quest.7FE2EED58AB791E8.quest_subtitle: "Generates Power using Liquid Fuel!"
-	quest.7FE969CB4B419FC6.quest_desc: ["With a little work into Mekanism, this machine allows you to transfer anything wirelessly.\\n\\nYou can set specific channels to transfer individual items, energy, or even gases from Mekanism. It's pretty cool."]
-	quest.7FE969CB4B419FC6.quest_subtitle: "Doesn't just work for Power"
-	quest.7FE969CB4B419FC6.title: "&9Mekanism: &6Quantum Entangloporter"
+	quest.7FE969CB4B419FC6.quest_desc: [
+		"With a little work into Mekanism, this machine allows you to transfer anything wirelessly. "
+		""
+		"You can set specific channels to transfer individual items, energy, or even gases from Mekanism. It's pretty cool."
+	]
+	quest.7FE969CB4B419FC6.quest_subtitle: "Also works for items, gases, liquids, and heat."
+	quest.7FE969CB4B419FC6.title: "&9Wireless Transfer:&r &6Quantum Entangloporter&r"
 	quest.7FF77463F2A0E210.quest_desc: ["Nightfall Mud can only be found within the Dark Swamps. \\n\\nYou can make more Blocks out of it!"]
 	reward_table.04285B94275AB879.title: "Powah: Rods and Cables"
 	reward_table.047C4C58EC06DBF3.title: "Powah: Hardened"
@@ -12917,8 +13121,7 @@
 	task.01F96E4C1D881AD1.title: "Steel Comb"
 	task.01FD75641E5EA5E4.title: "Mana"
 	task.025A45B704969EAE.title: "Wye Tracks"
-	task.02B26D0D73E5E361.title: "Belts"
-	task.0303CDB18BBD9575.title: "AllRightsReserved"
+	task.02B26D0D73E5E361.title: "Types of Belts"
 	task.0309B0EB29771EC0.title: "Blacksmith Gavel"
 	task.030FFC7C0532E7B2.title: "Kill 3 Honey Slimes"
 	task.034F49638F207523.title: "Iron Chests"
@@ -12926,6 +13129,7 @@
 	task.0362C10508FC4615.title: "Maintenance"
 	task.036759CF4EEFFC7D.title: "AllRightsReserved"
 	task.03982D782B426ABB.title: "AllRightsReserved"
+	task.03A4FFC4CFCA5DB7.title: "End Game Power Options"
 	task.03ACF4486D706DEE.title: "Vibranium Armor"
 	task.03AE084C781CBA31.title: "Track Kits"
 	task.03EB390E79866058.title: "Sourcestones"
@@ -12949,7 +13153,6 @@
 	task.083DE18D8C046344.title: "Valid Ores"
 	task.0896EE64F92CCD86.title: "Macaw's Doors"
 	task.08DA73B1AC17E5F5.title: "Crafting Storage"
-	task.098F1B932F851616.title: "Pipe Upgrades"
 	task.09C7E50E7E13C53C.title: "AllRightsReserved"
 	task.0A77407CE9055F04.title: "Sweat Bee"
 	task.0AD65BDFBE16460E.title: "Observe Complete Large Extraction Machine"
@@ -12959,8 +13162,6 @@
 	task.0B31B1E6089BB33E.title: "Observe a completed Fusion Reactor"
 	task.0B54EDC9E21F2E77.title: "Logistics Frames"
 	task.0B62C759781950A1.title: "IE Railgun Ammo"
-	task.0B79080463C860ED.title: "Wandering Trader Carpets"
-	task.0B7F934439806558.title: "AllRightsReserved"
 	task.0BAEC53DD32C9870.title: "Productive Trees Logs"
 	task.0BD1BA7949BB5855.title: "Mechanical Pistons"
 	task.0BFAF56214875C90.title: "Allthemodium Mage Armor"
@@ -12976,6 +13177,7 @@
 	task.0E6876A34D1975EB.title: "AllRightsReserved"
 	task.0E7E336483AFA69C.title: "Vibranium Mage Armor"
 	task.0E7EAD7D7DF5E7C3.title: "AllRightsReserved"
+	task.0EA4B08DAAFA4287.title: "Kill 5 Endermen"
 	task.0EBE231AB868C868.title: "Blocks"
 	task.0ED34925D7A494BF.title: "Sifter"
 	task.0EE3A88719BB0221.title: "Infusion"
@@ -12983,9 +13185,9 @@
 	task.0EF1CA8DED2FF38C.title: "Advanced Beehives"
 	task.0F0F3C716F921B64.title: "Voltage"
 	task.0F2BCC279B5731AB.title: "Amethyst Comb"
-	task.0F7D7AE91E20F778.title: "Coal Generators"
 	task.0F9FCFCEE795FD41.title: "Visit The Other"
 	task.100BBEDCB73557BC.title: "Pressure Mechanic"
+	task.1016033CBB003413.title: "Kill 5 Wither Skeletons"
 	task.1038F300D9F8EF3C.title: "Observe formed Large Chemical Reactor"
 	task.103C42C743E2A2DB.title: "Claiming Chunks"
 	task.104E1A4BF3520D67.title: "Reactor Glass"
@@ -13011,6 +13213,7 @@
 	task.1693B07767081FB3.title: "Armor Trims"
 	task.16EF7FF802D5A2BB.title: "Framed Blocks"
 	task.1709A45C149125F1.title: "AllRightsReserved"
+	task.1718CA0F8978181C.title: "Kill 5 Blazes"
 	task.171FD27057746E80.title: "Kill 1 Wither"
 	task.173044E1C1134A80.title: "Cobblestone"
 	task.173B725A839DEEAA.title: "Common Projectiles"
@@ -13020,6 +13223,7 @@
 	task.1809DDEA104A9CE8.title: "AllRightsReserved"
 	task.1809F1F9A3043683.title: "Kill 1 Ender Dragon"
 	task.181135E3A83C5B9E.title: "Zinc Comb"
+	task.18644A08B73A4B12.title: "Kill 5 Spiders"
 	task.1869893A4F8E9E9C.title: "Ore Hammers"
 	task.187F7B08BCC7202F.title: "Alloy Blast Smelter"
 	task.1884D3DA3CCC1439.title: "AllRightsReserved"
@@ -13032,7 +13236,6 @@
 	task.19CB734FC0897E75.title: "Creative Virtual Storage Power"
 	task.19DF62F00979AEA2.title: "&5The Alchemist"
 	task.19E2DE9D89B89D7B.title: "Spike Mauls"
-	task.19E65997851BC46E.title: "Quests By AllTheMods"
 	task.1A4F2611944EF2EE.title: "The Knowledge of the Gatekeeper"
 	task.1A66B7FFB4E2163E.title: "Vanilla Logs"
 	task.1A7078C3984DD910.title: "Netherite BLocks"
@@ -13115,11 +13318,12 @@
 	task.2BC0F5A88E2F03C3.title: "Archwood Logs"
 	task.2BECEC3EFA8F6DA3.title: "Chipped Stones"
 	task.2C268116DA162155.title: "AllRightsReserved"
+	task.2C5C6F411E2F0CAF.title: "Any #c:dusts/netherite"
 	task.2C621D97D1ED56DE.title: "FE Generation"
 	task.2C816285392535F0.title: "AllRightsReserved"
 	task.2CC38211F4C54ED8.title: "Draconic Comb"
 	task.2CE553B282962E01.title: "Buckets"
-	task.2D0212699F99459F.title: "The First Network"
+	task.2D0212699F99459F.title: "My First Network"
 	task.2D783271D8830D0E.title: "Steam Boilers"
 	task.2D9B8AF6C76D9CEA.title: "Tungsten Ingot"
 	task.2DA0BD7B2834A560.title: "Witherproof Blocks"
@@ -13152,7 +13356,6 @@
 	task.32447C5882610D6C.title: "Visit The End"
 	task.3282910297C28795.title: "AllRightsReserved"
 	task.32CB6A7BC1AB644E.title: "Simply Light"
-	task.330BFC92D5AEAD82.title: "Quests By AllTheMods"
 	task.335D80E83360A7DB.title: "Understanding Ether Gas"
 	task.337725ECA2C04090.title: "Logical Transporters"
 	task.338A6DA0D711B7DC.title: "ME Pattern Provider"
@@ -13161,6 +13364,7 @@
 	task.345245C32DB7B4D4.title: "Redstone Comb"
 	task.34551E919FD101CF.title: "Imperium Tools"
 	task.3489080F5FDE8B1B.title: "Heat"
+	task.348A7E3E3A3D324E.title: "Yes, I've read this and totally won't forget it!"
 	task.3490AE43AD653256.title: "Turnout Tracks"
 	task.349B2DA0A38AE9B5.title: "Framed Drawers"
 	task.34B6EB0B801E4743.title: "Netherite Chests"
@@ -13169,7 +13373,7 @@
 	task.34E5BD34C83CD6F9.title: "AllRightsReserved"
 	task.35320BB07FB39D05.title: "AllRightsReserved"
 	task.359396879CBA62D5.title: "Nest Spawning"
-	task.35C1DBD4544C9BB0.title: "Induction Cells"
+	task.3621D48E2CFAF2C2.title: "Any #c:wools"
 	task.362D501E0D663695.title: "RFTools Storage"
 	task.36397CBA6D39DC0D.title: "Tungsten Ingot"
 	task.363BADA865C39474.title: "AllRightsReserved"
@@ -13185,6 +13389,7 @@
 	task.3861678346D376C1.title: "Auxiliary Reaction Chamber"
 	task.386645685E595D4D.title: "PHOBIA ALERT"
 	task.388545A0E3B4930D.title: "AllRightsReserved"
+	task.3893B57532491926.title: "Find Portal Ruins"
 	task.389B5B0F35B89FC8.title: "Chipped Concrete"
 	task.38B6F45109CB033A.title: "AllRightsReserved"
 	task.38E166AC8F55D42E.title: "Upgrades"
@@ -13218,6 +13423,7 @@
 	task.3DC008A578A93CCF.title: "Tips and Tricks!"
 	task.3DE460F842195173.title: "Ashy Mining Bee"
 	task.3E133AC7B615971D.title: "Supremium Tools"
+	task.3E7F26D68D9A166B.title: "Basic Storage"
 	task.3E8F4263F7053EDD.title: "Carts"
 	task.3F53EFE85005BEEF.title: "Saplings"
 	task.3F5D1730023562C7.title: "Observe Formed EBF"
@@ -13236,6 +13442,7 @@
 	task.41FF171C7D97B574.title: "Chipped Gem Blocks"
 	task.4203F7ED807F3D30.title: "Skeletal Comb"
 	task.4209A06A392362DB.title: "Importer \\& Exporter GUI"
+	task.423AF6C6647B1626.title: "Kill 5 Creepers"
 	task.427138127BEBAEAF.title: "Carbon dust"
 	task.429FA8057B666565.title: "Lapis Comb"
 	task.42DA8E971B27ACED.title: "Tipped Out"
@@ -13248,8 +13455,6 @@
 	task.4448DE84ABA737BE.title: "Universal Cables"
 	task.4471A530B55D4140.title: "Osmium Comb"
 	task.44A3CDE54F2A5149.title: "Gaia Trinkets"
-	task.44BDEA5268F6ABE6.title: "Supply Camps"
-	task.44C02386C9B8E0D3.title: "Induction Providers"
 	task.44CEA28EBD6C0898.title: "AllRightsReserved"
 	task.452736994864F623.title: "Visit a Shimmer River"
 	task.452B65E139D9E12D.title: "Kill 1 Wilden Chimera"
@@ -13264,6 +13469,7 @@
 	task.47A9907066F31663.title: "A Brewery"
 	task.47BAD4AA76F9CF82.title: "Silver Comb"
 	task.47D34EA29A06AACD.title: "Understanding this page"
+	task.4800DD5A7039B8B7.title: "All Things Power!"
 	task.484375E0BC0F9177.title: "Builds from our friends"
 	task.4851C74261B5FA25.title: "AllRightsReserved"
 	task.485E17B9E80D5DFF.title: "Occultism Pickaxes"
@@ -13313,23 +13519,22 @@
 	task.510CE57C709D5A44.title: "Observe Hydrofluoric Acid in a Machine"
 	task.518B9569DCE0A771.title: "AllRightsReserved"
 	task.51A3E013D2B3D744.title: "Machine Upgrades"
-	task.51CC9A8E36385400.title: "Chests"
-	task.51F776CF868BABEF.title: "Mining Demons"
+	task.523951BF097BA61F.title: "Any #c:dusts/emerald"
 	task.52874F5B79ECAE65.title: "Stone Bricks"
-	task.529BF074A61E2EAB.title: "Quests By AllTheMods"
 	task.529FFD7D692AEFA5.title: "Specialized Projectiles"
 	task.52BB142F044075B4.title: "Quests"
 	task.539C6F64C251543B.title: "Coal"
 	task.53A6720343E57302.title: "Sushi Go Crafting"
 	task.53A682560123F9B6.title: "Glassential"
 	task.53C6E9EAC8AC15EB.title: "Allthemodium Pickaxes"
+	task.53DE943DF951696B.title: "Demon Miner"
 	task.5400EB85133AAAEE.title: "Arcane Crystal Obelisks"
 	task.540231448A4DE43B.title: "End Layer Ores"
 	task.54231849B7094A32.title: "Tungstate or Scheelite Dust"
 	task.543A08791D27BC62.title: "Quests By AllTheMods"
+	task.5457CD8C1ABA0B9E.title: "Kill 5 Zombies"
 	task.54A7E248C8A40239.title: "Tier 2 Sigils"
 	task.55628B1EECBB5E94.title: "Ritual Saplings"
-	task.5580FF146C9E7EA0.title: "Barrels"
 	task.558649C69096D2D7.title: "Starter Generating Flowers"
 	task.559F3BFEC15996F8.title: "Turbine Power"
 	task.55DD09212E3DB168.title: "Fluid Pipes"
@@ -13338,6 +13543,7 @@
 	task.56A486D09B8B90EC.title: "Observe Alloy Blast Smelter"
 	task.56D7513E9D02F900.title: "Drill Heads"
 	task.570BF38EA2870300.title: "Quests By AllTheMods"
+	task.57108C994437F25B.title: "Any #ae2:all_nether_quartz"
 	task.57895147416291FE.title: "AllRightsReserved"
 	task.57DD9261905988F3.title: "Mekanism Iron Swords"
 	task.57F40CFA03BD36EF.title: "The Hard Part"
@@ -13352,12 +13558,13 @@
 	task.596ABB45C0612AAF.title: "Kill 1 Wandering Trader"
 	task.59DC19A11848EFE1.title: "Connectors"
 	task.59DD89698DBAA215.title: "AllRightsReserved"
-	task.59DE118DD6597A4E.title: "Renewable Mekanism Energy Generators"
 	task.59F0226D83026397.title: "AllRightsReserved"
 	task.5A06ED36DD9E9681.title: "Basic Runes"
 	task.5A1784C5676CDC62.title: "Welcome!"
+	task.5A8F474927CC1E80.title: "Mid Game Power Options"
 	task.5A901578529C152E.title: "Infusion Enchanting"
 	task.5AB4103FF540ABB4.title: "Fluids"
+	task.5B35720DF93CE2DB.title: "Kill 5 Skeletons"
 	task.5B5DBA0A7644A551.title: "Signalum Comb"
 	task.5B7926B511000F1F.title: "Mechanical Pipes"
 	task.5BC88AE46F95774D.title: "Gravel or Sand"
@@ -13435,7 +13642,6 @@
 	task.6A4FADC04E1C9DA7.title: "Steam Boiler Tanks"
 	task.6A965CD027BF762F.title: "AllRightsReserved"
 	task.6AA335ED81844F9F.title: "AllRightsReserved"
-	task.6AC2C9C3DA38E390.title: "Quests By AllTheMods"
 	task.6AE0DA6AB109A840.title: "Quarried"
 	task.6B17A0D9906E8C90.title: "AllRightsReserved"
 	task.6B580F95A2E5A465.title: "AllRightsReserved"
@@ -13443,7 +13649,6 @@
 	task.6BD970777103D55D.title: "Stairs"
 	task.6C12449632AD53DC.title: "Track Kits"
 	task.6C3887D42B6B2122.title: "Familiars"
-	task.6C4B8A2662030CB0.title: "Universal Cables"
 	task.6C841FAADFD094AC.title: "Automation"
 	task.6C974DF242CFDB8E.title: "Locate an Ancient Pyramid"
 	task.6C996D5E63879519.title: "Catalytic Reclamation Chamber"
@@ -13451,6 +13656,7 @@
 	task.6D074E91F5BFC2A8.title: "Track Kits"
 	task.6D15CFE8E1CF6D25.title: "Grave's Comb"
 	task.6D2E8755BB3463FF.title: "Railcraft Colored Blocks"
+	task.6D3C243268479EE9.title: "Transferring Power"
 	task.6D4F62833424ADC0.title: "Iron Comb"
 	task.6D7DD99A02A8F451.title: "Visit The Deep Dark"
 	task.6D9221A533926A7B.title: "AllRightsReserved"
@@ -13486,7 +13692,6 @@
 	task.74CA4DE423248784.title: "Wall Lamps"
 	task.7536DA5A948671F2.title: "Observe completed Vacuum Freezer"
 	task.75924053D6F5B242.title: "Spatial Storage Cells"
-	task.76378687551A79C3.title: "Energy Cubes"
 	task.76B722B1AE7B6CF2.title: "AllRightsReserved"
 	task.76C41881A02F2098.title: "Kill 1 Wither"
 	task.76C92D826994D92B.title: "Chipped Glass"
@@ -13504,7 +13709,7 @@
 	task.78F0D5822BF96CA9.title: "Regions Unexplored Logs"
 	task.79400615E3A7401D.title: "Building Gadgets"
 	task.79712C13C6597E82.title: "Aluminum Comb"
-	task.79889CC26DCD7F19.title: "Self Pollination"
+	task.79889CC26DCD7F19.title: "Besides pollination"
 	task.79AEDC66EB312BCA.title: "Brass Comb"
 	task.79E961F671475850.title: "Thermodynamic Conductors"
 	task.79F67E07C28F8E97.title: "Minecraft Railgun Ammo"
@@ -13516,12 +13721,12 @@
 	task.7B46FA23AF26BF76.title: "Aluminum Ingot"
 	task.7B5C9FA866C0588A.title: "Stabilized RF Coil"
 	task.7B7C1C5BFEC92058.title: "Emerald Comb"
+	task.7BAB5E17D2DE4E3E.title: "Kill 5 Witches"
 	task.7BB13793B38DFC2C.title: "AllRightsReserved"
 	task.7BBE300C1AB19CCC.title: "Besides Pollinations"
 	task.7C6F7EF2B3AC2824.title: "AllRightsReserved"
 	task.7C88F80D05E62AC7.title: "Iron Furnaces"
 	task.7C91AC93D782A4BE.title: "Stage 2 EBF"
-	task.7CA8741CA073C1DA.title: "Powercells"
 	task.7D9A58EBADE91F54.title: "Inferium Tools"
 	task.7DE03D4A420D1028.title: "Visit a Dark Temple"
 	task.7E0D9E6342295AB0.title: "Foreword on Channels"

--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -116,7 +116,7 @@
 	quest.00A17728A387B426.quest_desc: ["Wood Nests are used to lure Carpenter Bees and the Blue Banded Bee.\\n\\nDark Oak Nests lures 3 different bees.\\n\\nThese can be placed in any Overworld Biome."]
 	quest.00A17728A387B426.quest_subtitle: "Can be used in any Overworld biome"
 	quest.00A17728A387B426.title: "Wood Nests"
-	quest.00A6020BC979947F.quest_desc: ["With your freshly summoned &9Marid Crusher&r, you can break down an echo shard and an Iesnium ingot, which combine with a glow ink sac to create Cyan Chalk."]
+	quest.00A6020BC979947F.quest_desc: ["With your freshly summoned &9Marid Crusher&r, you can break down an Echo Shard and an Iesnium Ingot, which when combined with a Glow Ink Sac creates Cyan Chalk."]
 	quest.00A6020BC979947F.title: "&3Cyan Chalk"
 	quest.00A91BD731486644.quest_subtitle: "Ceylon Ebony + Sour Cherry"
 	quest.00AC7CC291A3E590.quest_desc: ["You've probably (definitely) seen structures around the world with what looks like Beacons coming out of them. They're made of cobblestone, have 4 legs supporting them, kinda high in the air! \\n\\nHopefully you know it but they're called &8Dark Temples&r and they have an &aEnviromental Accumulator&r which we need. \\n\\nYou'll have to wait for Thunderstorm to happen to fill your Weather Container. Then, you can make your &3Lightning Bomb&r!"]
@@ -333,7 +333,7 @@
 	]
 	quest.030AC1AF8F735550.quest_desc: ["To get liquids into the Tank you'll need some sort of Pipes.\\n\\nThe Hydro Pump can automatically put Water into them at a slow rate, but also for free!"]
 	quest.030AC1AF8F735550.title: "Pipes"
-	quest.03250A0202C25E80.quest_desc: ["After you've successfully slain the &9unbound Marid&r demon that you summoned with &4Abras' Fortified Conjure&r, you can use the &9Marid Essence&r that it drops to craft the \"highest\" Colored Chalk, Blue Chalk."]
+	quest.03250A0202C25E80.quest_desc: ["After you've successfully slain the &9Unbound Marid&r Demon that you summoned with &4Abras' Fortified Conjure&r, you can use the &9Marid Essence&r that it drops to craft the \"highest\" colored Chalk, Blue Chalk."]
 	quest.03250A0202C25E80.title: "&9Blue Chalk"
 	quest.032B654201E71618.quest_desc: ["These &cTrack Kits&r are for using entities with your &7Carts&r (Entities aka Mobs). \\n\\nThe &cEmbarking Kit&r will pick up any Mobs nearby and put them in a &7Cart&r. \\nThe &cDisembarking Kit&r unloads Mobs from the &7Carts&r. \\nThe &cDumping Kit&r will drop the mobs in the &7Carts&r below the &6tracks&r its on."]
 	quest.032B654201E71618.title: "&cTrack Kits&r for moving entities"
@@ -1041,7 +1041,7 @@
 	quest.0A21773B773F34F8.quest_desc: ["Color is one of the most important parts of making a Build more lively! \\n\\nIt gives it life, personality, and color! \\n\\nStart with the Dyes!"]
 	quest.0A21773B773F34F8.title: "Colored Blocks"
 	quest.0A25276925EB0CBA.quest_desc: [
-		"Once you've gathered every single Colored Chalk and Foundation Chalk, you can perform the second &dDemon-less&r type ritual, &dRonaza's Contact&r. This is ultimate ritual, using everything you've learned so far!"
+		"Once you've gathered every single colored Chalk and Foundation Chalk, you can perform the second &dDemon-less&r type ritual, &dRonaza's Contact&r. This is the ultimate ritual, using everything you've learned so far!"
 		""
 		"It has limited uses, but everything created with this ritual is super powerful!"
 	]
@@ -1182,15 +1182,15 @@
 	quest.0BCCDE24D378F260.quest_subtitle: "Tier: &d3"
 	quest.0BCCDE24D378F260.title: "&dAdvanced Machine Frame"
 	quest.0BD6365534BF04D5.quest_desc: [
-		"With our lime chalk in hand, it's time to delve into &5Possesion Rituals&r. These rituals are slightly different from the others because they all require a live sacrifice, usually small mobs such as chickens, bees, bats, etc. However, as rituals get more complicated, they will require larger and larger sacrifices. "
+		"With Lime Chalk, it's time to delve into &5Possesion Rituals&r. These rituals are slightly different from the others because they all require a live sacrifice, usually small mobs such as Chickens, Bees, Bats, etc. However, as rituals get more complicated, they will require larger and larger sacrifices. "
 		""
 		"Even if you've placed all of the items needed and the Book of Binding into the Golden Sacrificial Bowl, the Ritual will not begin until you kill the sacrifice on top of the runes."
 		""
-		"We reccomend that you make some sort of mob capture item such as an empty soul gem, jar, Mob Imprisonment Tool, or Quantum Catcher!"
+		"It is recommended that you make some sort of mob capture item such as an Empty Soul Gem, Jar, Mob Imprisonment Tool, or Quantum Catcher!"
 		""
-		"The first tier of &5Possession rituals&r is &eHeidryn's Lure&r, which is only used to get mundane items like skeleton skulls and end stone. Because of this, we're skipping right to the second tier ritual, &aIhagan's Enthrallment&r. "
+		"The first tier of &5Possession rituals&r is &eHeidryn's Lure&r, which is only used to get mundane items like Skeleton Skulls and End Stone. Because of this, you can skip straight to the second tier of ritual, &aIhagan's Enthrallment&r. "
 	]
-	quest.0BD6365534BF04D5.quest_subtitle: "Who ya gonna call?"
+	quest.0BD6365534BF04D5.quest_subtitle: "Who you gonna call?"
 	quest.0BD6365534BF04D5.title: "&aIhagan's Enthrallment"
 	quest.0BD908937BC6E97B.quest_subtitle: "Kapok + Rosewood"
 	quest.0BE2E7C9454058C3.quest_desc: [
@@ -1296,8 +1296,8 @@
 	quest.0CF6D11016BAF3D0.quest_subtitle: "Complex Naquadah"
 	quest.0D01524F249E25D7.quest_subtitle: "Who turned off the lights?"
 	quest.0D01524F249E25D7.title: "&8Dark Xychorium Gems"
-	quest.0D18BBB04693885A.quest_desc: ["Strigeor's Higher Binding is the second tier of &6Infusion Rituals&r. It's used for a TON of different things, but the main things we'll need are the Infused Pickaxe and Gray Paste."]
-	quest.0D18BBB04693885A.quest_subtitle: "The \"everything\" ritual"
+	quest.0D18BBB04693885A.quest_desc: ["Strigeor's Higher Binding is the second tier of &6Infusion Rituals&r. It's used for many different things, but the main things we'll need are the Infused Pickaxe and Gray Paste."]
+	quest.0D18BBB04693885A.quest_subtitle: "The \"Everything\" Ritual"
 	quest.0D18BBB04693885A.title: "&aStrigeor's Higher Binding"
 	quest.0D19FB62C2C1D9F7.quest_desc: ["Once you've got at least 200 &4Mahou&r you might want to make a Boundary of Life Drain. \\n\\nFor every Mob that dies in that boundary, you get 10 &4Mahou&r back, but this is a SLOW process."]
 	quest.0D19FB62C2C1D9F7.title: "Boundary of Life Drain"
@@ -1733,7 +1733,7 @@
 	quest.1194FF35ADAA9957.quest_subtitle: "Sharks with Laser beams?"
 	quest.119FF09D481F9178.quest_desc: ["What good would a tech mod be without barrels and tanks. They could be useful, but functions the same as other items of the same."]
 	quest.119FF09D481F9178.title: "Tanks and Barrels"
-	quest.11A0593C0E2E6A35.quest_desc: ["Using &eEziveus' Spectral Compulsion&r, we can imbue a myriad of different nature blocks to form some &2Nature Paste&r. Combine this paste with some impure white chalk to create Green Chalk."]
+	quest.11A0593C0E2E6A35.quest_desc: ["Using &eEziveus' Spectral Compulsion&r, we can imbue a myriad of different nature blocks to form some &2Nature Paste&r. Combine this Paste with some Impure White Chalk to create Green Chalk."]
 	quest.11A0593C0E2E6A35.title: "&2Green Chalk"
 	quest.11AAA1DCB452DFFC.quest_subtitle: "For"
 	quest.11B0B93D725ABE43.quest_desc: ["Silent Gear gear can be repaired using a &9Repair Kit&r.\\n\\nTo repair an item, place the Repair Kit into a crafting grid, then place the materials needed to repair the tool in with it. This will \"fill\" the Repair Kit.\\n\\nTo repair the tool, combine the filled Repair Kit with the tool you'd like to repair in a crafting grid."]
@@ -2063,7 +2063,7 @@
 	quest.145C8235BCCB9BA8.quest_desc: [
 		"If we want to collect all of the Chalks, we'll need to summon and kill aa not-so friendly &cAfrit&r."
 		""
-		"Even though this isn't a &5Possession Ritual&r, you'll need a live sacrifice for this ritual. In this instance, we'll be sacrificing a cow. Sorry Betsy!"
+		"Even though this isn't a &5Possession Ritual&r, you'll need a live sacrifice for this ritual. In this instance, we'll be sacrificing a Cow. Sorry Betsy!"
 	]
 	quest.145C8235BCCB9BA8.title: "&cRed Chalk"
 	quest.145E7D1A88B83DDD.quest_desc: ["Where'd you go?"]
@@ -2459,11 +2459,11 @@
 	quest.1834B5C1F8435D7A.quest_subtitle: "Fluids"
 	quest.1843C79133DFB024.quest_desc: ["The most powerful and efficient Generator, the Netherstar Generator. Take a guess what it uses to make Energy!"]
 	quest.1848F431D0380DA9.quest_desc: [
-		"Similar to the Chalk Repairing function of &aStrigeor's Higher Binding&r, &cSevira's Permanent Confinement&r can be used to repair items using the power of an Afrit demon."
+		"Similar to the Chalk Repairing function of &aStrigeor's Higher Binding&r, &cSevira's Permanent Confinement&r can be used to repair items using the power of an Afrit Demon."
 		""
-		"This ritual can repair just about anything, so &edemon miners&r, tools, and armor can all be restored to their original durability! "
+		"This ritual can repair just about anything, so &eDemon Miners&r, tools, and armor can all be restored to their original durability! "
 		""
-		"All items that are repaired using this ritual retain their original properties (affixes, enchantments, etc.), so don't worry about your precious level 10 enchantments!"
+		"All items that are repaired using this ritual retain their original properties (affixes, enchantments, etc), so don't worry about your precious enchantments!"
 	]
 	quest.1848F431D0380DA9.quest_subtitle: "Free(ish) durability!"
 	quest.1848F431D0380DA9.title: "Repairing Items"
@@ -2759,15 +2759,15 @@
 	quest.1BD5B25B80EC0F97.quest_desc: ["Also makes those magnetic iron rods for just some energy - save your redstone!"]
 	quest.1BD5B25B80EC0F97.quest_subtitle: "Magnetizing!"
 	quest.1BDB369FD243D4C6.quest_desc: [
-		"Arguably the most useful item that you can create in the Occultism modpack, the &bIesnium Anvil&r is a super-powerful version of the anvil."
+		"Arguably the most useful item that you can create in Occultism, the &bIesnium Anvil&r is a super-powerful version of the Anvil."
 		""
 		"Created using &9Uphyxes' Inverted Tower&r, it:"
 		""
-		"- Is unbreakable"
-		"- Increases the maximum level of all enchants for anything combined on it by one level"
-		"- Costs 1/2 as much xp as the estimate says (rounded down, so if it says 25, it'll cost 12)"
-		"- Has a smaller xp-requirement increase for repeated edits on the same item"
-		"- Increases the maximum xp level at which you can edit items (the point at which it says \"Too Expensive!\")"
+		"- Is unbreakable."
+		"- Increases the maximum level of all enchants for anything combined on it by one level."
+		"- Costs half as much xp as the estimate says (rounded down, so if it says 25, it'll cost 12)."
+		"- Has a smaller experience requirement increase for repeated edits on the same item."
+		"- Increases the maximum xp level at which you can edit items (the point at which it says \"Too Expensive!\")."
 	]
 	quest.1BE26A00A420DAE3.quest_desc: ["In this mod, you'll need &aFlux Cores&r and &aFlux Blocks&r to craft the core parts of your network. Make a few of each!"]
 	quest.1BE26A00A420DAE3.title: "The 'Core' Crafting Materials"
@@ -2945,7 +2945,7 @@
 	quest.1DCFC67A8E3DCA2C.quest_desc: ["Similar to the Alchemy Catalyst, when placed under a Mana Pool, the &9Conjuration Catalyst&r unlocks the abillity to use conjuration recipes. "]
 	quest.1DDA5ADA11DF868F.quest_desc: ["Now we can upgrade our Multiblock structures Tiers! EBF's, VF's, Crackers, LFD, and more! They can process faster, and they can process &dLuV&r tier materials! Lets Go!"]
 	quest.1DDA5ADA11DF868F.quest_subtitle: "LuV Energy Hatch at Last!"
-	quest.1DE0F289821F55D1.quest_desc: ["Now that we have a Foliot Crusher, we can &muse&r politely ask it to crush down some &eEnd Stone&r, &9Obsidian&r, &7Calcite&r for us. We'll use these to make some new Chalk!"]
+	quest.1DE0F289821F55D1.quest_desc: ["Now that we have a Foliot Crusher, we can &muse&r politely ask it to crush down some &eEnd Stone&r, &9Obsidian&r and &7Calcite&r for us. We'll use these to make some new Chalk!"]
 	quest.1DE0F289821F55D1.title: "&aChalking It Up"
 	quest.1DE8B0C9A7195720.quest_desc: [
 		"Once you've finished placing in all of the required blocks to build the Reactor, it should give off red particles to show that it is complete.\\n\\nRight clicking anywhere on the Reactor will open up the &aInterface&r. This will have all of the information you need to run the Reactor properly, as well as two buttons to turn on and off the Reactor.\\n\\nOn the left, you have 2 tanks: One for &bCoolant&r and one for &3Fissile Fuel&r. On the right, you have one for &8Nuclear Waste&r, and one for &bHeated Coolant&r, which will most likely be &bSteam&r.\\n\\nThe &cTemperature&r bar will show you how hot the Reactor is. After a certain temp, the Reactor will start taking &4Damage&r, which will eventually cause the Reactor to explode.\\n\\nTo adjust the &cBurn Rate&r of the Fissile Fuel and see more statistics, click on the (I) tab on the left side. Here, you can adjust the Rate Limit, which controls how much fuel the Reactor burns per tick.\\n"
@@ -3021,7 +3021,7 @@
 	quest.1EABF2E7AE7B8F22.title: "&8Netherite&r"
 	quest.1EB04FE105ACA4BE.quest_desc: ["When a &9Warden&r dies it has a chance to drop a &9Heart of the Deep&r. \\n\\nThis can be used for the &6&lATM Star&r, or to activate the Portal in the Ancient City! \\n\\nThere can't be anything in the Portal to activate it, that includes &9Sculk&r!"]
 	quest.1EB04FE105ACA4BE.title: "&9Heart of the Deep"
-	quest.1EB887F8072439A3.quest_desc: ["After using &9Fatma's Incentivized Attraction&r to summon a &9Marid Crusher&r, you can turn ice, packed ice, and blue ice into their crushed forms, and use these to create Light Blue Chalk."]
+	quest.1EB887F8072439A3.quest_desc: ["After using &9Fatma's Incentivized Attraction&r to summon a &9Marid Crusher&r, you can turn Ice, Packed Ice, and Blue Ice into their crushed forms, and use these to create Light Blue Chalk."]
 	quest.1EB887F8072439A3.title: "&bLight Blue Chalk"
 	quest.1EBD5E4410A6DF34.quest_subtitle: "Feed a Ghostly Bee a Soulium Dagger"
 	quest.1EBD5E4410A6DF34.title: "Soulium Bee"
@@ -4055,11 +4055,11 @@
 	quest.2951B1D7080C5EF9.title: "Every Thorn has its Rose"
 	quest.295C77EEC89000FC.quest_subtitle: "Generates Source from Mob Deaths and Animal Breeding"
 	quest.2960FFE0C53DFEB1.quest_desc: [
-		"&cSevira's Permanent Confinement&r is the third tier of &6Infusion Rituals&r. It's mainly used to create the next level of foundation chalk, Black Chalk."
+		"&cSevira's Permanent Confinement&r is the third tier of &6Infusion Rituals&r. It's mainly used to create the next level of foundation Chalk, Black Chalk."
 		""
 		"It's also used to create a couple of items that can speed up ritual making and performing by a significant amount."
 	]
-	quest.2960FFE0C53DFEB1.quest_subtitle: "The \"even more everything\" ritual"
+	quest.2960FFE0C53DFEB1.quest_subtitle: "The \"Even More Everything\" Ritual"
 	quest.2960FFE0C53DFEB1.title: "&cSevira's Permanent Confinement"
 	quest.29706E3681616E41.quest_subtitle: "That's a Lot of Different Dusts!"
 	quest.2982D38BD5EE6349.quest_subtitle: "Feed a Shroombee Warped Fungus"
@@ -4085,13 +4085,13 @@
 	]
 	quest.29C78845B488EDF8.title: "&5Purple Sempiternal Sanctum"
 	quest.29C83B00AC4AFC23.quest_desc: [
-		"Now that you've completed the Occultism questline, you may be asking yourself, what's next? Well, there are so many more things to explore in Occultism! "
+		"Now that you've come this far, you may be asking yourself, what's next? Well, there are so many more things to explore in Occultism! "
 		""
-		"You can see a comprehensive list of every single ritual and item in your &6Dictionary of Spirits&r, try going through all the rituals' outcomes to see if you can find something that piques your interest!"
+		"You can see a comprehensive list of every single ritual and item in your &6Dictionary of Spirits&r, you could try going through all the rituals' outcomes to see if you can find something that piques your interest!"
 		""
-		"If you haven't already, you could lie out and decorate three separate ritual areas, one for summons, one for possessions, and one for infusions."
+		"If you haven't already, you could lay out and decorate three separate ritual areas, one for Summons, one for Possessions, and one for Infusions."
 		""
-		"With any mod, there's always new ways to use each and every seemingly mundane feature to maximize your experience with the modpack. Happy ritual crafting!"
+		"There's always new ways to use each and every seemingly mundane feature to maximize your experience with the modpack. Happy ritual crafting!"
 	]
 	quest.29C83B00AC4AFC23.title: "What's Next?"
 	quest.29C9F8719DA63D8D.quest_desc: ["The &2&lBuzzsaw&r works similar to the &4&lMining Drill&r, just for &2Trees&r! \\n\\nIt requires &2Bio-Diesel&r as Fuel, which I won't explain how to get here either! \\n\\nAnd some sort of &8Sawblade&r. Which you can attach via the Top Slot in the &6Engineer's Workbench&r. \\n\\nSimply break Logs on a &2Tree&r and every Log, Leaf, and Birds Nest will come down with it! You can hold Shift to not break everything attached. \\n\\nThe &2&lBuzzsaw&r also does 10 Damage! Dang, why even use a Sword? Oh yeah &8Saws&r have Durability and it needs &2Bio-Diesel&r. \\n\\nThe &2&lBuzzsaw&r can hold 1 &8Blade&r or &8Disk&r and 2 Upgrades."]
@@ -4596,7 +4596,7 @@
 	]
 	quest.2E596B5A4EA2ABF4.title: "&3S'Mog&r"
 	quest.2E5EF984B9CE0CB9.quest_desc: ["The all in one, big battery, big range ore/fluid finder"]
-	quest.2E68E1D96B25336D.quest_desc: ["After fighting through a few Demon possessed zombie piglins summoned by &6Abras' Open Commanding Conjure&r, you can use the Demonic Meat dropped by them to craft some Pink Chalk."]
+	quest.2E68E1D96B25336D.quest_desc: ["After fighting through a few Demon Possessed Zombified Piglins summoned by &6Abras' Open Commanding Conjure&r, you can use the Demonic Meat dropped by them to craft some Pink Chalk."]
 	quest.2E68E1D96B25336D.title: "&dPink Chalk"
 	quest.2E6D11A5F5626A6C.quest_subtitle: "Tier: &f2"
 	quest.2E6F1C8718EB8C66.title: "&4Blood&r Upgrade Orb"
@@ -4741,8 +4741,7 @@
 	quest.2FB62AE3C62CA052.quest_subtitle: "&f4.5&r &4Damage&r"
 	quest.2FC15D3916DBF4E4.quest_subtitle: "More Filtering Options"
 	quest.2FC15D3916DBF4E4.title: "&eAdvanced Void Upgrade"
-	quest.2FD22502E6481269.quest_desc: ["Using &dRonaza's Contact&r, you can upgrade your soul gem to create a trinity gem. It's basically just a beefed up version of the soul gem that can capture larger enemies, although it still can't contain most bosses."]
-	quest.2FD22502E6481269.title: "Trinity Gem"
+	quest.2FD22502E6481269.quest_desc: ["Using &dRonaza's Contact&r, you can upgrade your Soul Gem to create a Trinity Gem. It's basically just a beefed up version of the Soul Gem that can capture larger enemies, although it still can't contain most bosses."]
 	quest.2FDACD6F153D5B64.quest_desc: ["Processing Sheldonite and purifying it will allow you to get the highest return on Platinum Group Sludge. This Sludge contains resources you need to progress."]
 	quest.2FDACD6F153D5B64.quest_subtitle: "My Friend Sheldon went to a club on nite."
 	quest.2FE4B7B70D90A455.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks.\\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission.\\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
@@ -4830,7 +4829,7 @@
 		"{image:atm:textures/questpics/bumblezone/bumble_cell.png width:200 height:100 align:center}"
 	]
 	quest.30C12E249F7E2D52.title: "Cell Maze"
-	quest.30C5B597610F4AFB.quest_desc: ["The first and most important item to make using Eziveus' Spectral Compulsion is the Research Fragment Dust. This is used in combination with some crushed emeralds to create lime chalk!"]
+	quest.30C5B597610F4AFB.quest_desc: ["The first and most important item to make using Eziveus' Spectral Compulsion is the Research Fragment Dust. This is used in combination with some crushed Emeralds to create Lime Chalk!"]
 	quest.30C5B597610F4AFB.title: "&aLime Chalk"
 	quest.30CD69FC601F26B5.quest_desc: ["Now just 1 more processing step before you can finally craft the Naquadah Alloy Frame&l"]
 	quest.30CD69FC601F26B5.quest_subtitle: "Naq Alloy Time!"
@@ -5394,7 +5393,7 @@
 	quest.3663E93E169EF8E3.title: "&2Uranium Hexafluoride"
 	quest.3673893C88EB5EDE.quest_desc: ["Use 3 other crystals to craft this crystal."]
 	quest.3673893C88EB5EDE.quest_subtitle: "Weathering the Storm"
-	quest.367E891A50991436.quest_desc: ["Using &cSevira's Permanent Confinement&r, we can combine several different wither materials and some netherite to create three Witherite Dust. With these, we can create ourselfs the highest form of Foundation Chalk, Black Chalk."]
+	quest.367E891A50991436.quest_desc: ["Using &cSevira's Permanent Confinement&r, we can combine several different Wither materials and some Netherite to create three Witherite Dust. With these, we can create ourselfs the highest form of Foundation Chalk, Black Chalk."]
 	quest.367E891A50991436.title: "Black Chalk"
 	quest.36836AD948F96B9F.quest_desc: [
 		"The simplest of the simplest of &e&lPipes&r, the &eItem Pipe&r. \\n\\nIt will move Items from one Inventory to another. Could be from one Chest to another, could be a Farm to a System, or even a Quarry to a Smelter. \\n\\nVery simple just connect the &ePipes&r to what you want moved, and use your Wrench to configure which side it Pulls from. "
@@ -5578,7 +5577,7 @@
 		""
 		"&cAfrit Demons&r are Demons of &cFire&r. They are more advanced Demons, which some are friends and some are... not. It all depends on how strongly the ritual can control the &cAfrit&r. "
 		""
-		"Because we don't have access to red chalk yet, all we can summon is an &9unbound&r demon, meaning it cannot be controlled and will be violent."
+		"Because we don't have access to Red Chalk yet, all we can summon is an &9Unbound&r Demon, meaning it cannot be controlled and will be violent."
 	]
 	quest.38A1295878B68F83.quest_subtitle: "Hot Demons!"
 	quest.38A1295878B68F83.title: "&6Abras' Open Conjure"
@@ -5640,7 +5639,7 @@
 		""
 		"The first tier of &6Infusion Rituals&r is &eEziveus' Spectral Compulsion&r. We'll be using this ritual to create several items that you'll need throughout this mod."
 		""
-		"We reccomend creating this ritual in a separate area from your first one, because the three main types of rituals build off each previous tier."
+		"It is recommended to create this ritual in a separate area from your first one, because the three main types of rituals build off each previous tier."
 	]
 	quest.39647A2473F6F7D7.quest_subtitle: "Put some Demon Dust™ on it!"
 	quest.39647A2473F6F7D7.title: "&eEziveus' Spectral Compulsion"
@@ -6662,13 +6661,13 @@
 	quest.429785E8F64929CE.quest_desc: ["In order to get to the Starlight Dimension you'll need to find Portal Ruins in the Overworld. \\n\\nThere you will find a Gatekeeper, Right Click to initiate a conversation and challenge them to a duel! Careful, they are very tough. \\n\\nOnce you win the duel you'll be gifted a few Items, the Orb of Prophecy being one. Right Click the Portal with the Orb to activate it! Then, walk in to get to the..."]
 	quest.429785E8F64929CE.title: "The Gatekeeper and The Gate"
 	quest.429B5A81DF6C43FE.quest_desc: [
-		"&6Abras' Open Commanding Conjure&r is used to bring an &cAfrit&r demon into a pig. Because this ritual is performed without the use of red chalk, it's only powerful enough to summon an &9unbound&r demon."
+		"&6Abras' Open Commanding Conjure&r is used to bring an &cAfrit&r demon into a Pig. Because this ritual is performed without the use of Red Chalk, it's only powerful enough to summon an &9unbound&r demon."
 		""
-		"In particular, this ritual will create an &cAfrit&r-possessed zombified piglin, which will drop some demonic meat, which is used to craft pink chalk"
+		"In particular, this ritual will create an &cAfrit&r-possessed Zombified Piglin, which will drop some Demonic Meat, which is used to craft Pink Chalk"
 		""
-		"&l&4WARNING: YOU MAY HAVE TO DO THIS ONE MULTIPLE TIMES TO GET ENOUGH DEMONIC MEAT! "
+		"&4WARNING: YOU MAY HAVE TO DO THIS ONE MULTIPLE TIMES TO GET ENOUGH DEMONIC MEAT."
 	]
-	quest.429B5A81DF6C43FE.quest_subtitle: "How... fleshy..."
+	quest.429B5A81DF6C43FE.quest_subtitle: "How... Fleshy..."
 	quest.429B5A81DF6C43FE.title: "&6Abras' Open Commanding Conjure"
 	quest.42AAEC41F2BC2474.quest_desc: ["{image:atm:textures/questpics/basicarmor/armor_glacite.png width:100 height:150 align:center}"]
 	quest.42AAEC41F2BC2474.title: "&bGlacite&r"
@@ -7698,9 +7697,9 @@
 		""
 		"&aOak Saplings&r convert to &9Oak Saplings&r but they are not the same. When grown, these will look exactly like a regular Oak tree. However, under the effects of the &bThird Eye&r, you will be able to harvest the Otherworld variant."
 		""
-		"If you have trouble collecting the logs (if they turn into regular Oak logs even with &bThird Eye&r), try collecting them from the top."
+		"If you have trouble collecting the logs (if they turn into regular Oak Logs even with &bThird Eye&r), try collecting them from the top."
 		""
-		"&eDiamonds&r will turn into &dSpirit Attuned Gems&r which are used in several recipes we'll need later down the road."
+		"&eDiamonds&r will turn into &dSpirit Attuned Gems&r which are used in several recipes we'll need later on."
 	]
 	quest.4C873491F6F0FFAF.title: "&dSpiritfire&r Conversions"
 	quest.4C8C56F960D92E9D.quest_subtitle: "&f51 &cAttack Damage"
@@ -7727,9 +7726,9 @@
 	quest.4CE571F942461909.quest_desc: [
 		"The Ritual Satchel is nice, but it takes a long time to place all the blocks. Now that you can perform the &cSevira's Permenant Confinement&r ritual, you can create the Artisanal Ritual Satchel!"
 		""
-		"The Artisanal Ritual Satchel functions nearly identically to the regular Ritual satchel, except it instantly places all the nessecary items for the ritual, and has the added ability to right-click on a golden bowl to erase all the chalk runes and collect all the other items (skulls, candles, and crystals) and return them to the satchel. "
+		"The Artisanal Ritual Satchel functions nearly identically to the regular Ritual Satchel, except it instantly places all the nessecary items for the ritual, and has the added ability to right-click on Golden Bowl to erase all the Chalk Runes and collect all the other items (Skulls, Candles, and Crystals) and return them to the Satchel."
 		""
-		"No, it doesn't restore the durability of the chalk."
+		"No, it doesn't restore the durability of the Chalk."
 	]
 	quest.4CE571F942461909.title: "Tools of the Trade: Artisanal Ritual Satchel"
 	quest.4CE6CABCB2334C0E.quest_desc: ["We have used a bunch of chromium already. But we again need to call on this highly resistive and high hardness metal, except in its liquid form."]
@@ -8033,19 +8032,19 @@
 	quest.4F1FFC02F4EAA2E6.title: "Tier: &4Nitro"
 	quest.4F2BBB75E5B5EAD8.title: "Salts Vein"
 	quest.4F35D04721DFC9FF.quest_desc: [
-		"The first type of Ritual we'll be performing is the &9Summoning Ritual&r. These rituals are used to summon different types of useful Demons to assist you in crushing, smelting, and tons of other things as you get to higher tiers of rituals."
+		"The first type of ritual we'll be performing is the &9Summoning Ritual&r. These rituals are used to summon different types of useful Demons to assist you in crushing, smelting, and more as you get to higher tiers of rituals."
 		""
-		"For our first Ritual, we want to summon a &aFoliot Crusher&r Demon. This Demon will crush items for us, which is something we'll need to make some of the higher level Chalks!"
+		"For our first ritual, we want to summon a &aFoliot Crusher&r Demon. This Demon will crush items for us, which is something we'll need to make some of the higher level Chalks!"
 		""
-		"To start with, combine your Unbound Book with your &aDictionary of Spirits&r in a crafting table. This will bind a Demon to the book, which is what we'll need for the Ritual."
+		"To start with, combine your Unbound Book with your &aDictionary of Spirits&r in a crafting grid. This will bind a Demon to the Book, which is what we'll need for the ritual."
 		""
-		"Speaking of your Dictionary of Spirits, it's time to open it up! On the left, click on the &dPentacles&r tab and click on &bAviar's Circle&r. You might have to advance through it by reading a little bit. There is also a way to click \\\"Mark All As Read\\\" so it unlocks everything in the book."
+		"Speaking about your Dictionary of Spirits, it's time to open it up! On the left, click on the &dPentacles&r tab and click on &bAviar's Circle&r. You might have to advance through it by reading a little bit. There is also a way to click \\\"Mark All As Read\\\" so it unlocks everything in the Book."
 		""
-		"This is what we're going to use to summon our new Friend. On the right side, you can click the eye in the bottom-left corner of the image to build an outline of the Ritual for you in the world. This is super helpful!"
+		"This is what we're going to use to summon our new friend. On the right side, you can click the eye in the bottom-left corner of the image to build an outline of the ritual for you in the world. This is super helpful!"
 		""
-		"Once you've completed the multi-block Ritual, place down 4 (or more for future rituals) Sacrificial Bowls anywhere within 8 block horizontal radius from the center Sacrificial Bowl and use the required items on them. Once you place your Bound Book in the Golden Sacrificial Bowl, the Ritual will start!"
+		"Once you've completed the multi-block ritual, place down 4 (or more for future rituals) Sacrificial Bowls anywhere within 8 block horizontal radius from the center Sacrificial Bowl and use the required items on them. Once you place your Bound Book in the Golden Sacrificial Bowl, the ritual will start!"
 		""
-		"This is what the Ritual will look like."
+		"This is what the ritual will look like."
 		""
 		"{image:atm:textures/questpics/occultism/aviarcircle_v2.png width:200 height:200 align:1}"
 	]
@@ -8547,11 +8546,11 @@
 	]
 	quest.53DD784E75965947.title: "The Beyond"
 	quest.53DEA3DFEDC4809E.quest_desc: [
-		"Don't worry, this is the last of the Abras series of rituals. It is used to summon a &9Marid&r demon, but even though it uses Red Chalk, it's not powerful enough to &9bind&r the demon. This means that, unfortunately, you're going to have to fight it."
+		"Don't worry, this is the last of the Abras series of rituals. It is used to summon a &9Marid&r demon, but even though it uses Red Chalk, it's not powerful enough to &9bind&r the Demon. This means that, unfortunately, you're going to have to fight it."
 		""
-		"By the way, this ritual uses a trident as a sacrifice, which is confusing because most sacrifices are living creatures. So instead of killing a mob on top of the completed ritual circle, you simply throw the trident at the center bowl to start the ritual."
+		"This ritual uses a Trident as a sacrifice, which is confusing because most sacrifices are living creatures. So instead of killing a mob on top of the completed ritual circle, you simply throw the Trident at the center bowl to start the ritual."
 	]
-	quest.53DEA3DFEDC4809E.quest_subtitle: "Is it a bird? Is it a plane? No, it's an unbound &9Marid&r!"
+	quest.53DEA3DFEDC4809E.quest_subtitle: "Is it a Bird? Is it a Plane? No, it's an unbound &9Marid&r!"
 	quest.53DEA3DFEDC4809E.title: "&4Abras' Fortified Conjure"
 	quest.53E2BEA626B35BFC.quest_desc: ["Quite expensive recipe but most definitely worth it! \\n\\nUsing the &6Spectral &4Eye&r will give you the &4Spectral Vision Effect&r. This Effect gives &eGlowing&r to every Mob within a 100 Block radius in every direction! \\n\\nPerfect for finding structures underground, or Bastions in the &c&lNether&r, or even finding your friends hidden Axolotl farm!"]
 	quest.53E2BEA626B35BFC.quest_subtitle: "Very popular in ATM6!"
@@ -8837,7 +8836,7 @@
 	quest.56DA46DC82F6665D.quest_desc: ["The Wilden Chimera is a Boss added by Ars Nouveau and is needed for progressing through it. \\n\\nHe needs to be summoned through a ritual then fought!"]
 	quest.56DA46DC82F6665D.title: "Kill The Wilden Chimera"
 	quest.56E30438AE512475.quest_desc: ["Let's get these flames burning! \\n\\nThe Preheater is a very simple addition to the &l&4Improved Blast Furnace&r. \\n\\nSimply place them on the Left and Right of the &l&4Improved Blast Furnace&r. Then, connect power to the top of it and it will start speeding up the &l&4Improved Blast Furnace&r."]
-	quest.56EC79AF11B0869E.quest_desc: ["&9Xeovrenth Adjure&r is the maximum tier of &5Possession Rituals&r. It only has two uses: creating Cruelty Essence, the main ingredient in Brown Chalk, and creating an Iesnium Golem, which is basically just an Iron golem that's immortal and does more damage."]
+	quest.56EC79AF11B0869E.quest_desc: ["&9Xeovrenth Adjure&r is the maximum tier of &5Possession Rituals&r. It only has two uses: creating Cruelty Essence, the main ingredient in Brown Chalk, and creating an Iesnium Golem, which is basically just an Iron Golem that's immortal and does more damage."]
 	quest.56EC79AF11B0869E.quest_subtitle: "Maximum Possession"
 	quest.56EC79AF11B0869E.title: "&9Xeovrenth Adjure"
 	quest.56FB82DEB944F758.quest_desc: ["Works like the &aMace of Distortion&r, except it causes an AoE explosion instead."]
@@ -9208,25 +9207,25 @@
 	quest.5AC1BE754210429E.quest_desc: ["If you want to create a team for you and your friends, use the command &a/ftbteams party create (name of team)&r to create the team!"]
 	quest.5AC497F76A086A5C.title: "&l&9Overworld Bounty:&r&e Witches"
 	quest.5ACE97EE75813006.quest_desc: [
-		"This quest is your main source of information on &dRituals&r. Here's the basics:"
+		"This is the main source of information on &dRituals&r. Here's the basics:"
 		""
-		"&lTiers of Rituals:&r"
+		"&lTiers of Rituals&r:"
 		""
-		"Rituals have (basically) four tiers based on how powerful the demon that you're invoking is. The first tier is &eFoliot&r, then &aDijini&r, &cAfrit&r, and &9Marid&r. Some rituals fall into in-between tiers, such as the &6Unbound Afrit&r tier."
+		"Rituals have (basically) four tiers based on how powerful the Demon that you're invoking is. The first tier is &eFoliot&r, then &aDijini&r, &cAfrit&r, and &9Marid&r. Some rituals fall into in-between tiers, such as the &6Unbound Afrit&r tier."
 		""
-		"T&lypes of Rituals:&r"
+		"T&lypes of Rituals&r:"
 		""
-		"There are five main types of rituals, but we'll only need four for progression. The main three are &9Summoning Rituals&r, &5Possession Rituals&r, and &6Infusion Rituals&r. Each one will be explained the first time that they appear in this questbook. The fourth type of ritual is a sort of &dDemon-less&r &dRitual&r, meaning that it uses bits and pieces from all three types to preform a special action without the direct usage of a demon. "
+		"There are five main types of rituals, but we'll only need four for progression. The main three are &9Summoning Rituals&r, &5Possession Rituals&r, and &6Infusion Rituals&r. Each one will be explained the first time that they appear in these quests. The fourth type of ritual is a sort of &dDemon-less&r &dRitual&r, meaning that it uses bits and pieces from all three types to preform a special action without the direct usage of a Demon."
 		""
 		"The fifth type, &eFamiliar Rituals&r, are not needed for progression. But they can still be summon some useful friends to help you out!"
 		""
-		"&lChalks:&r"
+		"&lChalks&r:"
 		""
-		"There are two types of chalks: Foundation Chalks, and Colored Chalks."
+		"There are two types of Chalks: Foundation Chalks, and Colored Chalks."
 		""
-		"Foundation chalks are used in every single ritual, and each tier higher gets a shade darker, starting with white chalk and ending with black chalk. "
+		"Foundation chalks are used in every single ritual, and each tier higher gets a shade darker, starting with White Chalk and ending with Black Chalk. "
 		""
-		"Colored Chalks are the most commonly used, but the color of the chalk doesn't directly corelate to its power the same as Foundation Chalks."
+		"Colored Chalks are the most commonly used, but the color of the Chalk doesn't directly corelate to its power the same as Foundation Chalks."
 	]
 	quest.5ACE97EE75813006.title: "The Basics of Rituals"
 	quest.5AD09CCEEDC0B50F.quest_desc: ["Now these are super helpful, you should definitely check them out! \\n\\nThe actual Light Source is the Feral Flare Lantern. It will place invisible Light Sources around 20 Blocks or more around it. \\n\\nThe Mega Torch is different: it doesn't emit Light but it does Block all Hostile Mob spawns with 64 Blocks of it! Useful for those using Night Vision. \\n\\nThe Dread Lamp does the opposite, it blocks Passive Mob spawns in the same area."]
@@ -9240,13 +9239,13 @@
 	quest.5AD80D3242DD3F60.quest_desc: ["One of the hardest materials to get in the mod!\\n\\nThis is also used to create the &6ATM Star&r!"]
 	quest.5AD80D3242DD3F60.title: "&dInsanite Block"
 	quest.5AE80FF518B1BBA6.quest_desc: [
-		"Tired of lugging around chalks, candles, skulls, and crystals? Just make a ritual satchel!"
+		"Tired of lugging around Chalks, Candles, Skulls, and Crystals? Just make a Ritual Satchel!"
 		""
-		"By sneak + right-clicking with the ritual satchel in your hand, you can fill it with all the materials you need to draw a ritual circle."
+		"By sneak + right-clicking with the Ritual Satchel in your hand, you can fill it with all the materials you need to draw a ritual circle."
 		""
-		"Once you've loaded up the satchel, simply right-click any preview block to begin (slowly) automatically placing all the runes for the selected ritual. "
+		"Once you've loaded up the Satchel, simply right-click any preview block to begin (slowly) automatically placing all the runes for the selected ritual. "
 		""
-		"If a piece of chalk inside the bag falls under 40% durability, the enchantment glint on this item will dissapear to signal that it may be time to repair or replace some of your chalks."
+		"If a piece of chalk inside the bag falls under 40% durability, the enchantment glint on this item will dissapear to signal that it may be time to repair or replace some of your Chalks."
 	]
 	quest.5AE80FF518B1BBA6.quest_subtitle: "Pocket Ritual!"
 	quest.5AE80FF518B1BBA6.title: "Tools of the Trade: Ritual Satchel"
@@ -9962,13 +9961,13 @@
 	quest.618F1434757C8E69.quest_desc: ["&lGenerator's Galore&r adds very simple Generators. The most basic ones act like Furnaces with &3Augment&r: Generator. They'll take Fuel and make it into Energy! \\n \\nYes you have to start with &6Copper Generator&r."]
 	quest.618F1434757C8E69.title: "&6Copper Generator&r"
 	quest.61999669BDE127F9.quest_desc: [
-		"If you haven't noticed already, making and re-making rituals over and over again is very taxing on the durability of your chalks. "
+		"If you haven't noticed already, making and re-making rituals over and over again is very taxing on the durability of your Chalks. "
 		""
-		"If you're worried about your chalk breaking, but don't feel like doing the entire ritual to create a new chalk over again, then this ritual is for you!"
+		"If you're worried about your Chalk breaking, but don't feel like doing the entire ritual to create a new chalk over again, then this ritual is for you!"
 		""
-		"Using the power of a &aDijinni&r, you can repair any color of chalk to it's maximum!"
+		"Using the power of a &aDijinni&r, you can repair any color of Chalk to it's maximum!"
 		""
-		"Alternatively, you could use something like the &aEternal Stella&r from the Forbidden Arcanus mod to permenantly preserve your chalks!"
+		"Alternatively, you could use something like the &aEternal Stella&r from the Forbidden Arcanus mod to permenantly preserve your Chalks!"
 	]
 	quest.61999669BDE127F9.quest_subtitle: "You break it, &mwe&r Demons fix it!"
 	quest.61999669BDE127F9.title: "Chalk Repair"
@@ -10527,9 +10526,9 @@
 	quest.6786C701B7C4980B.quest_desc: ["The Gravistar is another very important component for our high tier machines were going to be making."]
 	quest.6786C701B7C4980B.quest_subtitle: "Stars have Lots of Gravity"
 	quest.67884BFA27870CCE.quest_desc: [
-		"&dOsorin's Unbound Calling&r is the second tier of &dDemon-less rituals&r. The first tier isn't useful for progression at all, it's only used for reviving familiars and turning vexes into allays. "
+		"&dOsorin's Unbound Calling&r is the second tier of &dDemon-less rituals&r. The first tier isn't useful for progression at all, it's only used for reviving Familiars and turning Vexes into Allays. "
 		""
-		"This ritual is used to create a ton of rare-ish blocks, items, and materials that you might not be able to (or it's hard to) get normally."
+		"This ritual is used to create a ton of rare-ish blocks, items, and materials that you might not be able to (or it's hard to) get otherwise."
 	]
 	quest.67884BFA27870CCE.quest_subtitle: "For the less trial-chamber-inclined of us"
 	quest.67884BFA27870CCE.title: "&dOsorin's Unbound Calling"
@@ -10719,7 +10718,7 @@
 	quest.690B89D23134B624.quest_desc: [
 		"Grab your chalks, draw your &dRonaza's Contact&r ritual, and get ready to create the ULTIMATE CHALK!"
 		""
-		"Instead of having to lug around a full set of 16 chalks, you can use the rainbow chalk to paint a color-changing rune that counts as any of them! "
+		"Instead of having to lug around a full set of 16 chalks, you can use the Rainbow Chalk to paint a color-changing Rune that counts as any of them! "
 	]
 	quest.690B89D23134B624.title: "&cR&6a&ei&an&9b&5o&dw&r Chalk"
 	quest.690CFF61CE787D43.quest_desc: ["Plastic is the main resource of &bIndustrial Foregoing&r, you now have access to some very useful machines!"]
@@ -11057,7 +11056,7 @@
 		"If you aren't sure what items have NBT data on them, you can always check out the quest \"NBT and You\" in the Storage questline for more info on NBT!"
 	]
 	quest.6CC5FE34778F0DFA.title: "&c&mDemonir&r &dMagical Storage&r!"
-	quest.6CCDEEDA2C99DA66.quest_desc: ["This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks. \\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission. \\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."]
+	quest.6CCDEEDA2C99DA66.quest_desc: "This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks.\\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission.\\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode."
 	quest.6CD1720B76F47806.quest_desc: ["This generator will burn Bio Fuel into energy. It produces around 140FE/t."]
 	quest.6CD7A3760C6D87E6.title: "Block of Diamond 4X"
 	quest.6CD7D99AA102A5C3.quest_desc: ["&n&f&lLogistics&r: \\nA system of moving, managing, and storing items or resources. \\n\\nIn Modded Minecraft it's quite the same, moving items! With Modded you will need items and by the thousands, heck if you want the &6&lStar&r it gets in the millions! So you'll need to move items from factories, machines, farms, and especially chests. That's what &l&fLogistics&r is for."]
@@ -11405,7 +11404,7 @@
 	]
 	quest.6FD65139CD50A8C0.quest_desc: ["Is that even possible?\\n\\nIf you wish to automate this process you can use &eProductive Bees&r or &aMystical Agriculture&r. Or I guess you could automate it, with...explosions."]
 	quest.6FD65139CD50A8C0.quest_subtitle: "Tired of blowing stuff up?"
-	quest.6FEED25FFAC4101F.quest_desc: ["Using &aStrigeor's Higher Binding&r, you can create Gray Paste. Smear this on a piece of impure white chalk to create Gray Chalk."]
+	quest.6FEED25FFAC4101F.quest_desc: ["Using &aStrigeor's Higher Binding&r, you can create Gray Paste. Smear this on a piece of Impure White Chalk to create Gray Chalk."]
 	quest.6FEED25FFAC4101F.title: "&8Gray Chalk"
 	quest.6FF04DD735346BED.quest_desc: ["Turns Latex into Dry Rubber."]
 	quest.6FF116239EACA390.title: "End Stone 5X"
@@ -11418,7 +11417,7 @@
 		""
 		"When using this in place of a Golden Ritual Bowl, it greatly reduces how long it takes to perform a ritual, taking it down to one fourth of its original time!"
 	]
-	quest.6FFFAE334DFAAAAB.quest_subtitle: "Super-speed rituals!"
+	quest.6FFFAE334DFAAAAB.quest_subtitle: "Super-speed Rituals!"
 	quest.700F3FF7C23D0C0F.quest_desc: ["The &5Ender Cell&r will store power for a channel in your &7Ender Network&r. To increase the power capacity of the network, right click on the Ender Cell to open up the interface, then add either a &aBattery&r or an &9Energy Cell&r to increase the overall capacity."]
 	quest.70112194DFFD15D3.title: "&5Tyr Armor"
 	quest.7026E46FD8B3A81D.quest_desc: ["The &9Hydra&r is the infamous multi-headed beast from Greek Mythology.\\n\\nRanged attacks aren't as effective, meaning you'll need to get up close and personal.\\n\\nOnce defeated, you'll be able to find the next boss in the &2Dark Forest&r."]
@@ -11910,7 +11909,7 @@
 	quest.74015945716FD10A.quest_subtitle: "A configurable hopper"
 	quest.7408CCF998D9CD37.quest_desc: ["A Craftable &eSpell Book&r... yeah it's not easy to craft. \\n\\nHardest to get would be the Ruined Book, which you can find in &9Ancient City&r Chests. &4Blood Vials&r can be obtained from either putting a Mob (or even yourself) into a Cauldron above a Campfire or an Alchemical Cauldron. &5Bottle O' Lightning&r comes from using a Bottle on a Charged Creeper. \\n\\nOnce you do all that you can craft the Ancient Codex. Its 12 &3Spell&r Slots is very helpful!"]
 	quest.7408CCF998D9CD37.title: "Ancient Codex"
-	quest.74130EB1E4B8586D.quest_desc: ["Using &aIhagan's Enthrallment&r, you can sacrifice an allay, bat, bee, or parrot to summon the &6Possessed Bee&r. Upon defeating it, it will drop cursed honey, the main ingredient for making orange chalk!"]
+	quest.74130EB1E4B8586D.quest_desc: ["Using &aIhagan's Enthrallment&r, you can sacrifice an Allay, Bat, Bee, or Parrot to summon a &6Possessed Bee&r. Upon defeating one, it will drop Cursed Honey, the main ingredient for making Orange Chalk!"]
 	quest.74130EB1E4B8586D.title: "&6Orange Chalk"
 	quest.7413BB136EF9D6C5.quest_desc: ["The Mechanical Drying Basin uses energy to dry"]
 	quest.74200A48498DD7F8.quest_desc: ["Generates power from the sun!"]
@@ -12665,7 +12664,7 @@
 	quest.7BC616DDB5933479.quest_desc: ["This one can be created with a &5Blood Vial&r and normal ingrediants for Scrolls. \\nYou will need to make sure it is Level 10 and &6Legendary&r which you can upgrade it to."]
 	quest.7BC616DDB5933479.title: "&4Wither Skull Scroll"
 	quest.7BC8F50A89A3BE1A.quest_desc: ["These are just used to Connect &cLaser Nodes&r to each other and to Connectors. Not too important I just wanted to keep with the theme of Wrenches. \\n\\nIt does work as a Wrench for other Configs!"]
-	quest.7BCD4A425CF6199B.quest_desc: ["After slaying the Goat of Mercy summoned from &9Xeovrenth Adjure&r, you'll find yourself one Cruelty Essence richer. Combine this with some cocao beans to create Brown Chalk."]
+	quest.7BCD4A425CF6199B.quest_desc: ["After slaying the Goat of Mercy summoned from &9Xeovrenth Adjure&r, you'll find yourself one Cruelty Essence richer. Combine this with some Cocao Beans to create Brown Chalk."]
 	quest.7BCD4A425CF6199B.title: "&#4E2C00Brown Chalk"
 	quest.7BCE96070C36D547.quest_subtitle: "&f7.5 &cAttack Damage"
 	quest.7BFC24607189B6D0.quest_desc: ["Makes you swim faster."]
@@ -13318,7 +13317,6 @@
 	task.2BC0F5A88E2F03C3.title: "Archwood Logs"
 	task.2BECEC3EFA8F6DA3.title: "Chipped Stones"
 	task.2C268116DA162155.title: "AllRightsReserved"
-	task.2C5C6F411E2F0CAF.title: "Any #c:dusts/netherite"
 	task.2C621D97D1ED56DE.title: "FE Generation"
 	task.2C816285392535F0.title: "AllRightsReserved"
 	task.2CC38211F4C54ED8.title: "Draconic Comb"
@@ -13373,7 +13371,6 @@
 	task.34E5BD34C83CD6F9.title: "AllRightsReserved"
 	task.35320BB07FB39D05.title: "AllRightsReserved"
 	task.359396879CBA62D5.title: "Nest Spawning"
-	task.3621D48E2CFAF2C2.title: "Any #c:wools"
 	task.362D501E0D663695.title: "RFTools Storage"
 	task.36397CBA6D39DC0D.title: "Tungsten Ingot"
 	task.363BADA865C39474.title: "AllRightsReserved"
@@ -13519,7 +13516,6 @@
 	task.510CE57C709D5A44.title: "Observe Hydrofluoric Acid in a Machine"
 	task.518B9569DCE0A771.title: "AllRightsReserved"
 	task.51A3E013D2B3D744.title: "Machine Upgrades"
-	task.523951BF097BA61F.title: "Any #c:dusts/emerald"
 	task.52874F5B79ECAE65.title: "Stone Bricks"
 	task.529FFD7D692AEFA5.title: "Specialized Projectiles"
 	task.52BB142F044075B4.title: "Quests"
@@ -13543,7 +13539,6 @@
 	task.56A486D09B8B90EC.title: "Observe Alloy Blast Smelter"
 	task.56D7513E9D02F900.title: "Drill Heads"
 	task.570BF38EA2870300.title: "Quests By AllTheMods"
-	task.57108C994437F25B.title: "Any #ae2:all_nether_quartz"
 	task.57895147416291FE.title: "AllRightsReserved"
 	task.57DD9261905988F3.title: "Mekanism Iron Swords"
 	task.57F40CFA03BD36EF.title: "The Hard Part"


### PR DESCRIPTION
I re-did the pull request after the base code was apparently flawed.
Thanks to TheBedrockMaster for helping me with this.

List of changes:
- Rearranged 90% of the existing quests to make the flow more natural/readable
- Renamed a few quests (mainly to add Tools of the Trade: to the beginning of tool quests)
- Deleted some quests and merged their requirements/text/rewards into new quests
- Changed dependencies of certain quests to better fit in with added quests
- Added more requirements to certain quests to better assist players in understanding the mod
- Changed descriptions of several of the existing quests to better assist players in understanding the mod
- Added quests:
  - The Basics of Rituals
  - Tools of the Trade: Butcher's Knife
  - Eziveus' Spectral Compulsion
  - Lime Chalk
  - Green Chalk
  - Strigeor's Higher Binding
  - Ihagan's Enthrallment
  - Chalk Repair
  - Tools of the Trade: Ritual Satchel
  - Gray Chalk
  - Orange Chalk
  - Abras' Open Conjure
  - Abras' Open Commanding Conjure
  - Pink Chalk
  - Red Chalk
  - Sevira's Permanent Confinement
  - Tools of the Trade: Artisanal Ritual Satchel
  - Iesnium Sacrificial Bowl
  - Repairing Items
  - Black Chalk
  - Abras' Fortified Conjure
  - Blue Chalk
  - Uphyxes' Inverted Tower
  - Xeovrenth Adjure
  - Fatmas' Incentivized Attraction
  - Iesnium Anvil
  - Magenta Chalk
  - Brown Chalk
  - Cyan Chalk
  - Light Blue Chalk
  - Osorin's Unbound Calling
  - Ronaza's Contact
  - Trinity Gem
  - Rainbow Chalk
  - Eldritch Chalice
  - Void Chalk (optional)
  - What's next?