### PR TITLE
Correction of typos for en_us.snbt

### DIFF
--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -489,7 +489,7 @@
 	quest.04C01A5FF3DAC326.quest_desc: [
 		"This special Enchanter enchants using the shards. It uses your levels and shards."
 		"It lets you decide enchants to put on. And lets you level them up."
-		"If you end up not able to use anymore, it may be \\\"completed\\\", consider using this in tandem of Apotheosis enchanting for absurd enchants."
+		"If you end up not able to use anymore, it may be \"completed\", consider using this in tandem of Apotheosis enchanting for absurd enchants."
 	]
 	quest.04C01A5FF3DAC326.quest_subtitle: "Consider this your gateway to Apotheosis"
 	quest.04D0543FE2820F64.quest_desc: ["Flax String can be used in replace of normal String."]
@@ -610,7 +610,7 @@
 	quest.05B0A7D0B991050F.title: "Reactor (Hardened)"
 	quest.05B5E640F1B68A28.quest_desc: ["{image:atm:textures/questpics/basicarmor/armor_golem.png width:100 height:150 align:center}"]
 	quest.05B5E640F1B68A28.title: "&3Golem Steel&r"
-	quest.05B6DB75AEC01187.quest_desc: ["RFTools Power has &9Powercells&r to store power, which are multi-block storage units that can be customized and upgraded to store power.\\\\n\\\\nYou will need a Wrench to determine inputs and outputs for power."]
+	quest.05B6DB75AEC01187.quest_desc: ["RFTools Power has &9Powercells&r to store power, which are multi-block storage units that can be customized and upgraded to store power.\\n\\nYou will need a Wrench to determine inputs and outputs for power."]
 	quest.05B6DB75AEC01187.title: "&9RFTools Power: &cPowercells"
 	quest.05B8C64EB012F6EA.quest_desc: ["Another option is using Chronal exchange; gain mahou for 12 hours, then spend it for 12 hours. If you make a second Chronal exchange circle when the first starts spending, it becomes a loop. "]
 	quest.05B8C64EB012F6EA.title: "Chronal Exchange"
@@ -678,7 +678,7 @@
 	quest.064BBCC379A69748.quest_desc: ["This one is around twice as good as a vanilla furnace, and is more efficient to boot! While it gets outclassed by other furnace mods, for a strictly MI playthrough this furnace is incredibly strong!"]
 	quest.0650996C7818ADB5.quest_desc: ["The Heat Generator has 2 modes to generate power:\\n\\n&9Passive:&r Surrounding the generator with lava source or flowing blocks creates passive power by creating heat. Place one lava source block on top, and let it flow over the sides. Make sure to connect pipes first!\\n\\n&9Active:&r Placing combustible materials such as coal or wood into the generator will burn the fuel to create power."]
 	quest.0650996C7818ADB5.quest_subtitle: "Basic Power Gen"
-	quest.0661E9669E639621.quest_desc: ["Some saplings can't be pollinated. These saplings have a random chance to grow into another tree.\\n\\nFor example if you want to get a &4Red Crepe Myrtle Sapling&r, first grow a Purple Crepe Sapling. You will have a chance to get a &4Red Crepe Myrtle Tree&r from that."]
+	quest.0661E9669E639621.quest_desc: ["Some saplings can't be pollinated. These saplings have a random chance to grow into another tree.\\n\\nFor example if you want to get a &4Red Crepe Myrtle Sapling&r, first grow a Purple Crepe Myrtle Sapling. You will have a chance to get a &4Red Crepe Myrtle Tree&r from that."]
 	quest.0661E9669E639621.quest_subtitle: "Self Breeding?"
 	quest.066438B01655D866.quest_desc: ["While their &dEssence&r is useful, we can also capture these Spirits for later use. That sounds evil, doesn't it?\\n\\nTo become a Spirit Hunter, you'll need to create the &dVengeance Focus&r first. This is used to &aFreeze Spirits&r in place, then you place a &9Box of Eternal Closure&r near the Spirit. This will then suck the Spirit in for later use."]
 	quest.066438B01655D866.title: "Capturing &dSpirits"
@@ -749,7 +749,7 @@
 	quest.06F55064A36274D2.quest_desc: [
 		"Now, take the Yttrium Barium Cuprate bolts we made, and the Crystal SOC, combine them together, and you get the cheapest available IV tier Processors!!"
 		""
-		"Remember, the controllers for most of the \\\"Large\\\" multiblocks of our machines use IV Processors in crafting them."
+		"Remember, the controllers for most of the \"Large\" multiblocks of our machines use IV Processors in crafting them."
 	]
 	quest.06F55064A36274D2.quest_subtitle: "Cheap as can be"
 	quest.06F8EDF7513F8611.title: "&dEpic&r Ink"
@@ -971,9 +971,9 @@
 		""
 		"The blocks must be glued together and any blocks requiring rotational force will automatically be working."
 		""
-		"To \\\"unmount\\\" the blocks from the Minecart, simply turn off the redstone signal and let the Minecart ride through."
+		"To \"unmount\" the blocks from the Minecart, simply turn off the redstone signal and let the Minecart ride through."
 	]
-	quest.09955CF85F579E0F.quest_desc: ["You'll get this eventually, it's quite literally the most abundunt Block in &2&lMinecraft&r."]
+	quest.09955CF85F579E0F.quest_desc: ["You'll get this eventually, it's quite literally the most abundant Block in &2&lMinecraft&r."]
 	quest.09955CF85F579E0F.title: "Stone Blocks"
 	quest.09BA45CBBFB4AE26.quest_desc: ["The next stage of this mod requires you to set up &3Assembly Lines&r. The main component of an &3Assembly Line&r is the &3Assembly Controller&r.\\n\\nThis is where the pressure will go."]
 	quest.09BA45CBBFB4AE26.quest_subtitle: "Always Required"
@@ -1100,7 +1100,7 @@
 	quest.0AE6AD813928DE4F.quest_desc: ["The External Heater can be used with Furnaces, like the &2&lVanilla&r ones, not &c&lCrude Blast Furnace&r! \\n\\nIt takes in &cEnergy&r from the Bottom and uses it for Heat. \\n\\nThe Heat comes out of the other sides of it, to adjacent Blocks. \\n\\nIt is technically used for the &4&lImproved Blast Furnace&r, by Crafting the Preheaters but I don't count that!"]
 	quest.0AEAEA976ED0C470.quest_desc: ["The &3Charging Station&r is used to charge various tools and gadgets in &aPneumaticCraft&r using pressure."]
 	quest.0AEAEA976ED0C470.quest_subtitle: "Where's the cord?"
