### PR TITLE
feat(immersiveengineering client config): fix rendering with shaders and improve manual readability

### DIFF
--- a/config/immersiveengineering-client.toml
+++ b/config/immersiveengineering-client.toml
@@ -7,7 +7,7 @@ showTextOverlay = true
 #Range: 1 ~ 32
 manualGuiScale = 4
 #Set this to true if you suffer from bad eyesight. The Engineer's manual will be switched to a bold and darker text to improve readability.
-badEyesight = false
+badEyesight = true
 #Set this to false to change fluid recipes in the manual to use decimals on buckets instead of fractions
 fluidFractions = true
 #Controls if item tooltips should contain the tags names of items. These tooltips are only visible in advanced tooltip mode (F3+H)
@@ -25,7 +25,7 @@ stencilBufferEnabled = true
 earDefenders_SoundBlacklist = []
 #Use VBOs to render certain blocks. This is significantly faster than the usual rendering,
 #but may not work correctly with visual effects from other mods
-enableVBO = true
+enableVBO = false
 
 #Options to set the RGB color of all IE wire types
 [wire_colors]


### PR DESCRIPTION
- Fixes incorrect rendering of waterwheel and windmill sails when using shaders by disabling Framebuffer Objects (FBO).  
- Enables `basEyesight` to improve readability of the Engineer’s Manual.