### PR TITLE
Fixed Mekanism Dirty Dust Quest Rewards

### DIFF
--- a/config/ftbquests/quests/chapters/mekanism.snbt
+++ b/config/ftbquests/quests/chapters/mekanism.snbt
@@ -128,7 +128,7 @@
 					id: "62B555EE0C1159EA"
 					item: {
 						count: 1
-						id: "mekanism:dirty_dust_iron"
+						id: "alltheores:dirty_iron_dust"
 					}
 					random_bonus: 2
 					type: "item"
@@ -1311,7 +1311,7 @@
 					id: "258304336DF472BB"
 					item: {
 						count: 1
-						id: "mekanism:clump_iron"
+						id: "alltheores:iron_clump"
 					}
 					random_bonus: 2
 					type: "item"


### PR DESCRIPTION
Updates 2 Mekanism quest rewards which gave the Mekanism variant that should've given the AllTheOres variant.

Fixes #2516 