-	quest.0AEC181F5E21A299.quest_desc: ["If you've ever heard of someone talking about \"Melon Power\", this is it. Mekanism's &dGas-Burning Generator&r can produce a good amount of power by pumping in &9Ethylene&r made from Melon Slices.\\\\n\\\\nTo produce &dEthylene&r, start by crushing organic materials in a &eCrusher&r to create &6Bio Fuel&r. Melon Slices are typically used for this! This is then pumped into a &dPressurized Reaction Chamber&r (PRC for short).\\\\n\\\\nThe PRC needs Water, Bio Fuel, and some Hydrogen to create Ethylene. You can get the Hydrogen from separating water in an &9Electrolytic Separator&r.\\\\n\\\\nOnce you've started producing the Ethylene, pump it into the Gas-Burning Generator to start generating power!"]
+	quest.0AEC181F5E21A299.quest_desc: ["If you've ever heard of someone talking about \"Melon Power\", this is it. Mekanism's &dGas-Burning Generator&r can produce a good amount of power by pumping in &9Ethylene&r made from Melon Slices.\\n\\nTo produce &dEthylene&r, start by crushing organic materials in a &eCrusher&r to create &6Bio Fuel&r. Melon Slices are typically used for this! This is then pumped into a &dPressurized Reaction Chamber&r (PRC for short).\\n\\nThe PRC needs Water, Bio Fuel, and some Hydrogen to create Ethylene. You can get the Hydrogen from separating water in an &9Electrolytic Separator&r.\\n\\nOnce you've started producing the Ethylene, pump it into the Gas-Burning Generator to start generating power!"]
 	quest.0AEC181F5E21A299.quest_subtitle: "MELON POWER!"
 	quest.0AEC181F5E21A299.title: "&9Mekanism: &dGas-Burning Generator"
 	quest.0AF5FB1B5AA5AA11.quest_subtitle: "Tier: &b4"
@@ -1226,7 +1226,7 @@
 	quest.0C82CE3AFBD48C1E.title: "&l&aSushi Go Crafting&r"
 	quest.0C856BBB1679A7DD.quest_desc: ["On this page, you'll find some useful items and info to help you on your journey!"]
 	quest.0C856BBB1679A7DD.quest_subtitle: "And Other Useful Items!"
-	quest.0C93D7A607AB8B83.quest_desc: ["To claim chunks, open up your map using &6M&r, then click the &aClaim Map&r icon in the top left.\\n\\nTo claim a chunk, left click and drag to claim.\\n\\nTo force load a chunk, shift-left click the chunk. If done properly, you'll see lines across the chunk."]
+	quest.0C93D7A607AB8B83.quest_desc: ["To claim chunks, open up your map using &6M&r, then click the &aClaimed Chunks&r icon in the top left.\\n\\nTo claim a chunk, left click and drag to claim.\\n\\nTo force load a chunk, shift-left click the chunk. If done properly, you'll see lines across the chunk."]
 	quest.0C98503A2F20484D.quest_desc: [
 		"Near Frostfields you may find Frosty Smogstem Forests. \\n\\nThese are just like Frostfields just with Smogstem Trees!"
 		"{image:atm:textures/questpics/undergarden/undergarden_frostytrees.png width:200 height:100 align:center}"
@@ -1375,7 +1375,7 @@
 	quest.0DC0E236C8213050.quest_desc: ["By combining 500mB of Unrefined Liquid Souls with a singular Soul, we can create 500mB of Liquid Souls! \\n\\nThis will need twice the amount of &dSource&r that the &bLiquid Aureal&r needs, at 2000 &dSource&r."]
 	quest.0DC0E236C8213050.title: "Liquid Souls"
 	quest.0DC8B68CDF945348.quest_desc: ["The Router giveth and the Router taketh. \\n\\nThis Module is helpful for Builders or even Miners! It can be set to send items from its Buffer to your Inventory or take items from your Inventory into its Buffer. \\n\\nPerfect for Strip-Mining, have it take all the Cobble and Deepslate from your Inventory and put it in a Trash Can."]
-	quest.0DD389A24F5F8CDD.quest_desc: ["&l&6Aqua Regia&r&r is a mixture of Concentrated Nitric Acid and Hydrochloric Acid, usually one part to three parts, respectively. The Mixture was given its name (literally \\\"Royal Water\\\") by alchemists because of its ability to dissovle &l&eGold&r&r."]
+	quest.0DD389A24F5F8CDD.quest_desc: ["&l&6Aqua Regia&r&r is a mixture of Concentrated Nitric Acid and Hydrochloric Acid, usually one part to three parts, respectively. The Mixture was given its name (literally \"Royal Water\") by alchemists because of its ability to dissovle &l&eGold&r&r."]
 	quest.0DD389A24F5F8CDD.quest_subtitle: "Im a Barbie Girl, In a Barbie world... If you know, you know."
 	quest.0DF4B01CC5B49E4E.quest_desc: ["With this Blueprint, you can make the basic sword! Reliable damage and reliable speed."]
 	quest.0DF4B01CC5B49E4E.quest_subtitle: "Good ol' Reliable"
@@ -1608,7 +1608,7 @@
 		"{image:atm:textures/questpics/forbidden/forbidden_forge1.png width:100 height:100 align:center}"
 		"To start making your Forge, place down our &9Polished Darkstone&r, &6Arcane Polished Darkstone&r, and &6Gilded Chiseled Polished Darkstone&r in this pattern. "
 		"{image:atm:textures/questpics/forbidden/forbidden_forge2.png width:100 height:100 align:center}"
-		"\"Next place our Smithing Table on the inner &6Gilded Chiseled Polished Darkstone&r and smack it with &cMundabitur Dust&r, you'll get the &6&lHephaestus Forge&r!\\\\n\\\\nLastly place our &6Darkstone Pedestals&r on top of the 8 outside &6Gilded Chiseled Polished Darkstone&r!\""
+		"\"Next place our Smithing Table on the inner &6Gilded Chiseled Polished Darkstone&r and smack it with &cMundabitur Dust&r, you'll get the &6&lHephaestus Forge&r!\\n\\nLastly place our &6Darkstone Pedestals&r on top of the 8 outside &6Gilded Chiseled Polished Darkstone&r!\""
 	]
 	quest.0FD638380EECFFBD.title: "Building the &6&lForge"
 	quest.0FE30548F25FEDB1.quest_desc: ["If you're like me and don't like living in a Box (it reminds me too much of School), then you'll like to have Glass in your Builds to see outside. \\n\\nWhile the normal Vanilla ones are nice of course we can do much better! \\n\\nWe can even get some use out of it!"]
@@ -1735,7 +1735,7 @@
 	quest.11C5F17C6BB1237B.quest_desc: ["While wearing the &5Withered Bracelet&r Melee Attacks have a chance to give the Wither Effect.\\n\\nSorry Bow users!"]
 	quest.11C5F17C6BB1237B.quest_subtitle: "Wrists (Hands)"
 	quest.11C5F17C6BB1237B.title: "&5Withered Bracelet&r"
