### PR TITLE
Additional Creative Recipes

### DIFF
--- a/kubejs/server_scripts/modpack/atm_star_creative.js
+++ b/kubejs/server_scripts/modpack/atm_star_creative.js
@@ -65,6 +65,43 @@ ServerEvents.recipes(allthemods => {
                 sourceCost: 0
             }
         ).id('allthemods:enchanting_apparatus/creative_source_jar')
+		
+    // Draconic Evolution
+    allthemods.custom(
+        {
+            type: 'powah:energizing',
+            energy: 2147483647,
+            ingredients: [
+                Ingredient.of('draconicevolution:dragon_heart').toJson(),
+                Ingredient.of('draconicevolution:chaotic_core').toJson(),
+                Ingredient.of('allthetweaks:atm_star').toJson(),
+                Ingredient.of('draconicevolution:chaotic_core').toJson(),
+                Ingredient.of('draconicevolution:dragon_heart').toJson()
+            ],
+            result: {
+                count: 1,
+                id: 'draconicevolution:creative_op_capacitor'
+            }
+        }
+    ).id('allthemods:energizing/draconicevolution_creative_power_source')
+
+    allthemods.custom(
+        {
+            type: 'powah:energizing',
+            energy: 2147483647,
+            ingredients: [
+                Ingredient.of('draconicevolution:dragon_heart').toJson(),
+                Ingredient.of('draconicevolution:chaotic_capacitor').toJson(),
+                Ingredient.of('allthetweaks:atm_star').toJson(),
+                Ingredient.of('draconicevolution:chaotic_capacitor').toJson(),
+                Ingredient.of('draconicevolution:dragon_heart').toJson()
+            ],
+            result: {
+                count: 1,
+                id: 'draconicevolution:creative_capacitor'
+            }
+        }
+    ).id('allthemods:energizing/draconicevolution_creative_capacitor')
 
     //EvilCraft
 
@@ -222,7 +259,19 @@ ServerEvents.recipes(allthemods => {
                     ).toJson()
             }
         ).id('allthemods:energizing/mekanism_creative_energy_cube')
-    
+	//Oritech
+       allthemods.recipes.kubejs.shaped('oritech:creative_tank_block',
+            [
+                'TUT',
+                'USU',
+                'TUT'
+            ],
+            {
+                T: 'oritech:small_tank_block',
+                U: 'allthemodium:unobtainium_ingot',
+                S: 'allthetweaks:atm_star_block',
+            }
+        ).id('allthemods:oritech/creative_tank_block')
     //Powah
 
         allthemods.custom(
@@ -368,6 +417,188 @@ ServerEvents.recipes(allthemods => {
         },
         "show_notification": false
     }).id("allthemods:create/creative_blaze_cake")
