### PR TITLE
fix: Compatibility between oritech oil and pneumaticcraft oil

### DIFF
--- a/kubejs/server_scripts/mods/Oritech/tags.js
+++ b/kubejs/server_scripts/mods/Oritech/tags.js
@@ -1,0 +1,9 @@
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
+
+ServerEvents.tags('fluid', allthemods => {
+    allthemods.add('c:fuels/crude_oil', 'oritech:still_oil')
+})
+
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.


### PR DESCRIPTION
Adds tag `c:fuels/crude_oil` to `oritech:still_oil` fluid

fixes #3017 