-	quest.11D09E918015355C.quest_desc: ["Mekanism's &cHeat Generator&r is a different take on basic power production. It has two modes of creating power:\\\\n\\\\n&9Passive:&r Surrounding the generator with Lava source or flowing blocks creates passive power over time through heat. Place one Lava source block on top and let it flow over the sides. Make sure to have Pipes connected for energy first!\\\\n\\\\n&9Active:&r Placing combustible materials such as Coal or Wood into the generator will burn the fuel to create power. This is not very efficient."]
+	quest.11D09E918015355C.quest_desc: ["Mekanism's &cHeat Generator&r is a different take on basic power production. It has two modes of creating power:\\n\\n&9Passive:&r Surrounding the generator with Lava source or flowing blocks creates passive power over time through heat. Place one Lava source block on top and let it flow over the sides. Make sure to have Pipes connected for energy first!\\n\\n&9Active:&r Placing combustible materials such as Coal or Wood into the generator will burn the fuel to create power. This is not very efficient."]
 	quest.11D09E918015355C.title: "&cHeat Generator"
 	quest.11D16434F78D2C2C.quest_desc: [
 		"You can use an Extractor to get glass in a liquid state for making the diode"
@@ -1854,7 +1854,7 @@
 	quest.12F916CDC2FB7A79.quest_desc: [
 		"Rather than live in a crafting grid making plates and wires, it is often easier to automate these"
 		""
-		"&5Applied Energistics&r can handle this nicely when you set \\\"Use Substitutions\\\" to Yes"
+		"&5Applied Energistics&r can handle this nicely when you set \"Use Substitutions\" to Yes"
 		"&eNote:&r If you find channels limiting, consider setting the channelmode to 4x or infinite with the following commands (you'll need OP on a server or cheats enabled on singleplayer)"
 		"&o/ae2 channelmode x4&r"
 		"&o/ae2 channelmode infinite&r"
@@ -1865,7 +1865,7 @@
 		""
 		"Automation is highly recommended, especially when we begin dealing with fluids"
 		""
-		"You can set &6LV+ Machines&r to automatically output back into a pattern provider, just be sure to toggle the \\\"Allow Inputs from Output Side\\\" setting in the GUI. Steam machines aren't smart enough to auto output, so you'll need something to &cimport&r back into the system for now"
+		"You can set &6LV+ Machines&r to automatically output back into a pattern provider, just be sure to toggle the \"Allow Inputs from Output Side\" setting in the GUI. Steam machines aren't smart enough to auto output, so you'll need something to &cimport&r back into the system for now"
 	]
 	quest.130577AD1A1A8222.quest_desc: ["&7Cloggrum&r has stats a little worse than Iron Armor, but it pratically grows on Trees so I think that's fair. \\n\\nThe Boots also help with going through Scintling Goo!"]
 	quest.130577AD1A1A8222.title: "&7Cloggrum&r Armor"
@@ -2094,7 +2094,7 @@
 		"{image:atm:textures/questpics/mek/induction_inside.png width:300 height:200 align:1}"
 	]
 	quest.14D772808D1BEAE2.title: "&aCustomizing Our &9Power Limits"
-	quest.14D9C071E184DE3B.quest_subtitle: "Purple Crepe + Luck"
+	quest.14D9C071E184DE3B.quest_subtitle: "Purple Crepe Myrtle + Luck"
 	quest.14DB8A515CA50932.quest_desc: ["The &9Enchanter's Sword&r allows you to attach a Touch Spell to the sword. \\n\\nAll spells on the Sword gain 1 additional Amplify augment to the last effect on the spell. \\n\\nTo apply a spell to the sword, use a Scribe's Table. Create the spell without using a form."]
 	quest.14E5349DD740D026.quest_desc: [
 		"To insert fuel into the reactor, you'll need to pick one of the sides that has a &9Reactor Solid Access Port&r and pump in &eUranium&r from an inventory.\\n\\nThe easiest way to do this is to use something like a &aStorage Drawer&r or even just a &aChest&r with an &9Item Pipe&r connected at the top, like the image shown below.\\n"
@@ -2124,7 +2124,7 @@
 	quest.151D836C7B0E6FAF.title: "&3Vibranium Shield"
 	quest.15279CAC2FFE6B35.quest_subtitle: "Tier: &c5"
 	quest.1533D98B3B2A758E.quest_desc: ["Shattered Swords can either be dropped from Lonestar Skeletons or crafted using the dropped Blades. \\n\\nThe Shattered Sword is used more like a Trident than a Sword, instead of hitting you'll throw it. Then, you can Right Click to bring back the Blade like a Loyalty Trident, and Right Click again to reload it if needed."]
-	quest.15540271BF17C2E4.quest_desc: ["&lWelcome to XyCraft!&r\\n\\nThis series of mods is mostly dedicated to XyCraft: World and Machines!\\\\nWorld gives us the Gems which can be found while mining."]
+	quest.15540271BF17C2E4.quest_desc: ["&lWelcome to XyCraft!&r\\n\\nThis series of mods is mostly dedicated to XyCraft: World and Machines!\\nWorld gives us the Gems which can be found while mining."]
 	quest.15540271BF17C2E4.title: "&lXyCraft"
 	quest.15564C11744D6AA0.quest_desc: ["Once you have obtained a full set of the required &eInscriber Presses&r, it's time to start making some &eProcessors&f. These are an important crafting ingredient used to make the large majority of ME-connected devices."]
 	quest.15564C11744D6AA0.title: "Processors"
@@ -2149,7 +2149,7 @@
 	quest.158B24939A269D83.quest_subtitle: "For when you don't find 3 Diamonds"
 	quest.158F13367C2E0C6D.quest_desc: [
 		"To start our first ritual, you'll need Soul Shards."
-		"Craft a Brazier, this will burn the \\\"important\\\" item to start a ritual."
+		"Craft a Brazier, this will burn the \"important\" item to start a ritual."
 		"Craft 8 hands. These will serve as outside method of added items for rituals. Or decorative if you like hands."
 	]
 	quest.158F13367C2E0C6D.quest_subtitle: "A rumbly in my tumbleys that only hands may satisfy."
@@ -2736,7 +2736,7 @@
 	quest.1BB1E43FFE3FD451.quest_subtitle: "The Star that started it all"
 	quest.1BC611E39465B026.quest_subtitle: "Wenge + Silver Lime"
 	quest.1BCA04665A8F5EF5.quest_desc: ["Instantly moisten farmland it creates. Do we know if there is a better word for that?"]
-	quest.1BCE8D02CDD13838.quest_desc: ["Can Create \\\"Liquid\\\" Potions that can be bottled into Potions."]
+	quest.1BCE8D02CDD13838.quest_desc: ["Can Create \"Liquid\" Potions that can be bottled into Potions."]
 	quest.1BD5B25B80EC0F97.quest_desc: ["Also makes those magnetic iron rods for just some energy - save your redstone!"]
 	quest.1BD5B25B80EC0F97.quest_subtitle: "Magnetizing!"
 	quest.1BE26A00A420DAE3.quest_desc: ["In this mod, you'll need &aFlux Cores&r and &aFlux Blocks&r to craft the core parts of your network. Make a few of each!"]
@@ -3042,7 +3042,7 @@
 	]
 	quest.1F7DA060792D716A.title: "&l&dMixer"
 	quest.1F7DFA5AA65F2812.quest_desc: ["The &bAcceleration Card&f, depending on the device being upgraded with it, will either increase the speed at which the device operates or allow the device to carry out more operations in one go.\\n\\nIn the case of the &eMolecular Assembler&f, a full set of 5 cards reduces the time taken for the MA to fulfil a craft from one second (with no cards) to one &otick&r."]
-	quest.1F81EA5E45424308.quest_desc: ["If you're looking for different ways to get power out of your machines, this is where you can find it!\\\\n\\\\nThere are several options, both &awired&r and &9wireless&r, for transferring power."]
+	quest.1F81EA5E45424308.quest_desc: ["If you're looking for different ways to get power out of your machines, this is where you can find it!\\n\\nThere are several options, both &awired&r and &9wireless&r, for transferring power."]
 	quest.1F81EA5E45424308.title: "&f&lTransferring Power"
 	quest.1F82DBE75059C139.title: "&9The Starter Dungeons"
 	quest.1F88C697817A7680.quest_desc: ["Buffs:\\n\\n - Absorption II (3:00)"]