+    allthemods.custom({
+        "type": "create:mechanical_crafting",
+        "accept_mirrored": false,
+        "category": "misc",
+        "key": {
+            "P": {
+            "item": 'allthemodium:unobtainium_plate'
+			},
+			"W": {
+            "item": 'createaddition:electrum_spool'
+			},
+			"V": {
+            "item": 'allthemodium:vibranium_allthemodium_alloy_ingot'
+			},
+			"R": {
+            "item": 'allthemodium:allthemodium_rod'
+			},
+			"C": {
+            "item": 'allthetweaks:atm_star'
+			}
+        },
+        "pattern": [
+            "  V  ",
+            " PWP ",
+            "PWRWP",
+			" PCP "
+        ],
+        "result": {
+            "count": 1,
+            "id": 'create:creative_motor'
+        },
+        "show_notification": false
+    }).id("allthemods:create/creative_motor")
+// Worldshaper Recipe. Scrapped due to concerns of being too OP, even with the ridiculous recipe
+// When reimplementing, add the following to startup scripts: allthemods.create('incomplete_creative_worldshaper').texture('constructionstick:item/iron_stick').color(0xB200FF)
+/* 	allthemods.custom({
+  "type": "create:sequenced_assembly",
+  "ingredient": {
+    "item": "constructionstick:netherite_stick"
+  },
+  "loops": 531441,
+  "results": [
+    {
+      "id": "create:handheld_worldshaper"
+    }
+  ],
+  "sequence": [
+    {
+      "type": "create:deploying",
+      "ingredients": [
+        {
+          "item": "kubejs:incomplete_creative_worldshaper"
+        },
+        {
+          "item": "allthemodium:unobtainium_allthemodium_alloy_block"
+        }
+      ],
+      "results": [
+        {
+          "id": "kubejs:incomplete_creative_worldshaper"
+        }
+      ]
+    },
+	{
+      "type": "create:deploying",
+      "ingredients": [
+        {
+          "item": "kubejs:incomplete_creative_worldshaper"
+        },
+        {
+          "item": "allthemodium:vibranium_allthemodium_alloy_block"
+        }
+      ],
+      "results": [
+        {
+          "id": "kubejs:incomplete_creative_worldshaper"
+        }
+      ]
+    },
+	{
+      "type": "create:deploying",
+      "ingredients": [
+        {
+          "item": "kubejs:incomplete_creative_worldshaper"
+        },
+        {
+          "item": "allthemodium:unobtainium_vibranium_alloy_block"
+        }
+      ],
+      "results": [
+        {
+          "id": "kubejs:incomplete_creative_worldshaper"
+        }
+      ]
+    },
+	{
+      "type": "create:deploying",
+      "ingredients": [
+        {
+          "item": "kubejs:incomplete_creative_worldshaper"
+        },
+        {
+          "item": "allthetweaks:atm_star_block"
+        }
+      ],
+      "results": [
+        {
+          "id": "kubejs:incomplete_creative_worldshaper"
+        }
+      ]
+    },
+	{
+      "type": "create:pressing",
+      "ingredients": [
+        {
+          "item": "kubejs:incomplete_creative_worldshaper"
+        }
+      ],
+      "results": [
+        {
+          "id": "kubejs:incomplete_creative_worldshaper"
+        }
+      ]
+    }
+  ],
+  "transitional_item": {
+    "id": "kubejs:incomplete_creative_worldshaper"
+  }
+}).id("allthemods:create/handheld_worldshaper") */
+		
+	allthemods.custom({
+  "type": "create:compacting",
+  "heat_requirement": "superheated",
+  "ingredients": [
+    {
+      "item": "create:fluid_tank"
+    },
+    {
+      "item": "create:fluid_tank"
+    },
+    {
+      "item": "create:fluid_tank"
+    },
+    {
+      "item": "create:fluid_tank"
+    },
+    {
+      "item": "allthetweaks:atm_star_block"
+    },
+    {
+      "tag": "c:plates/unobtainium"
+    },
+    {
+      "tag": "c:plates/unobtainium"
+    },
+    {
+      "tag": "c:plates/unobtainium"
+    },
+    {
+      "tag": "c:plates/unobtainium"
+    }
+  ],
+  "results": [
+    {
+      "id": "create:creative_fluid_tank"
+    }
+  ]
+}).id("allthemods:create/creative_fluid_tank")
+	// Tempad
+        allthemods.recipes.kubejs.shaped('tempad:creative_chronometer', 
+            [
+                ' G ', 
+                'USU', 
+                ' C '
+            ],
+            {
+                G: '#c:glass_blocks/tinted',
+				U: '#c:ingots/unobtainium',
+				S: 'allthetweaks:atm_star',
+				C: 'tempad:chronometer'
+        }
+    )
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.


### PR DESCRIPTION
Felt like the ATM Star could get some additional uses, so I added the following recipes:
Creative Chronometer
<img width="450" height="207" alt="image" src="https://github.com/user-attachments/assets/c5d3b8f3-c2e6-48b7-9725-9e545ed34ce4" />
Creative Motor
<img width="615" height="362" alt="image" src="https://github.com/user-attachments/assets/34c8bd61-8f52-4e32-a4b7-14ca87f16bc8" />
Oritech Creative Tank (i know, we have Mekanism's creative fluid tank. I wanted to offer an option that you can change the contents of)
<img width="441" height="205" alt="image" src="https://github.com/user-attachments/assets/f8f0d1f7-2196-4717-b244-417d740396c1" />
Create Creative Fluid Tank
<img width="609" height="345" alt="image" src="https://github.com/user-attachments/assets/125351ca-4fe0-4836-9c26-3660e60bfcaf" />
Draconic Evolution Creative Power Source and Creative Capacitor (ported from ATM10sky)
<img width="568" height="147" alt="image" src="https://github.com/user-attachments/assets/8bb9b64e-3440-4bbd-b522-2f195ff66ec1" />
<img width="558" height="158" alt="image" src="https://github.com/user-attachments/assets/726cf3c3-2659-4a5a-916e-8f666184eb8d" />
Originally, quests were planned for these, but I lost them overnight (plus I don't really like to format text for quests)
Additionally, an absolutely ridiculous recipe for the Creative Worldshaper was planned, but had concerns that it may be a bit too OP, even with the ridiculous recipe. I commented them out in the file.