### PR TITLE
Make Dissolution Chamber accept any XP Fluid for Bottles o' Enchanting

### DIFF
--- a/kubejs/server_scripts/mods/Indusrial Foregoing/Dissolution Chamber.js
+++ b/kubejs/server_scripts/mods/Indusrial Foregoing/Dissolution Chamber.js
@@ -33,6 +33,35 @@ ServerEvents.recipes(allthemods => {
 
         allthemods.custom(recipe).id(`kubejs:dissolution_chamber/${id}`);
     }
+	function dissolution_chamber_fluidtag(output, inputs, fluid, time, id) {
+    let recipe = {
+      type: "industrialforegoing:dissolution_chamber",
+      input: [],
+      inputFluid: {
+        amount: fluid.amount || 100,
+        tag: fluid.fluid
+      },
+      output: {
+        count: output.count || 1,
+        id: output.item
+      },
+      processingTime: time
+    }
+
+    inputs.forEach((input) => {
+      let ingredients = {}
+
+      if (input.tag) {
+        ingredients.tag = input.tag
+      } else {
+        ingredients.item = input.item
+      }
+
+      recipe.input.push(ingredients)
+    })
+
+    allthemods.custom(recipe).id(`kubejs:dissolution_chamber/${id}`)
+  }
 
     dissolution_chamber(
         {item: 'industrialforegoing:pink_slime_block'},
@@ -113,12 +142,12 @@ ServerEvents.recipes(allthemods => {
     );
 
     allthemods.remove({id: 'industrialforegoing:dissolution_chamber/xp_bottles'})
-    dissolution_chamber(
+    dissolution_chamber_fluidtag(
         {item: 'minecraft:experience_bottle'},
         [
             {item: 'minecraft:glass_bottle'}],
         {
-            fluid: 'industrialforegoing:essence',
+            fluid: 'c:experience',
             amount: 250
         },
         5,


### PR DESCRIPTION
Ported from ATM10sky. Normally, the Dissolution Chamber only accepts Essence. I made it accept any other form of XP Fluid as well (that is covered by the c:experience tag)
<img width="705" height="338" alt="image" src="https://github.com/user-attachments/assets/20cc4fc8-9736-4313-abdd-db0a88e83be2" />