@@ -3838,7 +3838,7 @@
 		"It might be worth making a new EBF, one for just Program 1 recipes"
 	]
 	quest.26D306418545A2D6.quest_desc: [
-		"The &dFusion Reactor&r can produce up to 200MRF/t on its own, but first we need to understand some mechanics.\\n\\nThe easiest way to produce power is by pumping in Deuterium and Tritium separately, then controlling how much fuel is burned using the &aInjection Rate&r in the &cFuel Tab&r.\\.\\.This has to be an even number with a max of 98, as it combines the D-T fuel inside of the Reactor itself. The consumption of each fuel is equal to half of the Injection Rate per tick, meaning 49mb/t of each for the max.\\n\\nHowever, you can directly inject &dD-T Fuel&r, but will not be able to control the Injection Rate. This will create massive amounts of power per tick, but at a much higher fuel consumption rate of 500mb/t of each fuel.\\n"
+		"The &dFusion Reactor&r can produce up to 200MRF/t on its own, but first we need to understand some mechanics.\\n\\nThe easiest way to produce power is by pumping in Deuterium and Tritium separately, then controlling how much fuel is burned using the &aInjection Rate&r in the &cFuel Tab&r.\\n\\nThis has to be an even number with a max of 98, as it combines the D-T fuel inside of the Reactor itself. The consumption of each fuel is equal to half of the Injection Rate per tick, meaning 49mb/t of each for the max.\\n\\nHowever, you can directly inject &dD-T Fuel&r, but will not be able to control the Injection Rate. This will create massive amounts of power per tick, but at a much higher fuel consumption rate of 500mb/t of each fuel.\\n"
 		"{image:atm:textures/questpics/mek/fusion_fuelui1.png width:175 height:150 align:1}"
 	]
 	quest.26D306418545A2D6.title: "&dThe End Game Power Source"
@@ -4038,7 +4038,7 @@
 	]
 	quest.29A1E1FF02BD9219.title: "Starlight Forest"
 	quest.29AE69722AB4C75C.quest_subtitle: "Tier: &a2"
-	quest.29BDF6CA8FAAC390.quest_desc: ["Oh come on, you saw that coming. Of course Im going to add a blurb saying \\\"You spin me Right Round...\\\" for the centrifuge! Who wouldnt?!?!"]
+	quest.29BDF6CA8FAAC390.quest_desc: ["Oh come on, you saw that coming. Of course Im going to add a blurb saying \"You spin me Right Round...\" for the centrifuge! Who wouldnt?!?!"]
 	quest.29BDF6CA8FAAC390.quest_subtitle: "You Spin me Right Round Baby...."
 	quest.29C78845B488EDF8.quest_desc: [
 		"The many many &5Purple Flowers&r and &5Purple Luminescent Ancient Wax&r show us this is the &5Purple structure&r. \\n\\nGo through the &5purple Wind Tunnels&r, sink past the &5purple sewers&r, walk through the &5purple rooms&r full of &5purple flowers&r, amethyst, and string curtains, to get to the &5Purple Essence&r. \\nOnce in you'll have to survive through the time limit to win. Purple Spikes will come out of the ground to kill you, avoid them!|"
@@ -4377,7 +4377,7 @@
 		""
 		"&dSparks&r are used to transfer Mana to specific blocks, which are needed for in the progression of Botania."
 		""
-		"To use a Spark, place one over a Mana Pool, then another over a nearby block that can accept it. Think of this like \\\"wirelessly\\\" transferring Mana from your Mana Pools to the desired nearby block."
+		"To use a Spark, place one over a Mana Pool, then another over a nearby block that can accept it. Think of this like \"wirelessly\" transferring Mana from your Mana Pools to the desired nearby block."
 		""
 		"To remove a Spark, sneak-right click it with a &2Wand of the Forest&r."
 	]
@@ -5216,8 +5216,8 @@
 	]
 	quest.358D4F507521075F.title: "&eHive&r Temple"
 	quest.3591EAA8E397F992.quest_desc: [
-		"Let's go through the checklist &oone more time&r to ensure we have everything ready to go before we boot it up:\\\\n\\\\n1. Hazmat Suit on (safety first).\\\\n2. Water/coolant pumping into an input Port."
-		"3. Fissile Fuel pumping into an input Port.\\\\n4. A Port set to output the Heated Coolant, either to a trashcan or an Industrial Turbine.\\\\n5. A Port set to output Nuclear Waste leading to Radioactive Waste Barrels or machines to process it, or both!\\\\n\\\\nIf you're ready to go, hit that &eActivate&r button! You can also adjust the &3Burn Rate&r to produce more Nuclear Waste, but start slow."
+		"Let's go through the checklist &oone more time&r to ensure we have everything ready to go before we boot it up:\\n\\n1. Hazmat Suit on (safety first).\\n2. Water/coolant pumping into an input Port."
+		"3. Fissile Fuel pumping into an input Port.\\n4. A Port set to output the Heated Coolant, either to a trashcan or an Industrial Turbine.\\n5. A Port set to output Nuclear Waste leading to Radioactive Waste Barrels or machines to process it, or both!\\n\\nIf you're ready to go, hit that &eActivate&r button! You can also adjust the &3Burn Rate&r to produce more Nuclear Waste, but start slow."
 	]
 	quest.3593D955361B0C6D.quest_desc: [
 		"To kick start the Fusion Reactor, we'll need a quick shot of D-T fuel. This is made by combining &cDeuterium&r and &eTritium&r together in a Chemical Infuser."
@@ -5413,7 +5413,7 @@
 	quest.3762F8137BFD5A74.quest_desc: ["The &aCracker&r doesn't get you oil, but it does allow for processing the byproducts more efficiently! "]
 	quest.378105383747DD48.quest_desc: ["Now this ones complicated. \\n\\nTo get &8&lReplica&r first have 100 Souls, Damage Exchange, and Immunity Exchange ready. \\n\\nThen, hold your Strengthened Shield to block an attack, then you'll get &8&lReplica&r!"]
 	quest.378105383747DD48.title: "&8&lReplica"
-	quest.378BF828DC931F0C.quest_desc: ["Personally, I hate having to run to a block just to craft. That's where the &2Crafting Stick&r comes in!\\n\\nThis item works as a &aPortable Crafting Table&r!\\n\\nTip: You can also put this in your &aCurios&r slot and set a &bKeybind&r to open it!"]
+	quest.378BF828DC931F0C.quest_desc: ["Personally, I hate having to run to a block just to craft. That's where the &2Crafting Table on a Stick&r comes in!\\n\\nThis item works as a &aPortable Crafting Table&r!\\n\\nTip: You can also put this in your &aCurios&r slot and set a &bKeybind&r to open it!"]
 	quest.378BF828DC931F0C.title: "Crafting, but on a Stick"
 	quest.378C95C18798D413.quest_desc: ["A quick way to switch between tools.\\n\\nUpgrade with belt pouches in an anvil to increase capacity."]
 	quest.378C95C18798D413.title: "Tool Belt"
@@ -5639,7 +5639,7 @@
 		""
 		"This is a good way to obtain a decent amount of &2Beryllium&r, as well as other resources that are helpful and used in other recipies, such as Nitrogen Dioxide."
 	]
-	quest.3A8BF9BE08F54513.quest_subtitle: "\\\"By Grabthar's hammer...!\\\""
+	quest.3A8BF9BE08F54513.quest_subtitle: "\"By Grabthar's hammer...!\""
 	quest.3A9AC6AB4407DC32.quest_desc: ["Although not every recipe requires the same components, you can set up your &3Assembly Lines&r with everything installed. A simple &3Assembly Line&r setup that can be used for everything is shown in the image below. Read the quests for each component for some important information about them.\\n\\nSpeed Upgrades make this so much quicker!"]
 	quest.3A9AC6AB4407DC32.quest_subtitle: "Some Assembly Required"
 	quest.3A9AC6AB4407DC32.title: "Using Assembly Lines"
