### PR TITLE
fix: remove extra comments, removed enchanting from oritech

### DIFF
--- a/kubejs/server_scripts/mods/Oritech/recipes.js
+++ b/kubejs/server_scripts/mods/Oritech/recipes.js
@@ -37,66 +37,6 @@
         allthemods.remove({id: 'oritech:crafting/catalyst'})
         allthemods.remove({id: 'oritech:crafting/enchanter'})
 
-
-        // Oil compatibility
-        allthemods.remove({id: 'oritech:refinery/oilalt'})
-        allthemods.remove({id: 'oritech:refinery/oilbase'})
-
-        allthemods.custom({
-  "type": "oritech:refinery",
-  "fluidInput": {
-    "amount": 1000,
-    "fluid": "#c:crude_oil"
-  },
-  "fluidOutputs": [
-    {
-      "amount": 500,
-      "fluid": "oritech:still_heavy_oil"
-    },
-    {
-      "amount": 250,
-      "fluid": "oritech:still_naphtha"
-    },
-    {
-      "amount": 250,
-      "fluid": "oritech:still_sulfuric_acid"
-    }
-  ],
-  "ingredients": [],
-  "results": [],
-  "time": 120
-})
-    allthemods.custom({
-  "type": "oritech:refinery",
-  "fluidInput": {
-    "amount": 1000,
-    "fluid": "#c:crude_oil"
-  },
-  "fluidOutputs": [
-    {
-      "amount": 500,
-      "fluid": "oritech:still_diesel"
-    },
-    {
-      "amount": 500,
-      "fluid": "oritech:still_naphtha"
-    },
-    {
-      "amount": 500,
-      "fluid": "oritech:still_sulfuric_acid"
-    }
-  ],
-  "ingredients": [
-    {
-      "item": "oritech:clay_catalyst_beads"
-    }
-  ],
-  "results": [],
-  "time": 120
-})
-
-    })
-
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
 

--- a/kubejs/server_scripts/mods/Oritech/recipes.js
+++ b/kubejs/server_scripts/mods/Oritech/recipes.js
@@ -4,7 +4,8 @@
     ServerEvents.recipes(allthemods => {
 
         // Rebalance of 'machine addon extender'
-        allthemods.remove({output: 'oritech:machine_core_3'})
+        allthemods.remove({id: 'oritech:crafting/core3alt'})
+        allthemods.remove({id: 'oritech:crafting/core3'})
         allthemods.shaped(
             Item.of('oritech:machine_core_3', 1),
             [
@@ -17,7 +18,7 @@
                 B: 'oritech:fluxite_block'
             }
         )
-        allthemods.remove({output: 'oritech:machine_extender'})
+        // allthemods.remove({output: 'oritech:machine_extender'})
         allthemods.shaped(
             Item.of('oritech:machine_extender', 1),
             [
@@ -32,8 +33,67 @@
         )
 
         // Remove enchanting stuff
-        allthemods.remove({output: 'oritech:enchantment_catalyst_block'})
-        allthemods.remove({output: 'oritech:enchanter_block'})
+        allthemods.remove({id: 'oritech:crafting/catalyst_alt'})
+        allthemods.remove({id: 'oritech:crafting/catalyst'})
+        allthemods.remove({id: 'oritech:crafting/enchanter'})
+
+
+        // Oil compatibility
+        allthemods.remove({id: 'oritech:refinery/oilalt'})
+        allthemods.remove({id: 'oritech:refinery/oilbase'})
+
+        allthemods.custom({
+  "type": "oritech:refinery",
+  "fluidInput": {
+    "amount": 1000,
+    "fluid": "#c:crude_oil"
+  },
+  "fluidOutputs": [
+    {
+      "amount": 500,
+      "fluid": "oritech:still_heavy_oil"
+    },
+    {
+      "amount": 250,
+      "fluid": "oritech:still_naphtha"
+    },
+    {
+      "amount": 250,
+      "fluid": "oritech:still_sulfuric_acid"
+    }
+  ],
+  "ingredients": [],
+  "results": [],
+  "time": 120
+})
+    allthemods.custom({
+  "type": "oritech:refinery",
+  "fluidInput": {
+    "amount": 1000,
+    "fluid": "#c:crude_oil"
+  },
+  "fluidOutputs": [
+    {
+      "amount": 500,
+      "fluid": "oritech:still_diesel"
+    },
+    {
+      "amount": 500,
+      "fluid": "oritech:still_naphtha"
+    },
+    {
+      "amount": 500,
+      "fluid": "oritech:still_sulfuric_acid"
+    }
+  ],
+  "ingredients": [
+    {
+      "item": "oritech:clay_catalyst_beads"
+    }
+  ],
+  "results": [],
+  "time": 120
+})
 
     })
 

--- a/kubejs/server_scripts/mods/Oritech/recipes.js
+++ b/kubejs/server_scripts/mods/Oritech/recipes.js
@@ -1,28 +1,9 @@
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
 
-// ServerEvents.recipes(allthemods => {
-
-//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_efficient_speed_tier_9'})
-//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_efficient_speed_tier_8'})
-//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_efficient_speed_tier_7'})
-//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_efficient_speed_tier_6'})
-    
-//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_capacitor_tier_6'})
-
-//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_acceptor_tier_9'})
-//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_acceptor_tier_8'})
-//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_acceptor_tier_7'})
-//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_acceptor_tier_6'})
-
-//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_efficiency_tier_9'})
-//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_efficiency_tier_8'})
-//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_efficiency_tier_7'})
-//     allthemods.remove({id: 'oritechthings:atomicforge/addon_block_efficiency_tier_6'})
-// })
-
     ServerEvents.recipes(allthemods => {
 
+        // Rebalance of 'machine addon extender'
         allthemods.remove({output: 'oritech:machine_core_3'})
         allthemods.shaped(
             Item.of('oritech:machine_core_3', 1),
@@ -49,6 +30,10 @@
                 B: 'oritech:machine_core_3'
             }
         )
+
+        // Remove enchanting stuff
+        allthemods.remove({output: 'oritech:enchantment_catalyst_block'})
+        allthemods.remove({output: 'oritech:enchanter_block'})
 
     })
 


### PR DESCRIPTION
Clean up of file
Removes recipe of `Arcane Catalyst` and `Stabilised Enchanter` temporarily till a balance is found to limit enchantment levels.

Max possible is 156
![cFJaKXn](https://github.com/user-attachments/assets/699e2976-c49b-47fa-944d-89325a653991)