### PR TITLE
fix: Adjust Containment Jar Blacklist to not be overly broad

### DIFF
--- a/kubejs/server_scripts/Tweaks/tags.js
+++ b/kubejs/server_scripts/Tweaks/tags.js
@@ -137,7 +137,7 @@ ServerEvents.tags('entity_type', allthemods => {
     allthemods.add('c:bosses', [
       "eternal_starlight:starlight_golem",
       "eternal_starlight:the_gatekeeper"
-    ])
+  ])}
     
   allthemods.add('allthemods:jank_blacklist', [
     "@iceandfire",


### PR DESCRIPTION
I believe the intention of adding the Containment Jar blacklist to the jank blacklist was to prevent a specific issue with excessive trading with the Bee Queen. However, it has come to my attention that it covers too many things, such as Marid Crushers.

I've separated the jar blacklist from the jank blacklist because of this. Currently it only contains the Bee Queen, but feel free to add any other mobs you feel should not go into Containment Jars.