@@ -6254,7 +6254,7 @@
 	quest.3FF97A4B5029C0E7.title: "&7Scroll of Weapon Projectiles"
 	quest.3FFF9018DA2A2763.quest_desc: ["Once we start burning up Fissile Fuel in the reactor, we'll get heated &bCoolant&r and &8Nuclear Waste&r.\\n\\nThis is where the Radiation kicks in. As long as it stays &osafely in some container or machine&r, you won't have any spills....right?\\n\\nThe best way to store any Radioactive substance is using a &2Radioactive Waste Barrel&r. These will safely store the waste, while slowly decaying the gas without causing a Radiation spill. You don't want your Nuclear Waste sitting in your Reactor as it causes it to produce more heat, so set a port to &aoutput Waste&r and ship it to a barrel!\\n\\n&9Important Note&r: Breaking &nany&r machine, barrel, pipe, or &oanything&r that has a Radioactive gas inside of it &cwill cause a Radiation leak&r. That includes the products of Nuclear Waste, like Polonium or Plutonium."]
 	quest.3FFF9018DA2A2763.title: "Dealing with &8Nuclear Waste"
-	quest.4007DFA7CC3A5FF2.quest_desc: ["To save you from having this &oentire quest section&r covered with filter upgrades, take a look at the Sophisticated Backpack upgrades\\n\\nYou'll need to make the Sophisticated Storage equivalent, but they function about the same."]
+	quest.4007DFA7CC3A5FF2.quest_desc: ["To save you from having this &oentire quest section&r covered with upgrades, take a look at the Sophisticated Backpack upgrades\\n\\nYou'll need to make the Sophisticated Storage equivalent, but they function about the same."]
 	quest.4007DFA7CC3A5FF2.quest_subtitle: "The Base for Upgrades"
 	quest.40096ED0B04C3EC5.quest_desc: ["The must-need for all Spawners. When it says ignores all conditions, it means most. Ignores light levels, blocks needing for spawning, and biomes. Space conditions are still needed though, like slimes needing 3x3 area to spawn, and same goes with players needing to be nearby."]
 	quest.40096ED0B04C3EC5.title: "Ignore All Conditions"
@@ -6375,7 +6375,7 @@
 		""
 		"It starts off as the equivalent of Iron, but has Upgrade Points that can be spent to train it in specific ways. It starts with 100, but there are ways to increase this limit."
 		""
-		"As you use it, it will \\\"learn\\\" from you. You can see what it has learned so far by holding left shift while looking at it."
+		"As you use it, it will \"learn\" from you. You can see what it has learned so far by holding left shift while looking at it."
 	]
 	quest.41030E1E341C3A4E.title: "Living Armor"
 	quest.4104ABDC0E577350.title: "&2Nature&r Upgrade Orb"
@@ -6917,8 +6917,8 @@
 	]
 	quest.469663FE3DA932EF.quest_desc: ["Combines Liquids with Items"]
 	quest.4699B9569F9E65A0.quest_desc: [
-		"Once you've learned the Soul symbol, you can do \\\"animal\\\" sacrifice. Kill an animal while near the altar, its blood will fill the Goblet."
-		"Then chant \\\"Animal Sacrifice\\\" on a new day, you should learn how to make Unholy Symbols."
+		"Once you've learned the Soul symbol, you can do \"animal\" sacrifice. Kill an animal while near the altar, its blood will fill the Goblet."
+		"Then chant \"Animal Sacrifice\" on a new day, you should learn how to make Unholy Symbols."
 		"Drop a Pewter Inlay on the ground, then Chant on it, should turn into a Unholy Symbol."
 		"You only need 1 for all your crafting needs. Can make more if you like putting them in frames."
 	]
@@ -6992,7 +6992,7 @@
 	quest.47358ADC1470C82A.quest_desc: [
 		"&cDemon's Dream Fruit&r is perfectly healthy for you. There might be some side effects you should know about."
 		""
-		"When you consume one, you have a chance to get the effect of the &3Third Eye&r, allowing you to see into the &9The Otherworld&r. Certain items in the world might not be what they seem, and you'll need this \\\"vision\\\" to find certain items for progression."
+		"When you consume one, you have a chance to get the effect of the &3Third Eye&r, allowing you to see into the &9The Otherworld&r. Certain items in the world might not be what they seem, and you'll need this \"vision\" to find certain items for progression."
 		""
 		"Or you can set it on fire and skip finding most of them. That's up to you."
 	]
@@ -7043,7 +7043,7 @@
 		""
 		"The first step is to find &3Oil&r in the Overworld. You can find some spouting out in the ocean, and you'll need to collect a good bit so we can refine it!"
 		""
-		"That's where the &aFuel Refinery&r comes in. It will accept any \\\"Crude\\\" Oil and convert it into fuel for the Rockets."
+		"That's where the &aFuel Refinery&r comes in. It will accept any \"Crude\" Oil and convert it into fuel for the Rockets."
 		""
 		"I'd suggest on stocking up, as each will cost &e3 Buckets of Fuel&r, meaning 6 for a round trip!"
 	]
@@ -7627,7 +7627,7 @@
 	quest.4D3379D38237F830.quest_subtitle: "Feet"
 	quest.4D3379D38237F830.title: "&bAqua-Dashers&r"
 	quest.4D3D96B6019CA7F9.title: "Singularity"
-	quest.4D4152032F0410D2.quest_desc: ["The Logic Programmer lets you set the value of variables. This can be set to to items and fluids for filtering, or even values. \\\\n\\\\nLet me give you a simple example: Select &bItem&r from the left side, place an item of choice into the center slot of the GUI that pops up, and place a &bVariable Card&r in the bottom right slot. If you then put that variable card in an importer/exporter, it will only import/export that block!"]
+	quest.4D4152032F0410D2.quest_desc: ["The Logic Programmer lets you set the value of variables. This can be set to to items and fluids for filtering, or even values. \\n\\nLet me give you a simple example: Select &bItem&r from the left side, place an item of choice into the center slot of the GUI that pops up, and place a &bVariable Card&r in the bottom right slot. If you then put that variable card in an importer/exporter, it will only import/export that block!"]
 	quest.4D4152032F0410D2.quest_subtitle: "Getting Advanced"
 	quest.4D4AB60B3B1CD437.quest_desc: ["From the scales of the &2Naga&r, you can craft some armor.\\n\\nThe armor isn't very strong, but it looks nice."]
 	quest.4D4AB60B3B1CD437.title: "&2Naga Scale Armor"
@@ -7793,7 +7793,7 @@
 	quest.4E737C490DCC5D6C.title: "&5Unobtainium Armor"
 	quest.4E7990AEBCCC3C95.quest_subtitle: "Tier: &b4"
 	quest.4E802144C6E40D43.quest_subtitle: "Ceylon Ebony + Cherry"
-	quest.4E802144C6E40D43.title: "Purple Crepe Sapling"
+	quest.4E802144C6E40D43.title: "Purple Crepe Myrtle Sapling"
 	quest.4E82E843737045D9.quest_desc: [""]
 	quest.4E82E843737045D9.quest_subtitle: "&oEssence of the most powerful beings."
 	quest.4E82E843737045D9.title: "&d&lDragon Soul"
@@ -7826,7 +7826,7 @@
 	]
 	quest.4EA0F9DE0A373761.quest_desc: ["To get Morgan you need to kill the Warden with Caliburn. Also Caliburns Innate Cap will be Morgans Innate Cap. Good luck!"]
 	quest.4EA0F9DE0A373761.title: "Got Morgan"
