### PR TITLE
fix: mekanism gbg nerf

### DIFF
--- a/kubejs/data/mekanism/data_maps/mekanism/chemical/chemical_attribute_fuel.json
+++ b/kubejs/data/mekanism/data_maps/mekanism/chemical/chemical_attribute_fuel.json
@@ -1,0 +1,12 @@
+﻿{
+    "values": {
+        "mekanism:ethene": {
+            "burn_time": 20,
+            "energy": 300
+        },
+        "mekanism:hydrogen": {
+            "burn_time": 1,
+            "energy": 200
+        }
+    }
+}


### PR DESCRIPTION
Fixes the energy values in the `Mekanism Gas Burning Generator` after the config change
- resolves #2947 