### PR TITLE
Mekanism: Reactor page incompletable Fix

### DIFF
--- a/config/ftbquests/quests/chapters/mekanism_reactors.snbt
+++ b/config/ftbquests/quests/chapters/mekanism_reactors.snbt
@@ -3076,6 +3076,7 @@
 		{
 			id: "505799C894C771B2"
 			invisible: true
+			optional: true
 			tasks: [{
 				id: "74E743C093C7EC3B"
 				type: "checkmark"


### PR DESCRIPTION
Made the invisible quest with no dependencies in mekanism reactors page optional.

The page is impossible to complete otherwise.

Related issue: #3499