### PR TITLE
Limit time_wand_max_multiplier to 128 to prevent error message when attempting to accelerate to 256x

### DIFF
--- a/config/justdirethings-common.toml
+++ b/config/justdirethings-common.toml
@@ -215,7 +215,7 @@
 	#Range: 0.0 ~ 1.7976931348623157E308
 	time_wand_fluid_cost = 0.5
 	#The maximum speed multiplier that can be applied using a Time Wand. This value should be a power of two.
-	time_wand_max_multiplier = 256
+	time_wand_max_multiplier = 128
 	#Can fake players use the Time Wand (Like in the clickers)?
 	time_wand_fake_player_allowed = false
 


### PR DESCRIPTION
When attempting to accelerate past 128x with the JDT time wand, you currently get the error "insufficient energy". I've been told in discord that this is a balance change.   

I propose lowering the max multiplier to 128 to prevent this error message from popping up each time you click past 128x.