### PR TITLE
Fixed the Runic Star Altar Block icon in the quest.

### DIFF
--- a/config/ftbquests/quests/chapters/chapter_2_the_star.snbt
+++ b/config/ftbquests/quests/chapters/chapter_2_the_star.snbt
@@ -3601,10 +3601,7 @@
 		}
 		{
 			icon: {
-				components: {
-					"modular_machinery_reborn:machine": "atm:runic_star_altar"
-				}
-				id: "modular_machinery_reborn:controller"
+				id: "modern_industrialization:star_altar"
 			}
 			id: "70CCE558E03227AB"
 			rewards: [


### PR DESCRIPTION
- **Fixed the mod icon to the correct Runic Star Altar Block block in Chapter 3.**

![ALTAR](https://github.com/user-attachments/assets/ae63298a-e57b-495a-8250-f1de99fd8b05)
