### PR TITLE
fix: portal fluid works in all end biomes

### DIFF
--- a/kubejs/data/justdirethings/tags/worldgen/biome/unstable_portal_fluid_viable.json
+++ b/kubejs/data/justdirethings/tags/worldgen/biome/unstable_portal_fluid_viable.json
@@ -1,0 +1,12 @@
+{
+  "values": [
+    "minecraft:end_barrens",
+    "minecraft:end_highlands",
+    "minecraft:end_midlands",
+    "minecraft:small_end_islands",
+    "minecraft:the_end",
+    "nullscape:crystal_peaks",
+    "nullscape:shadowlands",
+    "nullscape:void_barrens"
+  ]
+}


### PR DESCRIPTION
Fixes #3149 
Portal fluid will now work in all the biomes of end(I could find)

