### PR TITLE
Fix RFTools Module Syringe Display in JEI

### DIFF
--- a/kubejs/server_scripts/mods/rftools/Recipes.js
+++ b/kubejs/server_scripts/mods/rftools/Recipes.js
@@ -8,7 +8,171 @@ ServerEvents.recipes(allthemods => {
       e: '#c:ender_pearls',
       r: '#c:storage_blocks/redstone',
       m: 'rftoolsbase:machine_frame'
-    })
+    });
+    allthemods.remove({ id: `rftoolsutility:flight_module`})
+	allthemods.remove({ id: `rftoolsutility:blindness_module`})
+	allthemods.remove({ id: `rftoolsutility:featherfalling_module`})
+	allthemods.remove({ id: `rftoolsutility:haste_module`})
+	allthemods.remove({ id: `rftoolsutility:glowing_module`})
+	allthemods.remove({ id: `rftoolsutility:luck_module`})
+	allthemods.remove({ id: `rftoolsutility:nightvision_module`})
+	allthemods.remove({ id: `rftoolsutility:noteleport_module`})
+	allthemods.remove({ id: `rftoolsutility:peaceful_module`})
+	allthemods.remove({ id: `rftoolsutility:poison_module`})
+	allthemods.remove({ id: `rftoolsutility:regeneration_module`})
+	allthemods.remove({ id: `rftoolsutility:saturation_module`})
+	allthemods.remove({ id: `rftoolsutility:slowness_module`})
+	allthemods.remove({ id: `rftoolsutility:speed_module`})
+	allthemods.remove({ id: `rftoolsutility:waterbreathing_module`})
+	allthemods.remove({ id: `rftoolsutility:weakness_module`})
+	// Fix Syringe Display
+     allthemods.shaped(Item.of('rftoolsutility:flight_module', 1), [
+        'DUD',
+        'DND',
+        'DPD'
+    ], {
+        D: 'minecraft:ghast_tear',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:ghast"}]',
+        N: 'rftoolsutility:moduleplus_template',
+		P: 'rftoolsbase:infused_enderpearl'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:blindness_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:black_dye',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:squid"}]',
+        N: 'rftoolsutility:moduleplus_template'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:featherfalling_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:feather',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:chicken"}]',
+        N: 'rftoolsutility:module_template'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:haste_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:redstone',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:pillager"}]',
+        N: 'rftoolsutility:module_template'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:glowing_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:glowstone',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:creeper"}]',
+        N: 'rftoolsutility:module_template'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:luck_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:quartz',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:cat"}]',
+        N: 'rftoolsutility:module_template'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:nightvision_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:glowstone',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:drowned"}]',
+        N: 'rftoolsutility:module_template'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:noteleport_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:ender_pearl',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:enderman"}]',
+        N: 'rftoolsutility:moduleplus_template'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:peaceful_module', 1), [
+        'IUI',
+        'DND',
+        'IDI'
+    ], {
+        D: 'rftoolsbase:infused_enderpearl',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:iron_golem"}]',
+        N: 'rftoolsutility:moduleplus_template',
+		I: 'minecraft:iron_block'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:poison_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:poisonous_potato',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:cave_spider"}]',
+        N: 'rftoolsutility:module_template'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:regeneration_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:golden_apple',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:witch"}]',
+        N: 'rftoolsutility:module_template'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:saturation_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:rotten_flesh',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:zombie"}]',
+        N: 'rftoolsutility:module_template'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:slowness_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:string',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:turtle"}]',
+        N: 'rftoolsutility:module_template'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:speed_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:powered_rail',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:wolf"}]',
+        N: 'rftoolsutility:module_template'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:waterbreathing_module', 1), [
+        'PUP',
+        'DND',
+        'PDP'
+    ], {
+        D: 'rftoolsbase:infused_enderpearl',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:guardian"}]',
+        N: 'rftoolsutility:moduleplus_template',
+		P: 'minecraft:prismarine'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:weakness_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:cactus',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:piglin"}]',
+        N: 'rftoolsutility:module_template'
+    });
   })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.

