### PR TITLE
Quest Reward: 4 dark oak saplings instead of 1

### DIFF
--- a/config/ftbquests/quests/chapters/building_tips.snbt
+++ b/config/ftbquests/quests/chapters/building_tips.snbt
@@ -1785,7 +1785,7 @@
 					exclude_from_claim_all: true
 					id: "221B83F8C189F1A1"
 					item: {
-						count: 1
+						count: 4
 						id: "minecraft:dark_oak_sapling"
 					}
 					type: "item"


### PR DESCRIPTION
[Dark oak and pale oak need at least 7 spaces above (6×6 column) and must be planted as **4 saplings** in a 2×2 square.](https://minecraft.wiki/w/Sapling#Growing_trees)