### PR TITLE
Basic Power chapter additions

### DIFF
--- a/config/ftbquests/quests/chapters/basic_power.snbt
+++ b/config/ftbquests/quests/chapters/basic_power.snbt
@@ -307,8 +307,8 @@
 				item: { components: { "ftbfiltersystem:filter": "or(item(mekanism:basic_energy_cube)item(mekanism:advanced_energy_cube)item(mekanism:elite_energy_cube)item(mekanism:ultimate_energy_cube)item(mekanism:creative_energy_cube))" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 				type: "item"
 			}]
-			x: 5.5d
-			y: 1.5d
+			x: 7.5d
+			y: 0.0d
 		}
 		{
 			dependencies: ["76EA017B12E8F01B"]
@@ -337,7 +337,7 @@
 				type: "item"
 			}]
 			x: 6.5d
-			y: 1.0d
+			y: 1.5d
 		}
 		{
 			dependencies: ["76EA017B12E8F01B"]
@@ -362,7 +362,7 @@
 				type: "item"
 			}]
 			x: 4.5d
-			y: 1.0d
+			y: 1.5d
 		}
 		{
 			dependencies: ["4AB0DD227471FDBF"]
@@ -497,8 +497,8 @@
 					type: "item"
 				}
 			]
-			x: 5.5d
-			y: 3.0d
+			x: 9.0d
+			y: 0.0d
 		}
 		{
 			dependencies: ["1F81EA5E45424308"]
@@ -846,6 +846,72 @@
 			]
 			x: 0.0d
 			y: 6.0d
+		}
+		{
+			dependencies: ["76EA017B12E8F01B"]
+			icon: {
+				id: "draconicevolution:energy_core"
+			}
+			id: "677D0C23D53A77CA"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "0846E066332FBFCE"
+					table_id: 5036812014823277174L
+					type: "random"
+				}
+				{
+					id: "788EAA17663077E5"
+					type: "xp"
+					xp: 50
+				}
+			]
+			shape: "rsquare"
+			tasks: [{
+				id: "7EFDC209D199681D"
+				item: { count: 1, id: "draconicevolution:energy_core" }
+				type: "item"
+			}]
+			x: 5.5d
+			y: 1.5d
+		}
+		{
+			dependencies: ["35CC898E0E49FE58"]
+			hide_until_deps_complete: true
+			id: "1EECA19DF9CF6A0C"
+			optional: true
+			rewards: [
+				{
+					count: 5
+					id: "7A4E9CB6E67430E6"
+					item: {
+						count: 1
+						id: "fluxnetworks:flux_dust"
+					}
+					random_bonus: 5
+					type: "item"
+				}
+				{
+					id: "00E3D3B0B266F9FE"
+					type: "xp"
+					xp: 100
+				}
+			]
+			shape: "diamond"
+			tasks: [
+				{
+					id: "122A80350E32318A"
+					item: { count: 1, id: "xycraft_machines:extractor" }
+					type: "item"
+				}
+				{
+					id: "0E8994B88ABB9271"
+					item: { count: 1, id: "appflux:charged_redstone_block" }
+					type: "item"
+				}
+			]
+			x: -4.5d
+			y: 2.0d
 		}
 	]
 }

--- a/config/ftbquests/quests/lang/en_us/chapters/basic_power.snbt
+++ b/config/ftbquests/quests/lang/en_us/chapters/basic_power.snbt
@@ -17,6 +17,8 @@
 	quest.1BE26A00A420DAE3.quest_desc: ["In this mod, you'll need &aFlux Cores&r and &aFlux Blocks&r to craft the core parts of your network. Make a few of each!"]
 	quest.1BE26A00A420DAE3.quest_subtitle: "Of Cores you need these"
 	quest.1BE26A00A420DAE3.title: "The \"Core\" Crafting Materials"
+	quest.1EECA19DF9CF6A0C.quest_desc: ["Flux Dust can also be automated using &6XyCraft&r!\\n\\nPlace a charged redstone crystal block on bedrock, surround the crystal block with 4 obsidian on all sides and place the extractor on top.\\nThen just place a storage on top of the extractor and you're done!"]
+	quest.1EECA19DF9CF6A0C.title: "Automated Flux Dust"
 	quest.1F81EA5E45424308.quest_desc: ["If you're looking for different ways to get power out of your machines, this is where you can find it!\\n\\nThere are several options, both &awired&r and &9wireless&r, for transferring power."]
 	quest.1F81EA5E45424308.title: "&f&lTransferring Power"
 	quest.27A4FA38992448A0.quest_desc: [
@@ -79,8 +81,18 @@
 	quest.5F078A574A783B02.quest_desc: ["The first item you'll need to start your Flux Network is a &9Flux Plug&r.\\n\\nThe Plug is used to \"draw\" power from the block it is attached to. Aside from a small buffer, the Plug does not store any power itself, so don't worry about it zapping up all of your power.\\n\\nIt is suggested to place the Plug on a power storage block like an Energy Cube. It can connect to Cables, Pipes, or the output of any power producing machine.\\n\\nTo learn how to set up your first network, check the next quest!"]
 	quest.5F078A574A783B02.quest_subtitle: "Just plug it in!"
 	quest.5F078A574A783B02.title: "Starting Your Network"
+	quest.677D0C23D53A77CA.quest_desc: [
+		"&bDraconic Evolution&r adds a multiblock called the &dEnergy Core&r."
+		""
+		"While it may seem confusing, the final tier can hold &m9,223,372,036,854,775,808 FE&r basically infinite power."
+		""
+		"For more information check out the Draconic Evolution Chapter"
+		"{image:atm:textures/questpics/draconic/draconic_core_8on.png width:100 height:100 align:1}"
+	]
+	quest.677D0C23D53A77CA.quest_subtitle: "Basically Infinite Storage"
+	quest.677D0C23D53A77CA.title: "&9Draconic Evolution: &dEnergy Core"
 	quest.682034C680FDEDC2.quest_desc: [
-		"&9Mekanism's&r &aInduction Matrix&r is the ultimate way to store your power.\\n\\nIf you're looking for the best power storage in the game, check out the &aMekanism:&r &dReactors&r quest chapter.\\n"
+		"&9Mekanism's&r &aInduction Matrix&r is one of the best ways to store your power.\\n\\nIf you're looking for the best power storage Mekanism has to offer, check out the &aMekanism:&r &dReactors&r quest chapter.\\n"
 		"{image:atm:textures/questpics/mek/mek_induction_matrix_small.png width:125 height:150 align:center fit:true}"
 	]
 	quest.682034C680FDEDC2.title: "More Power Storage"


### PR DESCRIPTION
 - Added New Quest "Draconic Evolution: Energy Core" with information about the energy core and referring users to the main quest
 - Added New Optional Quest "Automated Flux Dust" with information about automating flux dust using XyCraft
 - More Power Storage: Replaced "is the ultimate way" with "is one of the best ways", "in the game" with "Mekanism has to offer"
 
 ---
 
 This was made by @wrobber1, I just made the PR for them