-	quest.4EA2DB12E8F0068F.quest_desc: ["&l&aOh The Biomes We've Gone&r is a continuation of &l&aOh The Biomes You'll Go&r which is a pun off the Dr Seuss book \"Oh the Places You'll Go\".\\n\\nIt adds tons of gorgeous new biomes! With new plants, rocks, and of course trees!"]
+	quest.4EA2DB12E8F0068F.quest_desc: ["&l&aOh The Biomes We've Gone&r is a continuation of &l&aOh The Biomes You'll Go&r which is a pun off the Dr. Seuss book \"Oh the Places You'll Go\".\\n\\nIt adds tons of gorgeous new biomes! With new plants, rocks, and of course trees!"]
 	quest.4EA2DB12E8F0068F.title: "&l&aOh The Biomes We've Gone&r Wood"
 	quest.4EA4EDD5A7923F98.quest_desc: ["The &n&5Weighted Ejector&r can launch items or entities to a selected location."]
 	quest.4EA8BA9753D0DD81.quest_desc: [
@@ -7858,7 +7858,7 @@
 	quest.4EDD96EB60EF5814.quest_desc: ["If you're wondering if it is worth making this upgrade, the answer is yes.\\n\\nThis version can be used to add extra heat to Thermal Evaporation Plants."]
 	quest.4EDD96EB60EF5814.quest_subtitle: "Generates about 410FE/t"
 	quest.4EE482B9D61B5933.quest_desc: ["Of course &2Vanilla&r isn't our max, there's much more and much rarer in Modded! "]
-	quest.4EEAB467C722ECE7.quest_desc: ["These are simple pipes that can be upgraded with Pipe Upgrades.\\\\n\\\\nTo 'extract' power from a block, place the pipe down next to the block, and on the side that is connected, shift+right-click with the pipe wrench to set the pipe to extract.\\\\n\\\\nThe &e&lPipez&r mod also offers ways to transport items, gases, and liquids as well! Or you can make an All-In-One Pipe called the &aUniversal Pipe&r.\\n\\nOther Wrenches work with &e&lPipez&r as well!"]
+	quest.4EEAB467C722ECE7.quest_desc: ["These are simple pipes that can be upgraded with Pipe Upgrades.\\n\\nTo 'extract' power from a block, place the pipe down next to the block, and on the side that is connected, shift+right-click with the pipe wrench to set the pipe to extract.\\n\\nThe &e&lPipez&r mod also offers ways to transport items, gases, and liquids as well! Or you can make an All-In-One Pipe called the &aUniversal Pipe&r.\\n\\nOther Wrenches work with &e&lPipez&r as well!"]
 	quest.4EEAB467C722ECE7.title: "&9Pipez: &aEnergy Pipes"
 	quest.4EEFECB9D741B371.quest_desc: [
 		"As previously stated, alloys are going to continue to increase in complexity, as it should be expected."
@@ -7896,7 +7896,7 @@
 		""
 		"To start with, combine your Unbound Book with your &aDictionary of Spirits&r in a crafting table. This will bind a Demon to the book, which is what we'll need for the Ritual."
 		""
-		"Speaking of your Dictionary of Spirits, it's time to open it up! On the left, click on the &dPentacles&r tab and click on &bAviar's Circle&r. You might have to advance through it by reading a little bit. There is also a way to click \\\"Mark All As Read\\\" so it unlocks everything in the book."
+		"Speaking of your Dictionary of Spirits, it's time to open it up! On the left, click on the &dPentacles&r tab and click on &bAviar's Circle&r. You might have to advance through it by reading a little bit. There is also a way to click \"Mark All As Read\" so it unlocks everything in the book."
 		""
 		"This is what we're going to use to summon our new Friend. On the right side, you can click the eye in the bottom-left corner of the image to build an outline of the Ritual for you in the world. This is super helpful!"
 		""
@@ -8459,7 +8459,7 @@
 	quest.544011D1C48D8E65.title: "Getting better Gems"
 	quest.54423ED491F170B5.quest_desc: [
 		"In this portion, chanting to the gods to get power (well, not actual super powers)."
-		"First make an Effigy, 6 Altar tables. Place on them 2 Candlesticks, Effigy, wither (or best skull), Goblet and 2 Potted wither roses (or best \\\"flower\\\" you can from book)."
+		"First make an Effigy, 6 Altar tables. Place on them 2 Candlesticks, Effigy, wither (or best skull), Goblet and 2 Potted wither roses (or best \"flower\" you can from book)."
 		"Be a lesson to tell you that these can only be done once a day."
 		"Start with clicking Wicked Sign 3 times, then click Chant."
 		"You will get a new symbol if done right, with the Effigy's eyes glow."
@@ -8944,7 +8944,7 @@
 	]
 	quest.5962DC39E5874FB9.quest_subtitle: "Lapis + Skeletal"
 	quest.5963FBEB78A79668.quest_desc: [
-		"Creates \\\"Presses\\\" using Casts."
+		"Creates \"Presses\" using Casts."
 		""
 		"Think plates, gears, etc."
 	]
@@ -9181,7 +9181,7 @@
 	quest.5C3FF43CF16BCF30.quest_desc: ["With Source Gems, you can get started crafting the various machines by creating &5Sourcestones&r."]
 	quest.5C3FF43CF16BCF30.quest_subtitle: "Formerly \"Arcane Stones\""
 	quest.5C3FF43CF16BCF30.title: "Sourcestone"
-	quest.5C47935A3B2877FF.quest_desc: ["Mekanism offers a nice looking Cable to transfer your power.\\\\n\\\\nIf the machine you are connecting to already pulls or pushes power, you will not need to configure the Cable. Otherwise, you'll need a &9Configurator&r to configure the Cable. Shift right-clicking will change the Cable to pull or push mode."]
+	quest.5C47935A3B2877FF.quest_desc: ["Mekanism offers a nice looking Cable to transfer your power.\\n\\nIf the machine you are connecting to already pulls or pushes power, you will not need to configure the Cable. Otherwise, you'll need a &9Configurator&r to configure the Cable. Shift right-clicking will change the Cable to pull or push mode."]
 	quest.5C47935A3B2877FF.quest_subtitle: "Mekanism's Energy Transfer Pipe"
 	quest.5C47935A3B2877FF.title: "&9Mekanism: &aUniversal Cables"
 	quest.5C5546A5103BCF55.quest_desc: ["This one is supposed to shoot Chemicals like &bFluids&r or Gases... but it won't do it for me. \\n\\nIt can hold 2 Upgrades atleast! Those work!"]
@@ -9383,7 +9383,7 @@
 	quest.5E45D2A2FDD67495.quest_desc: ["This goes in the right side of the forge."]
 	quest.5E45D2A2FDD67495.quest_subtitle: "Experience in a bottle"
 	quest.5E45D2A2FDD67495.title: "&aBottle O' Enchanting"
-	quest.5E4BC0F59C90433A.quest_desc: ["Sophisticated Storage allows you to upgrade your Chests and Barrels with metals to increase their storage! You can also add upgrade filters to increase their functionality.\\n\\nThese chests are just like a vanilla Chest or Barrel, but they have a slot for a Storage Upgrade!"]
+	quest.5E4BC0F59C90433A.quest_desc: ["Sophisticated Storage allows you to upgrade your Chests and Barrels with metals to increase their storage! You can also add upgrades to increase their functionality.\\n\\nThese chests are just like a vanilla Chest or Barrel, but they have a slot for a Storage Upgrade!"]
 	quest.5E4BC0F59C90433A.quest_subtitle: "\"Vanilla Chest\""
 	quest.5E4BC0F59C90433A.title: "Sophisticated Storage"
 	quest.5E4FE420B6D2C97F.quest_desc: ["Compacts items in the backpack to their 3x3 recipe."]
@@ -9439,7 +9439,7 @@
 	quest.5ECC93FB8F676E3F.quest_desc: [
 		"Works like a Coke Oven, but simplified."
 		""
-		"Insert \\\"fuel\\\" like Coal and it'll produce Coal Coke and a by-product."
+		"Insert \"fuel\" like Coal and it'll produce Coal Coke and a by-product."
 	]
 	quest.5ED0DA95BAE43D88.quest_desc: ["The last of the Prisms, well this one's a &dCrystal&r but you get the idea! \\n\\nFirst, you'll need a &eDivine Pact&r Relic, which are found in &b&lThe Other&r. \\n\\nThen, you'll need &3Enderpearl Fragments&r, &5Amethyst&r, and Nether Quartz. Don't worry it gets harder! \\n\\nNow we'll need every type of Soul. I taught you how to get Souls and &9Corrupt Souls&r in other Quests now I'll teach you about &dEnchanted Souls&r. \\n\\nFind a Lost Soul flying around in your world, then toss a &bSplash Potion of Aureal&r at them! Then, they'll become a &dLost Enchanted Soul&r, kill them! \\n\\nWith that you can now make the &dCrystal&r, which can be applied to Tools and Armor to give it Soulbound. This means when you die, you'll respawn with these Items in your Inventory still."]
 	quest.5ED0DA95BAE43D88.title: "&dSoul Binding Crystal"
@@ -10156,7 +10156,7 @@
 		"You'll then want to put the Pattern into a crafter!"
 	]
 	quest.65C8A43FEDBA3835.title: "Pattern Grid"
-	quest.65D89991A45BC042.quest_desc: ["Place a Crafting Interfaces on a crafting table and right-click on it, this will give you some slots for &bVariable Cards&r. \\\\n\\\\nUsing the Logic Programmer, search for &eRecipe&r in the top left, and create one for autocrafting, then save it to a &bVariable Card&r. If a recipe &c&lrequires&r items that need to be crafted, create a recipe for each of those, then put everything in the Crafting Interface."]
+	quest.65D89991A45BC042.quest_desc: ["Place a Crafting Interfaces on a crafting table and right-click on it, this will give you some slots for &bVariable Cards&r. \\n\\nUsing the Logic Programmer, search for &eRecipe&r in the top left, and create one for autocrafting, then save it to a &bVariable Card&r. If a recipe &c&lrequires&r items that need to be crafted, create a recipe for each of those, then put everything in the Crafting Interface."]
 	quest.65D89991A45BC042.quest_subtitle: "&l&cA&6U&eT&aO &bC&dR&9A&3F&0T"
 	quest.65D993EB95726067.title: "Bee-ware of the Temple"
 	quest.65E2AF881709C896.quest_desc: ["One of the most important materials you'll be needing is &3Reinforced Stone&r, start by making 32 using Compressed Iron and some regular stone."]
@@ -10319,7 +10319,7 @@
 	quest.6783F21811D0F149.quest_desc: [
 		"Ever wanted a forge that just smelts things without fuel?"
 		""
-		"Me too. Technically, this does need a \\\"fuel\\\" per se. It has a charge, and can be recharged using Sunstone or anything made from Horizonite."
+		"Me too. Technically, this does need a \"fuel\" per se. It has a charge, and can be recharged using Sunstone or anything made from Horizonite."
 		""
 		"The forge must be empty to recharge."
 	]
@@ -10406,7 +10406,7 @@
 	quest.681A3F31FB242555.quest_desc: ["&3Ethanol&r can be used to make Biodiesel."]
 	quest.681A3F31FB242555.title: "Ethanol"
 	quest.682034C680FDEDC2.quest_desc: [
-		"&9Mekanism's&r &aInduction Matrix&r is the ultimate way to store your power.\\\\n\\\\nIf you're looking for the best power storage in the game, check out the &aMekanism:&r &dReactors&r quest chapter.\\n"
+		"&9Mekanism's&r &aInduction Matrix&r is the ultimate way to store your power.\\n\\nIf you're looking for the best power storage in the game, check out the &aMekanism:&r &dReactors&r quest chapter.\\n"
 		"{image:atm:textures/questpics/mek/mek_induction_matrix_small.png width:125 height:150 align:center fit:true}"
 	]
 	quest.682034C680FDEDC2.title: "More Power Storage"
@@ -10527,7 +10527,7 @@
 	quest.692C9BA71EA0F0A7.quest_desc: ["You need this tier of Mixer to make &3Tungstensteel Dust&r as well as &dVanadium Gallium Dust&r"]
 	quest.692C9BA71EA0F0A7.quest_subtitle: "Where's the dough hook?"
 	quest.69383DA579901E7E.quest_subtitle: "Let me Axe you this"
-	quest.69439426534EBDC4.quest_desc: ["&bBlazing Grips&r are another Item we can make with &bIgnitium&r! \\n\\nIt is a Curios Item that goes on your Hands. \\n\\nWhen worn, all attacks have a chance of giving the recipient &bBlazing Brand&r. \\n\\nI don't re\\ally know what it does, but it sucks to get from the &b&lIgnis&r."]
+	quest.69439426534EBDC4.quest_desc: ["&bBlazing Grips&r are another Item we can make with &bIgnitium&r! \\n\\nIt is a Curios Item that goes on your Hands. \\n\\nWhen worn, all attacks have a chance of giving the recipient &bBlazing Brand&r. \\n\\nI don't really know what it does, but it sucks to get from the &b&lIgnis&r."]
 	quest.69439426534EBDC4.title: "&bBlazing Grips"
 	quest.694D7CD9EC663355.quest_subtitle: "Mace I interest you in this?"
 	quest.6950FC974624C6AA.quest_subtitle: "Tier: &63"
@@ -12378,7 +12378,7 @@
 	quest.7ADFAC678D21E6B8.quest_desc: ["While we wont necessarily be utilizing this ship immediately, it would be better to get it crafted now, and have it on stand by for when we are ready to use it."]
 	quest.7ADFAC678D21E6B8.quest_subtitle: "One Epic Ship"
 	quest.7AE3C8134F5ED726.quest_desc: ["Increases stack size in the Backpack by 16."]
-	quest.7AE3C8134F5ED726.title: "&d\\Stack Upgrade Tier 4"
+	quest.7AE3C8134F5ED726.title: "&dStack Upgrade Tier 4"
 	quest.7AE502EDB73BD57A.quest_desc: ["This machine crushes ores into their \"dirty dust\" forms. This is useful to convert clumps into dirty dust, which can go through an Enrichment Chamber to create the ore dust, which then can be smelted into an ingot."]
 	quest.7AE502EDB73BD57A.quest_subtitle: "It Crushes Things."
 	quest.7AE6AF0B5D3390E7.quest_desc: ["So much of the work that has been done was directly to support being able to construct the &n&l&5Star Forge!&r&r&r"]
@@ -12444,7 +12444,7 @@
 	quest.7B5A0BFD47D96BDE.quest_desc: ["Used to catch bees that are flying around it.\\n\\nYou can use a Filter Upgrade to filter out which bees you want to catch, as well as a BaBee Upgrade to only catch baby bees."]
 	quest.7B5A0BFD47D96BDE.quest_subtitle: "Catches Bees"
 	quest.7B5D34650BBD97D9.quest_desc: ["Very rarely in the Starlight Dimension a Meteor Shower might occur. \\n\\nMost times the Meteors are tiny and disappear before hitting the ground. \\n\\nBut some are bigger and survive, there you will find Aethersent Ore!"]
-	quest.7B690431CF1B87D0.quest_desc: ["To get started with gear crafting in the early game, we'll need to make some &9Template Boards&r to create our first Template.\\n\\nTemplates are single-use \"blueprints\" for creating tool parts. Using basic Template Boards, craft yourself a &aPickaxe Template&r.\\n\\nIf you combine the Pickaxe Template with 3 of most materials, you can create a Pickaxe Head.\\n\\nNote: The material must have a Silent Gear material tooltip with the main type."]
+	quest.7B690431CF1B87D0.quest_desc: ["To get started with gear crafting in the early game, we'll need to make some &9Template Boards&r to create our first Template.\\n\\nTemplates are single-use \"blueprints\" for creating gear parts. Using basic Template Boards, craft yourself a &aPickaxe Template&r.\\n\\nIf you combine the Pickaxe Template with 3 of most materials, you can create a Pickaxe Head.\\n\\nNote: The material must have a Silent Gear material tooltip with the main type."]
 	quest.7B690431CF1B87D0.title: "Pickaxe Heads"
 	quest.7B7504F386DABBDD.quest_desc: ["Place this under the soil to allow Dragon Egg Seeds to grow."]
 	quest.7B76EC62E3F7E12C.quest_desc: ["{image:atm:textures/questpics/basicarmor/armor_aethersent.png width:100 height:150 align:center}"]
@@ -12562,13 +12562,13 @@
 		""
 		"Make sure to get a passive processing line of this going, as you will need quite a bit of the resulting resources."
 	]
