### PR TITLE
Industrial foregoing souls rebalance

### DIFF
--- a/config/industrialforegoingsouls/industrialforegoing-souls-machines.toml
+++ b/config/industrialforegoingsouls/industrialforegoing-souls-machines.toml
@@ -1,0 +1,47 @@
+[IFSoulsMachines]
+	#How many souls each pipe can hold
+	# Default: 4
+	# Range: > 0
+	SOUL_AMOUNT_PER_PIPE = 4
+
+	[IFSoulsMachines.ConfigSoulLaserBase]
+		#Max soul storage tank amount
+		# Default: 1350
+		# Range: > 1
+		SOUL_STORAGE_AMOUNT = 1500
+		#Max progress of the machine
+		# Default: 20
+		# Range: > 1
+		MAX_PROGRESS = 30
+		#Kill the warden when it's life reaches near to 0 or keep it alive
+		KILL_WARDEN = true
+		#Damage done to the warden when an operation is done
+		# Default: 4
+		# Range: > 0
+		DAMAGE_PER_OPERATION = 12
+		#Souls generated when an operation is done
+		# Default: 2
+		# Range: > 1
+		SOULS_PER_OPERATION = 4
+
+	[IFSoulsMachines.ConfigSoulSurge]
+		#How long in ticks a soul last to accelerate ticks
+		# Default: 300
+		# Range: > 1
+		SOUL_TIME = 200
+		#How many extra ticks the surge will accelerate for tile entities
+		# Default: 4
+		# Range: > 0
+		ACCELERATION_TICK = 4
+		#How many extra ticks the surge will accelerate for mobs
+		# Default: 4
+		# Range: > 0
+		ENTITIES_ACCELERATION_TICK = 4
+		#How many extra ticks the surge will accelerate for blocks
+		# Default: 4
+		# Range: > 0
+		BLOCK_ACCELERATION_TICK = 4
+		#How often a random tick block will be accelerated, by default 3% of the ticks (random)
+		# Default: 0.03
+		# Range: 0.0 ~ 1.0
+		RANDOM_TICK_ACCELERATION_CHANCE = 0.025

--- a/kubejs/client_scripts/RecipeViewer.js
+++ b/kubejs/client_scripts/RecipeViewer.js
@@ -12,33 +12,34 @@ const runicYEET = [
     'forbidden_arcanus:corrupted_arcane_crystal_block'
 ]
 
