### PR TITLE
Add Compressed recipe for ATM/Vib alloy, 1x to 7x

### DIFF
--- a/kubejs/server_scripts/modpack/atm_alloys.js
+++ b/kubejs/server_scripts/modpack/atm_alloys.js
@@ -100,6 +100,19 @@ ServerEvents.recipes(allthemods => {
         9000000000,
         'vibranium_allthemodium_alloy_block'
     );
+    for (let i = 3; i < 10; i++) {
+        energizing(
+            { item: `allthecompressed:vibranium_allthemodium_alloy_block_${i-2}x` },
+            [
+                { item: `allthecompressed:allthemodium_block_${i-2}x`},
+                { item: `allthecompressed:piglich_heart_block_${i-2}x` },
+                { item: `allthecompressed:nitro_crystal_block_${i}x` },
+                { item: `allthecompressed:piglich_heart_block_${i-2}x` },
+                { item: `allthecompressed:vibranium_block_${i-2}x` }],
+             9000000000 * Math.pow(3, i - 2),
+            `vibranium_allthemodium_alloy_block_${i-2}x`
+        );
+    }
 
     function enchanting_apparatus(output, pedestalItems, reagent, nbt, sourceCost, id) {
         let recipe = {


### PR DESCRIPTION
Added compression recipes for vibranium_allthemodium_alloy_block from 1x to 7x.

Each tier multiplies recipe energy ×3 (but raw crafting would be ×9), so every tier gives a 66.67% reduction vs making 9 of the previous tier and an exponential cumulative saving vs starting from base blocks. For 7x -> 19.68 TFE.