### PR TITLE
fix: hardcode prod bees to produce MI oil

### DIFF
--- a/kubejs/data/productivebees/recipe/centrifuge/fluids/honeycomb_oily.json
+++ b/kubejs/data/productivebees/recipe/centrifuge/fluids/honeycomb_oily.json
@@ -1,0 +1,22 @@
+{
+  "type": "productivebees:centrifuge",
+  "ingredient": {
+    "type": "productivebees:component",
+    "components": {
+      "productivebees:bee_type": "productivebees:oily"
+    },
+    "items": "productivebees:configurable_honeycomb"
+  },
+  "outputs": [
+  ],
+  "fluid": {
+    "fluid": "modern_industrialization:crude_oil",
+    "amount": 50
+  },
+  "neoforge:conditions": [
+    {
+      "type": "productivebees:bee_exists",
+      "bee": "productivebees:oily"
+    }
+  ]
+}


### PR DESCRIPTION
MI does not accept oil from other mods but other mods can work with MI oil, this change hardcodes prod bees oily bee combs to produce MI crude oil 
Fixes #3141 