### PR TITLE
fix: Oritech ores generating in boulders

### DIFF
--- a/kubejs/data/oritech/worldgen/configured_feature/resource_node_common.json
+++ b/kubejs/data/oritech/worldgen/configured_feature/resource_node_common.json
@@ -1,0 +1,45 @@
+{
+  "type": "oritech:resource_node",
+  "config": {
+    "nodeSize": 6,
+    "nodeOreChance": 0.4,
+    "boulderRadius": 3,
+    "nodeOres": [
+      "oritech:resource_node_copper",
+      "oritech:resource_node_copper",
+      "oritech:resource_node_copper",
+      "oritech:resource_node_iron",
+      "oritech:resource_node_iron",
+      "oritech:resource_node_nickel",
+      "oritech:resource_node_nickel",
+      "oritech:resource_node_coal",
+      "oritech:resource_node_coal"
+    ],
+    "boulderOres": [
+      "minecraft:deepslate_iron_ore",
+      "minecraft:deepslate_copper_ore",
+      "minecraft:deepslate_copper_ore",
+      "minecraft:deepslate_copper_ore",
+      "minecraft:deepslate_iron_ore",
+      "minecraft:deepslate_coal_ore",
+      "minecraft:deepslate_coal_ore",
+      "alltheores:deepslate_nickel_ore",
+      "alltheores:deepslate_nickel_ore",
+      "minecraft:deepslate",
+      "minecraft:deepslate",
+      "minecraft:deepslate",
+      "minecraft:deepslate",
+      "minecraft:deepslate",
+      "minecraft:deepslate",
+      "minecraft:deepslate",
+      "minecraft:deepslate",
+      "minecraft:deepslate",
+      "minecraft:deepslate",
+      "minecraft:deepslate",
+      "minecraft:deepslate",
+      "minecraft:deepslate"
+    ],
+    "overlayBlock": "oritech:still_oil_block",
+    "overlayHeight": 5
+  }
+}

--- a/kubejs/data/oritech/worldgen/configured_feature/resource_node_rare.json
+++ b/kubejs/data/oritech/worldgen/configured_feature/resource_node_rare.json
@@ -1,0 +1,40 @@
+{
+  "type": "oritech:resource_node",
+  "config": {
+    "nodeSize": 6,
+    "nodeOreChance": 0.2,
+    "boulderRadius": 3,
+    "nodeOres": [
+      "oritech:resource_node_diamond",
+      "oritech:resource_node_diamond",
+      "oritech:resource_node_gold",
+      "oritech:resource_node_emerald",
+      "oritech:resource_node_uranium",
+      "oritech:resource_node_platinum"
+    ],
+    "boulderOres": [
+      "minecraft:deepslate_diamond_ore",
+      "minecraft:deepslate_gold_ore",
+      "minecraft:deepslate_gold_ore",
+      "minecraft:deepslate_emerald_ore",
+      "alltheores:deepslate_platinum_ore",
+      "alltheores:deepslate_uranium_ore",
+      "minecraft:deepslate",
+      "minecraft:deepslate",
+      "minecraft:deepslate",
+      "minecraft:deepslate",
+      "minecraft:deepslate",
+      "minecraft:deepslate",
+      "minecraft:deepslate",
+      "minecraft:deepslate",
+      "minecraft:deepslate",
+      "minecraft:deepslate",
+      "minecraft:deepslate",
+      "minecraft:deepslate",
+      "minecraft:deepslate",
+      "minecraft:deepslate"
+    ],
+    "overlayBlock": "oritech:still_fuel_block",
+    "overlayHeight": 5
+  }
+}


### PR DESCRIPTION
Replaces `Nickel ore`, `Platinum ore`, `Uranium ore` generation from the wrong mod, now AllTheOres Nickel will generate in said boulders