-	quest.7CC3BD5F3D66A637.quest_subtitle: "A cloud of radon floats into a cafe. The waiter says, \\\"we don't serve inert gases here\\\". There was no reaction from the radon."
+	quest.7CC3BD5F3D66A637.quest_subtitle: "A cloud of radon floats into a cafe. The waiter says, \"we don't serve inert gases here\". There was no reaction from the radon."
 	quest.7CC49360D07086B8.quest_desc: ["This item is how you make Wireless Transfers possible.\\n\\nYou can set specific channels, named by you, to transfer whatever you want from it."]
 	quest.7CC49360D07086B8.quest_subtitle: "Wireless Power, Gases, Fluids, Everything."
 	quest.7CC96CE9901F25BB.quest_desc: ["&l&5Forbidden and Arcanus&r is another magic mod, this one revolving around the Multiblock structure called, the Hephaestus Forge.\\n\\nTo make it follow the instructions in the forge's tooltip! Once made you can feed it the 4 Materials to power Rituals: Aureal, Souls, Blood, and Experience.\\n\\nYou'll also need to upgrade the Forge via Rituals (all these you can find in JEI)."]
 	quest.7CE86300AF8E9BCA.quest_desc: ["Crafting 8 of the same Generators together with an Echo Shard combines them into 1 massive Generator! Works the same as 8 regular generators but only takes up the space of 1."]
 	quest.7CE86300AF8E9BCA.title: "8x What a deal!"
