### PR TITLE
Rebalance oritech power

### DIFF
--- a/config/oritech-config.json5
+++ b/config/oritech-config.json5
@@ -16,44 +16,44 @@
 		"centrifugeData": {
 			"energyCapacity": 10000,
 			"maxEnergyInsertion": 512,
-			"energyPerTick": 64,
+			"energyPerTick": 128,
 			"tankSizeInBuckets": 8
 		},
 		"foundryData": {
 			"energyCapacity": 50000,
 			"maxEnergyInsertion": 1024,
 			"maxEnergyExtraction": 0,
-			"energyPerTick": 128
+			"energyPerTick": 256
 		},
 		"coolerData": {
 			"energyCapacity": 50000,
 			"maxEnergyInsertion": 256,
 			"maxEnergyExtraction": 0,
-			"energyPerTick": 32
+			"energyPerTick": 128
 		},
 		"fragmentForgeData": {
 			"energyCapacity": 50000,
 			"maxEnergyInsertion": 2048,
 			"maxEnergyExtraction": 0,
-			"energyPerTick": 256
+			"energyPerTick": 512
 		},
 		"furnaceData": {
 			"energyCapacity": 10000,
 			"maxEnergyInsertion": 256,
-			"energyPerTick": 32,
+			"energyPerTick": 64,
 			"speedMultiplier": 0.5
 		},
 		"pulverizerData": {
 			"energyCapacity": 25000,
 			"maxEnergyInsertion": 256,
 			"maxEnergyExtraction": 0,
-			"energyPerTick": 32
+			"energyPerTick": 64
 		},
 		"refineryData": {
 			"energyCapacity": 50000,
 			"maxEnergyInsertion": 512,
 			"maxEnergyExtraction": 0,
-			"energyPerTick": 64
+			"energyPerTick": 128
 		}
 	},
 	"generators": {
@@ -99,8 +99,8 @@
 	},
 	"laserArmConfig": {
 		"energyCapacity": 20000,
-		"maxEnergyInsertion": 1024,
-		"energyPerTick": 128,
+		"maxEnergyInsertion": 2048,
+		"energyPerTick": 512,
 		"blockBreakEnergyBase": 1024,
 		"damageTickBase": 2.0,
 		"range": 128
@@ -119,24 +119,24 @@
 	"fertilizerConfig": {
 		"moveDuration": 10,
 		"workDuration": 20,
-		"moveEnergyUsage": 8,
-		"workEnergyUsage": 128,
+		"moveEnergyUsage": 16,
+		"workEnergyUsage": 256,
 		"liquidPerBlockUsage": 0.25
 	},
 	"placerConfig": {
 		"moveDuration": 10,
 		"workDuration": 5,
-		"moveEnergyUsage": 8,
-		"workEnergyUsage": 64
+		"moveEnergyUsage": 16,
+		"workEnergyUsage": 128
 	},
 	"smallEnergyStorage": {
-		"energyCapacity": 1000000,
+		"energyCapacity": 5000000,
 		"maxEnergyInsertion": 5000,
 		"maxEnergyExtraction": 5000,
 		"energyPerTick": 0
 	},
 	"largeEnergyStorage": {
-		"energyCapacity": 20000000,
+		"energyCapacity": 60000000,
 		"maxEnergyInsertion": 10000,
 		"maxEnergyExtraction": 10000,
 		"energyPerTick": 0
@@ -223,15 +223,15 @@
 	"easyFindFeatures": true,
 	"safeMode": false,
 	"safeModeCooldown": 2400,
-	"maxSize": 64,
-	"reactorMaxEnergyStored": 50000000,
-	"reactorMaxEnergyOutput": 25000,
-	"rfPerPulse": 64,
-	"absorberRate": 16,
-	"ventBaseRate": 4,
-	"ventRelativeRate": 100,
+	"maxSize": 32,
+	"reactorMaxEnergyStored": 150000000,
+	"reactorMaxEnergyOutput": 125000,
+	"rfPerPulse": 1100,
+	"absorberRate": 64,
+	"ventBaseRate": 24,
+	"ventRelativeRate": 160,
 	"maxHeat": 2000,
-	"maxUnstableTicks": 400,
+	"maxUnstableTicks": 600,
 	"boringNukes": true,
 	"enchanterCostMultiplier": 5,
 	"catalystBaseSouls": 50,


### PR DESCRIPTION
# Oritech Power Rebalance

- Most machines now use 200% power.
- `Small Energy Storage` now stores 5x more power
- `Large Energy Storage` now stores 3x more power

## Reactor Rebalance

### Current problems

1. Reactors are very hard to scale, they require a lot of knowledge about heat movement.
2. They are much more expensive than most alternatives in the modpack.
3. Too large of a reactor can crash the game.
4. Reactors do not produce any real amount of power.

### Changes

1. Made reactors a little bit more forgiving.
2. Cost remains same but they produce a significant amount of power.  With these changes, they can make more energy than a reactor of the same size but they still cost a decent amount more.
3. They are limited by size so people shouldn't be able to crash their game easily.

### Technical Changes

1. Max size reduced from `64` -> `32`
2. Storage increased from `50000000` -> `150000000`
3. Each energy port output increased from `25000` -> `125000`
4. RF per pulse increased from `64` to `1100` (pulses explained below)
5. Absorber rate increased from `16` to `64`
6. Vent rate increased from `4` to `24`
7. Vent relative rate increased from `100` to `160`

### Explanation of changes

1. Reactors work on pulses, Single Rod creates 1 pulse, Double Rod creates 4 pulses, Quad Rods creates 12 pulses, pulses can be reflected by `Reactor Neutron Reflector` and all rods give external pulses as well. 
2. Heat is very sensitive, in a 15 by 15 reactor, only 5 rods are used and rest of the space is to accomodate for the heat produced.
3. Attaching an image to showcase what a reactor will look like 

![image](https://github.com/user-attachments/assets/c0634245-b159-47cc-bdf9-247f8bfcc3a5)
