### PR TITLE
Added more ATM Star indicators near quests for various items that are required for the ATM Star

### DIFF
--- a/config/ftbquests/quests/chapters/applied_energistics_2.snbt
+++ b/config/ftbquests/quests/chapters/applied_energistics_2.snbt
@@ -10,14 +10,48 @@
 		id: "ftbquests:custom_icon"
 	}
 	id: "07210DDF872160BA"
-	images: [{
-		height: 3.0d
-		image: "atm:textures/questpics/ae2.png"
-		rotation: 0.0d
-		width: 9.27d
-		x: 7.0d
-		y: -3.5d
-	}]
+	images: [
+		{
+			height: 3.0d
+			image: "atm:textures/questpics/ae2.png"
+			rotation: 0.0d
+			width: 9.27d
+			x: 7.0d
+			y: -3.5d
+		}
+		{
+			height: 0.3d
+			image: "allthetweaks:item/atm_star"
+			rotation: 0.0d
+			width: 0.3d
+			x: 12.02d
+			y: 5.27d
+		}
+		{
+			height: 0.3d
+			image: "allthetweaks:item/atm_star"
+			rotation: 0.0d
+			width: 0.3d
+			x: 15.03d
+			y: 5.32d
+		}
+		{
+			height: 0.3d
+			image: "allthetweaks:item/atm_star"
+			rotation: 0.0d
+			width: 0.3d
+			x: 6.01d
+			y: 3.77d
+		}
+		{
+			height: 0.3d
+			image: "allthetweaks:item/atm_star"
+			rotation: 0.0d
+			width: 0.3d
+			x: 8.01d
+			y: 3.79d
+		}
+	]
 	order_index: 1
 	progression_mode: "flexible"
 	quest_links: [ ]

--- a/config/ftbquests/quests/chapters/ars_nouveau.snbt
+++ b/config/ftbquests/quests/chapters/ars_nouveau.snbt
@@ -9,14 +9,6 @@
 	id: "6AEDA2F9BEB57759"
 	images: [
 		{
-			height: 0.3d
-			image: "allthetweaks:item/atm_star"
-			rotation: 0.0d
-			width: 0.3d
-			x: 7.5d
-			y: 7.7d
-		}
-		{
 			height: 1.0d
 			image: "ars_nouveau:item/starbuncle_shards"
 			rotation: 0.0d
@@ -31,6 +23,14 @@
 			width: 8.0d
 			x: 4.5d
 			y: -2.0d
+		}
+		{
+			height: 0.3d
+			image: "allthetweaks:item/atm_star"
+			rotation: 0.0d
+			width: 0.3d
+			x: 4.02d
+			y: -4.75d
 		}
 	]
 	order_index: 1

--- a/config/ftbquests/quests/chapters/elmystical_agriculturerr.snbt
+++ b/config/ftbquests/quests/chapters/elmystical_agriculturerr.snbt
@@ -508,7 +508,7 @@
 			image: "allthetweaks:item/atm_star"
 			rotation: 0.0d
 			width: 0.3d
-			x: 37.75d
+			x: 37.8d
 			y: -0.7750000000000004d
 		}
 		{
@@ -516,8 +516,8 @@
 			image: "allthetweaks:item/atm_star"
 			rotation: 0.0d
 			width: 0.3d
-			x: 36.0d
-			y: 1.0250000000000004d
+			x: 36.05d
+			y: 1.0150000000000003d
 		}
 		{
 			height: 1.0d

--- a/config/ftbquests/quests/chapters/twilight_forest.snbt
+++ b/config/ftbquests/quests/chapters/twilight_forest.snbt
@@ -24,8 +24,32 @@
 			x: 5.0d
 			y: -5.0d
 		}
+		{
+			height: 0.3d
+			image: "allthetweaks:item/atm_star"
+			rotation: 0.0d
+			width: 0.3d
+			x: 10.05d
+			y: 0.25d
+		}
+		{
+			height: 0.3d
+			image: "allthetweaks:item/atm_star"
+			rotation: 0.0d
+			width: 0.3d
+			x: 14.02d
+			y: -1.25d
+		}
+		{
+			height: 0.3d
+			image: "allthetweaks:item/atm_star"
+			rotation: 0.0d
+			width: 0.3d
+			x: 18.01d
+			y: 0.25d
+		}
 	]
-	order_index: 2
+	order_index: 3
 	progression_mode: "flexible"
 	quest_links: [ ]
 	quests: [
@@ -954,8 +978,8 @@
 					type: "item"
 				}
 			]
-			x: 9.0d
-			y: -0.5d
+			x: 9.5d
+			y: -1.5d
 		}
 		{
 			dependencies: ["3DCF26B53AE1EBF6"]
@@ -1541,8 +1565,8 @@
 					type: "item"
 				}
 			]
-			x: 10.0d
-			y: -1.5d
+			x: 9.0d
+			y: -0.5d
 		}
 		{
 			dependencies: ["04440BB2EFFD6DD9"]


### PR DESCRIPTION
- Added more ATM Star icons to Twilight Forest's, Ars Nouveau's and AE2's questlines
- Removed the ATM Star indicator next to the Ritual of the Wilden Beast in the Ars Noueveau's questline because it's no longer required for the ATM Star
- Small corrections to ATM Star indicators in the Mystical Aggriculture's questline

Here's how my changes look like in-game:
![ae2](https://github.com/user-attachments/assets/65bf7d31-936b-4dfa-a965-74a50c4911d0)
![ars](https://github.com/user-attachments/assets/537de89f-9dc4-4f2e-98c1-1b33c10dae94)
![mystical](https://github.com/user-attachments/assets/c957f13d-eabb-42fb-af6d-6c43bbdba34e)
![twilight](https://github.com/user-attachments/assets/09822003-a411-44b4-973e-def70faff345)