-	quest.7CF13A4941F608E5.quest_desc: ["From normal Glass, to Glass with Panes, to even Mosiacs!"]
+	quest.7CF13A4941F608E5.quest_desc: ["From normal Glass, to Glass with Panes, to even Mosaics!"]
 	quest.7CF13A4941F608E5.title: "&l&bChipped&r Glass"
 	quest.7CF76A542529A181.quest_desc: [
 		"Used to corrupt Souls and Runes. You'll need this for later."
@@ -12651,7 +12651,7 @@
 	]
 	quest.7D972F334DCE5626.quest_subtitle: "Must Make More Naq!"
 	quest.7DA48EDCF28DBE03.quest_subtitle: "Ginkgo + Hazel"
-	quest.7DA8ACE06DE8097F.quest_desc: ["&6Copper&r is the most abundunt Ore in &2&lMinecraft&r and its main use is for decoration. \\n\\nThere's already plenty of different variants added by &2&lMinecraft&r but &l&bChipped&r didn't think it was good enough! So we got more! \\n\\nEven variants for the oxidized versions. \\n\\nYou can make faux &aEmerald Blocks&r."]
+	quest.7DA8ACE06DE8097F.quest_desc: ["&6Copper&r is the most abundant Ore in &2&lMinecraft&r and its main use is for decoration. \\n\\nThere's already plenty of different variants added by &2&lMinecraft&r but &l&bChipped&r didn't think it was good enough! So we got more! \\n\\nEven variants for the oxidized versions. \\n\\nYou can make faux &aEmerald Blocks&r."]
 	quest.7DA8ACE06DE8097F.title: "&l&bChipped &6Copper"
 	quest.7DABD82393713B5A.quest_desc: ["&c&lAntiblocks&r is a very simple Mod. You like Colored Lights? You can have Colored Lights. \\n\\nThey are all one color with no Texturing and can come in different Shapes like Stairs or Slabs or even Pressure Plates! "]
 	quest.7DABD82393713B5A.title: "&l&cAntiblocks Rechiseled&r"
@@ -12677,7 +12677,7 @@
 		""
 		"For more information, you can always check your &aLexica Botania&r."
 	]
-	quest.7DF972754C48E22B.quest_desc: ["Now, having a multiblock, we can set \\\"Distinct Buses\\\" and set each one to do a specific mold and or Programmed Circuit! We now have an all in one machine!!"]
+	quest.7DF972754C48E22B.quest_desc: ["Now, having a multiblock, we can set \"Distinct Buses\" and set each one to do a specific mold and or Programmed Circuit! We now have an all in one machine!!"]
 	quest.7DF972754C48E22B.quest_subtitle: "Extruding Saves Materials"
 	quest.7DFF18CFEB0B8DBE.quest_desc: ["You'll want to start growing &aInferium&r as soon as you can!\\n\\nWhile not required for growing these seeds, you can also create &eEssence Farmland&r that will increase the growth speed of the seeds (especially Inferium Seeds). However, certain seeds will require certain farmlands to be planted on."]
 	quest.7DFF18CFEB0B8DBE.title: "&aInferium Farmland"


### PR DESCRIPTION
Correction of typos for en_us.snbt

Typos
1x [ Mosiacs -> Mosaics ]
2x [ abundunt -> abundant ]
1x [ Dr Seuss -> Dr. Seuss ]

Adjust to match in-game terminology
3x [ Purple Crepe -> Purple Crepe Myrtle ]
1x [ Claim Map -> Claimed Chunks ]
1x [ Crafting Stick -> Crafting Table on a Stick ]
1x [ tool parts -> gear parts ]

Sophisticated Storage upgrades are not just filters
1x [ upgrade filters -> upgrades ]
1x [ filter upgrades -> upgrades ]

Corrections related to escape sequences
1x [ `re\\ally` -> `really` ]
1x [ `&d\\Stack` -> `&dStack` ]
1x [ `\\.\\.` -> `\\n\\n` ]
46x [ `\\\"` -> `\"` ]
36x [ `\\\\n` -> `\\n` ]