### PR TITLE
Fix Nexium Emitter's quest to properly show Infinity Range Booster as a dependency

### DIFF
--- a/config/ftbquests/quests/chapters/chapter_2_the_star.snbt
+++ b/config/ftbquests/quests/chapters/chapter_2_the_star.snbt
@@ -506,6 +506,7 @@
 		}
 		{
 			dependencies: [
+				"601C719C8FD513F0"
 				"535525EA4DF4AB59"
 				"75EE965CBA598FEA"
 				"268EA2DEC8840D13"
@@ -2602,6 +2603,7 @@
 		}
 		{
 			dependencies: ["4485C4ABD57874EB"]
+			hide_dependent_lines: true
 			id: "601C719C8FD513F0"
 			rewards: [
 				{


### PR DESCRIPTION
Sorry for spamming with pull requests, I'm a little stupid