--- a/kubejs/server_scripts/mods/rftools/Recipes.js
+++ b/kubejs/server_scripts/mods/rftools/Recipes.js
@@ -9,22 +9,6 @@ ServerEvents.recipes(allthemods => {
       r: '#c:storage_blocks/redstone',
       m: 'rftoolsbase:machine_frame'
     });
-    allthemods.remove({ id: `rftoolsutility:flight_module`})
-	allthemods.remove({ id: `rftoolsutility:blindness_module`})
-	allthemods.remove({ id: `rftoolsutility:featherfalling_module`})
-	allthemods.remove({ id: `rftoolsutility:haste_module`})
-	allthemods.remove({ id: `rftoolsutility:glowing_module`})
-	allthemods.remove({ id: `rftoolsutility:luck_module`})
-	allthemods.remove({ id: `rftoolsutility:nightvision_module`})
-	allthemods.remove({ id: `rftoolsutility:noteleport_module`})
-	allthemods.remove({ id: `rftoolsutility:peaceful_module`})
-	allthemods.remove({ id: `rftoolsutility:poison_module`})
-	allthemods.remove({ id: `rftoolsutility:regeneration_module`})
-	allthemods.remove({ id: `rftoolsutility:saturation_module`})
-	allthemods.remove({ id: `rftoolsutility:slowness_module`})
-	allthemods.remove({ id: `rftoolsutility:speed_module`})
-	allthemods.remove({ id: `rftoolsutility:waterbreathing_module`})
-	allthemods.remove({ id: `rftoolsutility:weakness_module`})
 	// Fix Syringe Display
      allthemods.shaped(Item.of('rftoolsutility:flight_module', 1), [
         'DUD',
@@ -35,7 +19,7 @@ ServerEvents.recipes(allthemods => {
         U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:ghast"}]',
         N: 'rftoolsutility:moduleplus_template',
 		P: 'rftoolsbase:infused_enderpearl'
-    });
+    }).id('rftoolsutility:flight_module');
 	allthemods.shaped(Item.of('rftoolsutility:blindness_module', 1), [
         'DUD',
         'DND',
@@ -44,7 +28,7 @@ ServerEvents.recipes(allthemods => {
         D: 'minecraft:black_dye',
         U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:squid"}]',
         N: 'rftoolsutility:moduleplus_template'
-    });
+    }).id('rftoolsutility:blindness_module');
 	allthemods.shaped(Item.of('rftoolsutility:featherfalling_module', 1), [
         'DUD',
         'DND',
@@ -53,7 +37,7 @@ ServerEvents.recipes(allthemods => {
         D: 'minecraft:feather',
         U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:chicken"}]',
         N: 'rftoolsutility:module_template'
-    });
+    }).id('rftoolsutility:featherfalling_module');
 	allthemods.shaped(Item.of('rftoolsutility:haste_module', 1), [
         'DUD',
         'DND',
@@ -62,7 +46,7 @@ ServerEvents.recipes(allthemods => {
         D: 'minecraft:redstone',
         U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:pillager"}]',
         N: 'rftoolsutility:module_template'
-    });
+    }).id('rftoolsutility:haste_module');
 	allthemods.shaped(Item.of('rftoolsutility:glowing_module', 1), [
         'DUD',
         'DND',
@@ -71,7 +55,7 @@ ServerEvents.recipes(allthemods => {
         D: 'minecraft:glowstone',
         U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:creeper"}]',
         N: 'rftoolsutility:module_template'
-    });
+    }).id('rftoolsutility:glowing_module');
 	allthemods.shaped(Item.of('rftoolsutility:luck_module', 1), [
         'DUD',
         'DND',
@@ -80,7 +64,7 @@ ServerEvents.recipes(allthemods => {
         D: 'minecraft:quartz',
         U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:cat"}]',
         N: 'rftoolsutility:module_template'
-    });
+    }).id('rftoolsutility:luck_module');
 	allthemods.shaped(Item.of('rftoolsutility:nightvision_module', 1), [
         'DUD',
         'DND',
@@ -89,7 +73,7 @@ ServerEvents.recipes(allthemods => {
         D: 'minecraft:glowstone',
         U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:drowned"}]',
         N: 'rftoolsutility:module_template'
-    });
+    }).id('rftoolsutility:nightvision_module');
 	allthemods.shaped(Item.of('rftoolsutility:noteleport_module', 1), [
         'DUD',
         'DND',
@@ -98,7 +82,7 @@ ServerEvents.recipes(allthemods => {
         D: 'minecraft:ender_pearl',
         U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:enderman"}]',
         N: 'rftoolsutility:moduleplus_template'
-    });
+    }).id('rftoolsutility:noteleport_module');
 	allthemods.shaped(Item.of('rftoolsutility:peaceful_module', 1), [
         'IUI',
         'DND',
@@ -108,7 +92,7 @@ ServerEvents.recipes(allthemods => {
         U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:iron_golem"}]',
         N: 'rftoolsutility:moduleplus_template',
 		I: 'minecraft:iron_block'
-    });
+    }).id('rftoolsutility:peaceful_module');
 	allthemods.shaped(Item.of('rftoolsutility:poison_module', 1), [
         'DUD',
         'DND',
@@ -117,7 +101,7 @@ ServerEvents.recipes(allthemods => {
         D: 'minecraft:poisonous_potato',
         U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:cave_spider"}]',
         N: 'rftoolsutility:module_template'
-    });
+    }).id('rftoolsutility:poison_module');
 	allthemods.shaped(Item.of('rftoolsutility:regeneration_module', 1), [
         'DUD',
         'DND',
@@ -126,7 +110,7 @@ ServerEvents.recipes(allthemods => {
         D: 'minecraft:golden_apple',
         U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:witch"}]',
         N: 'rftoolsutility:module_template'
-    });
+    }).id('rftoolsutility:regeneration_module');
 	allthemods.shaped(Item.of('rftoolsutility:saturation_module', 1), [
         'DUD',
         'DND',
@@ -135,7 +119,7 @@ ServerEvents.recipes(allthemods => {
         D: 'minecraft:rotten_flesh',
         U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:zombie"}]',
         N: 'rftoolsutility:module_template'
-    });
+    }).id('rftoolsutility:saturation_module');
 	allthemods.shaped(Item.of('rftoolsutility:slowness_module', 1), [
         'DUD',
         'DND',
@@ -144,7 +128,7 @@ ServerEvents.recipes(allthemods => {
         D: 'minecraft:string',
         U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:turtle"}]',
         N: 'rftoolsutility:module_template'
-    });
+    }).id('rftoolsutility:slowness_module');
 	allthemods.shaped(Item.of('rftoolsutility:speed_module', 1), [
         'DUD',
         'DND',
@@ -153,7 +137,7 @@ ServerEvents.recipes(allthemods => {
         D: 'minecraft:powered_rail',
         U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:wolf"}]',
         N: 'rftoolsutility:module_template'
-    });
+    }).id('rftoolsutility:speed_module');
 	allthemods.shaped(Item.of('rftoolsutility:waterbreathing_module', 1), [
         'PUP',
         'DND',
@@ -163,7 +147,7 @@ ServerEvents.recipes(allthemods => {
         U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:guardian"}]',
         N: 'rftoolsutility:moduleplus_template',
 		P: 'minecraft:prismarine'
-    });
+    }).id('rftoolsutility:waterbreathing_module');
 	allthemods.shaped(Item.of('rftoolsutility:weakness_module', 1), [
         'DUD',
         'DND',
@@ -172,7 +156,7 @@ ServerEvents.recipes(allthemods => {
         D: 'minecraft:cactus',
         U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:piglin"}]',
         N: 'rftoolsutility:module_template'
-    });
+    }).id('rftoolsutility:weakness_module');
   })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.


### PR DESCRIPTION
This aims to fix the recipes for the various modules in RFToolsUtility displaying an empty syringe in JEI by removing the original recipes then creating an exact duplicate with KubeJS. An example of this can be seen here, with the Flight Module.
<img width="441" height="204" alt="image" src="https://github.com/user-attachments/assets/3e0acfc4-8a44-438e-9a59-84e93eb4342b" />
<img width="579" height="384" alt="image" src="https://github.com/user-attachments/assets/b010d7b7-e075-4dc2-bf6d-361678b1ba45" />
I applied the same fix to ATM10sky, figured why not make a PR for it here (not sure if it is as much of an issue here as it is there)