### PR TITLE
Fix Ars Nouveau quests using generic Mixed Potion instead of Potion of Mana Regeneration

### DIFF
--- a/config/ftbquests/quests/chapters/ars_nouveau.snbt
+++ b/config/ftbquests/quests/chapters/ars_nouveau.snbt
@@ -1520,6 +1520,11 @@
 				{
 					id: "565501823D60D08C"
 					item: {
+						components: {
+							"minecraft:potion_contents": {
+								potion: "ars_nouveau:mana_regen_potion"
+							}
+						}
 						count: 1
 						id: "minecraft:potion"
 					}
@@ -2230,6 +2235,11 @@
 				{
 					id: "31255CD8D6C186BF"
 					item: {
+						components: {
+							"minecraft:potion_contents": {
+								potion: "ars_nouveau:mana_regen_potion"
+							}
+						}
 						count: 1
 						id: "minecraft:lingering_potion"
 					}

--- a/config/ftbquests/quests/chapters/ars_nouveau.snbt
+++ b/config/ftbquests/quests/chapters/ars_nouveau.snbt
@@ -2228,6 +2228,11 @@
 		{
 			dependencies: ["64D0E66CB4FBEC82"]
 			icon: {
+				components: {
+					"minecraft:potion_contents": {
+						potion: "ars_nouveau:mana_regen_potion"
+					}
+				}
 				id: "minecraft:potion"
 			}
 			id: "6B511C8B572E8940"


### PR DESCRIPTION
Two Ars Nouveau quests were giving out generic "mixed potions" since no NBT data was specified. I am making the assumptions that these were intended to be mana potions, given the context. I also updated the icon for the quest to be a mana potion instead. If that was not the intent, feel free to close this. **Please squash merge this, Github ate the commit title for one of my commits and just made it "Add files via upload" instead**

### Old quest rewards:
![image](https://github.com/user-attachments/assets/a3e163c8-2e8c-47ee-8545-73f9c29dbe07)
![image](https://github.com/user-attachments/assets/c9ffb719-0796-4122-8e69-f7a1d9dcf6bd)
![image](https://github.com/user-attachments/assets/612773b7-4e24-45da-82fd-772abbe7c1d5)


### New quest rewards:
![image](https://github.com/user-attachments/assets/b61ef6eb-5917-41da-9ef1-01fc61170d58)
![image](https://github.com/user-attachments/assets/063be11d-fe19-4c79-8581-811718baae19)
![image](https://github.com/user-attachments/assets/48174ad2-1d8f-4a77-9e72-e3c833512059)


Fixes #2522 