-RecipeViewerEvents.removeEntriesCompletely('item', allthemods =>{
-  allthemods.remove('quarryplus:adv_quarry')
-  allthemods.remove('allthetweaks:greg_star')
-  allthemods.remove('allthetweaks:greg_star_block')
+RecipeViewerEvents.removeEntriesCompletely('item', allthemods => {
+    allthemods.remove('quarryplus:adv_quarry')
+    allthemods.remove('allthetweaks:greg_star')
+    allthemods.remove('allthetweaks:greg_star_block')
 
-  for(let i=1; i < 10; i++){
-      allthemods.remove(`allthecompressed:greg_star_block_${i}x`)}
-  
-  allthemods.remove('relics:researching_table')
-  allthemods.remove("extradisks:infinite_chemical_storage_block")
-  allthemods.remove("extradisks:infinite_chemical_storage_disk")
-  allthemods.remove("extradisks:infinite_chemical_storage_part")
-  allthemods.remove("extradisks:infinite_fluid_storage_block")
-  allthemods.remove("extradisks:infinite_fluid_storage_disk")
-  allthemods.remove("extradisks:infinite_fluid_storage_part")
-  allthemods.remove("extradisks:infinite_item_storage_block")
-  allthemods.remove("extradisks:infinite_item_storage_disk")
-  allthemods.remove("extradisks:infinite_item_storage_part")
+    for (let i = 1; i < 10; i++) {
+        allthemods.remove(`allthecompressed:greg_star_block_${i}x`)
+    }
 
-  let $DyeColor = Java.loadClass("net.minecraft.world.item.DyeColor")
-  for (let color of $DyeColor.values()){
-    allthemods.remove(`/refinedstorage:${color}_.*/`)
-  }
+    allthemods.remove('relics:researching_table')
+    allthemods.remove("extradisks:infinite_chemical_storage_block")
+    allthemods.remove("extradisks:infinite_chemical_storage_disk")
+    allthemods.remove("extradisks:infinite_chemical_storage_part")
+    allthemods.remove("extradisks:infinite_fluid_storage_block")
+    allthemods.remove("extradisks:infinite_fluid_storage_disk")
+    allthemods.remove("extradisks:infinite_fluid_storage_part")
+    allthemods.remove("extradisks:infinite_item_storage_block")
+    allthemods.remove("extradisks:infinite_item_storage_disk")
+    allthemods.remove("extradisks:infinite_item_storage_part")
+
+    let $DyeColor = Java.loadClass("net.minecraft.world.item.DyeColor")
+    for (let color of $DyeColor.values()) {
+        allthemods.remove(`/refinedstorage:${color}_.*/`)
+    }
 })
 
 RecipeViewerEvents.removeRecipes(event => {
-  event.remove(["xycraft_machines:extractor/enderio/grains_of_infinity"])
+    event.remove(["xycraft_machines:extractor/enderio/grains_of_infinity"])
 })
 
 RecipeViewerEvents.removeEntries('item', allthemods => {
@@ -47,10 +48,25 @@ RecipeViewerEvents.removeEntries('item', allthemods => {
     }
 })
 
-RecipeViewerEvents.addInformation('fluid', allthemods =>{
-  allthemods.add("advanced_ae:quantum_infusion_source", [
-      'In the Reaction Chamber: §e4000mb of Water§f + §e1x Quantum Infused Dust§f = §b1000mb of Quantum Infusion'
-  ])
+RecipeViewerEvents.addInformation('item', allthemods => {
+    allthemods.add('justdirethings:polymorphic_catalyst', [
+        '§8Drop a §cPolymorphic Catalyst§8 into §1Water§8 to get Polymorphic Fluid'
+    ])
+    allthemods.add('justdirethings:portal_fluid_catalyst', [
+        '§8Drop a §dPortal Fluid Catalyst§8 into Polymorphic Fluid§8 in t§dThe End§8 to get §5Unstable Portal Fluid'
+    ])
+})
+
+RecipeViewerEvents.addInformation('fluid', allthemods => {
+    allthemods.add("advanced_ae:quantum_infusion_source", [
+        '§8In the Reaction Chamber: §e4000mb of Water§8 + §e1x Quantum Infused Dust§8 = §b1000mb of Quantum Infusion'
+    ])
+    allthemods.add("justdirethings:polymorphic_fluid_source", [
+        '§8Drop a §cPolymorphic Catalyst§8 into §bWater§8 to get Polymorphic Fluid'
+    ])
+    allthemods.add("justdirethings:unstable_portal_fluid_source", [
+        '§8Drop a §dPortal Fluid Catalyst§8 into §dPolymorphic Fluid§8 in §5The End§8 to get §5Unstable Portal Fluid'
+    ])
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.

--- a/kubejs/server_scripts/mods/Indusrial Foregoing/Dissolution Chamber.js
+++ b/kubejs/server_scripts/mods/Indusrial Foregoing/Dissolution Chamber.js
@@ -3,7 +3,7 @@
 
 ServerEvents.recipes(allthemods => {
 
-    function dissolution_chamber(output, inputs, fluid, time, id){
+    function dissolution_chamber(output, inputs, fluid, time, id) {
         let recipe = {
             "type": "industrialforegoing:dissolution_chamber",
             "input": [],
@@ -40,9 +40,76 @@ ServerEvents.recipes(allthemods => {
             {tag: 'c:glass_blocks/colorless'}],
         {
             fluid: 'industrialforegoing:pink_slime',
-            amount: 2700},
+            amount: 2700
+        },
         200,
         'pink_slime_block'
+    );
+
+    dissolution_chamber(
+        {item: 'industrialforegoingsouls:soul_laser_base'},
+        [
+            {tag: 'c:plastics'},
+            {item: 'minecraft:sculk_shrieker'},
+            {tag: 'c:plastics'},
+            {tag: 'industrialforegoing:machine_frame/supreme'},
+            {tag: 'industrialforegoing:machine_frame/supreme'},
+            {tag: 'c:gears/netherite'},
+            {item: 'minecraft:sculk_catalyst'},
+            {tag: 'c:gears/netherite'},
+        ],
+        {
+            fluid: 'justdirethings:unstable_portal_fluid_source',
+            amount: 1000
+        },
+        200,
+        'soul_laser_base'
+    );
+
+    dissolution_chamber(
+        {
+            item: 'industrialforegoingsouls:soul_surge',
+            count: 4
+        },
+        [
+            {tag: 'c:plastics'},
+            {item: 'minecraft:sculk_shrieker'},
+            {tag: 'c:plastics'},
+            {item: 'minecraft:echo_shard'},
+            {item: 'minecraft:echo_shard'},
+            {tag: 'industrialforegoing:machine_frame/simple'},
+            {item: 'minecraft:echo_shard'},
+            {tag: 'industrialforegoing:machine_frame/simple'},
+        ],
+        {
+            fluid: 'justdirethings:unstable_portal_fluid_source',
+            amount: 20
+        },
+        50,
+        'soul_surge'
+    );
+
+    dissolution_chamber(
+        {
+            item: 'industrialforegoingsouls:soul_network_pipe',
+            count: 32
+        },
+        [
+            {tag: 'c:plastics'},
+            {tag: 'c:gears/iron'},
+            {tag: 'c:plastics'},
+            {item: 'minecraft:echo_shard'},
+            {item: 'minecraft:echo_shard'},
+            {tag: 'c:plastics'},
+            {tag: 'c:gears/iron'},
+            {tag: 'c:plastics'},
+        ],
+        {
+            fluid: 'industrialforegoing:pink_slime',
+            amount: 20
+        },
+        20,
+        'soul_network_pipe'
     );
 
 })

--- a/kubejs/server_scripts/mods/industrialforegoingsouls/recipes.js
+++ b/kubejs/server_scripts/mods/industrialforegoingsouls/recipes.js
@@ -1,0 +1,11 @@
+﻿// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
+
+ServerEvents.recipes(allthemods => {
+    allthemods.remove({id: 'industrialforegoingsouls:soul_laser_base'})
+    allthemods.remove({id: 'industrialforegoingsouls:soul_surge'})
+    allthemods.remove({id: 'industrialforegoingsouls:soul_network_pipe'})
+})
+
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.


### PR DESCRIPTION
- Recipes of the following have been made slightly harder
   - `industrialforegoingsouls:soul_laser_base`
   - `industrialforegoingsouls:soul_surge`
   - `industrialforegoingsouls:soul_network_pipe`
   
- The `industrialforegoing-souls-machines.toml` was adjusted with the following
   - **Increased** the internal buffer of souls `SOUL_STORAGE_AMOUNT = 1350 -> 1500`
   - **More ticks** required per operation `MAX_PROGRESS = 20 -> 30`
   - The Warden **can be killed** if not properly healed by the statis chamber `KILL_WARDEN  = false -> true`
   - **More damage** done to the warden per operation `DAMAGE_PER_OPERATION  = 4 -> 12`
   - **More souls** per operation `SOULS_PER_OPERATION = 2 -> 4`
   - **Decreased** the time a single soul can boost a machine for `SOUL_TIME = 300 -> 200`
   - **Slightly decreased** the chance of random tick block being boosted `RANDOM_TICK_ACCELERATION_CHANCE = 0.03 ->  0.025`