### PR TITLE
fix: wither bone tags for recipe compatibility

### DIFF
--- a/kubejs/server_scripts/mods/Ice and Fire/tags.js
+++ b/kubejs/server_scripts/mods/Ice and Fire/tags.js
@@ -1,0 +1,6 @@
+
+
+ServerEvents.tags('item', allthemodium => {
+
+    allthemodium.add('c:wither_bones', 'iceandfire:witherbone')
+})


### PR DESCRIPTION
Adds tag `c:wither_bones` to Ice and Fire `Witherbone` to allow it to be used in baubley heart cannisters recipe

Fixes #3039 