### PR TITLE
Oritech balances

### DIFF
--- a/kubejs/server_scripts/mods/Oritech/recipes.js
+++ b/kubejs/server_scripts/mods/Oritech/recipes.js
@@ -1,0 +1,57 @@
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
+
+// ServerEvents.recipes(allthemods => {
+
+//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_efficient_speed_tier_9'})
+//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_efficient_speed_tier_8'})
+//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_efficient_speed_tier_7'})
+//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_efficient_speed_tier_6'})
+    
+//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_capacitor_tier_6'})
+
+//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_acceptor_tier_9'})
+//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_acceptor_tier_8'})
+//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_acceptor_tier_7'})
+//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_acceptor_tier_6'})
+
+//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_efficiency_tier_9'})
+//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_efficiency_tier_8'})
+//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_efficiency_tier_7'})
+//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_efficiency_tier_6'})
+// })
+
+    ServerEvents.recipes(allthemods => {
+
+        allthemods.remove({output: 'oritech:machine_core_3'})
+        allthemods.shaped(
+            Item.of('oritech:machine_core_3', 1),
+            [
+                'AAA',
+                'ABA',
+                'AAA'
+            ],
+            {
+                A: 'oritech:carbon_fibre_strands',
+                B: 'oritech:fluxite_block'
+            }
+        )
+        allthemods.remove({output: 'oritech:machine_extender'})
+        allthemods.shaped(
+            Item.of('oritech:machine_extender', 1),
+            [
+                'AAA',
+                'ABA',
+                'AAA'
+            ],
+            {
+                A: 'oritech:carbon_plating_block',
+                B: 'oritech:machine_core_3'
+            }
+        )
+
+    })
+
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
+


### PR DESCRIPTION
Added recipes.js
- Removed alternate recipe `Improved Machine core` 
- Made `Improved Machine core` recipe slightly more expensive by adding fluxite block to it instead of redstone dust
- Removed `Plating block` tag from Machine extender addon recipe, now it only takes highest tier plating which is `Carbon Plating Block`
- Recipe also affects further machine cores since those use `Improved Machine cores`


This was all done since resources are easily available in the pack and `Machine Addon Extender` are extremely broken.

![image](https://github.com/user-attachments/assets/790201e7-ca7f-40f9-95c2-bbe7f219637e)
![image](https://github.com/user-attachments/assets/ff47afbd-e84b-425d-b3a1-2573b0282760)
