### PR TITLE
feat: Replace Eternal Starlight items in custom recipes

### DIFF
--- a/kubejs/server_scripts/Tweaks/tags.js
+++ b/kubejs/server_scripts/Tweaks/tags.js
@@ -75,6 +75,11 @@ ServerEvents.tags('item', allthemods => {
     '#c:storage_blocks/fire_essence',
     '#c:storage_blocks/water_essence'
   ])
+  // Eldritch Chalices
+  allthemods.add('allthemods:eldritch_chalices', [
+	'occultism:eldritch_chalice',
+	'occultism:celestial_chalice'
+  ])
 
   // Bibliocraft compat
   // Ars Elemental Books

--- a/kubejs/server_scripts/modpack/att_items.js
+++ b/kubejs/server_scripts/modpack/att_items.js
@@ -12,7 +12,7 @@ ServerEvents.recipes(allthemods => {
     I: 'allthemodium:piglich_heart_block',
     B: 'productivebees:spawn_egg_configurable_bee[entity_data={id:"productivebees:configurable_bee",type:"productivebees:soul_lava"}]',
 	  G: 'cataclysm:abyssal_sacrifice',
-    E: Platform.isLoaded("eternal_starlight") ? 'eternal_starlight:chain_of_souls' : 'ftbquests:missing_item[ftbquests:missing_item="eternal_starlight:chain_of_souls"]'
+    E: Platform.isLoaded("eternal_starlight") ? 'eternal_starlight:chain_of_souls' : 'draconicevolution:chaotic_core'
   }).id('allthemods:allthetweaks/dragon_soul')
 
  // Improbable Probability Device

--- a/kubejs/server_scripts/modpack/runic_multis/controllers.js
+++ b/kubejs/server_scripts/modpack/runic_multis/controllers.js
@@ -61,7 +61,17 @@ ServerEvents.recipes(allthemods => {
             main: 'eternal_starlight:loot_bag[eternal_starlight:loot_table="eternal_starlight:bosses/lunar_monstrosity"]',
             secondary: 'alltheores:enderium_gear'
         })
-    }
+    } else {
+		runic_controllers.push({
+            id: 'modern_industrialization:star_altar',
+            aureal: 200000,
+            blood: 1000000,
+            souls: 10000,
+            xp: 75000,
+            main: '#allthemods:eldritch_chalices',
+            secondary: 'alltheores:enderium_gear'
+        })
+	}
 
     for (let item of runic_controllers) {
         allthemods.recipes.modern_industrialization.auto_forge(512, 300)
@@ -373,7 +383,7 @@ ServerEvents.generateData('after_mods', allthemods => {
             },
             forge_tier: 5,
             inputs: [
-                { amount: 1, ingredient: Ingredient.of(Platform.isLoaded("eternal_starlight") ? 'eternal_starlight:loot_bag[eternal_starlight:loot_table="eternal_starlight:bosses/lunar_monstrosity"]' : 'ftbquests:missing_item[ftbquests:missing_item="eternal_starlight:loot_bag"]').toJson() },
+                { amount: 1, ingredient: Ingredient.of(Platform.isLoaded("eternal_starlight") ? 'eternal_starlight:loot_bag[eternal_starlight:loot_table="eternal_starlight:bosses/lunar_monstrosity"]' : '#allthemods:eldritch_chalices').toJson() },
                 { amount: 1, ingredient: Ingredient.of('enderio:z_logic_controller').toJson() },
                 { amount: 1, ingredient: Ingredient.of('alltheores:enderium_gear').toJson() },
                 { amount: 1, ingredient: Ingredient.of('forbidden_arcanus:mundabitur_dust').toJson() },

--- a/kubejs/server_scripts/modpack/runic_multis/recipes/runic_crucible.js
+++ b/kubejs/server_scripts/modpack/runic_multis/recipes/runic_crucible.js
@@ -21,7 +21,7 @@ ServerEvents.recipes(allthemods => {
     allthemods.recipes.modern_industrialization.runic_crucible(32, 100)
         .itemIn('4x forbidden_arcanus:corrupti_dust')
         .itemIn('forbidden_arcanus:soul')
-        .itemIn(Platform.isLoaded("eternal_starlight") ? '4x eternal_starlight:trapped_soul' : 'ftbquests:missing_item[ftbquests:missing_item="eternal_starlight:trapped_soul"]')
+        .itemIn(Platform.isLoaded("eternal_starlight") ? '4x eternal_starlight:trapped_soul' : '4x oritech:wither_crop_block')
         .fluidIn("2500x starbunclemania:source_fluid")
         .itemOut('forbidden_arcanus:corrupt_soul')
 


### PR DESCRIPTION
These are some of my ideas that I had for replacing the Eternal Starlight items in recipes that would be affected by its removal. Namely: Chaotic Core from Draconic Evolution for the Dragon Soul instead of the Chain of Souls (An alternative idea is to replace the Chain of Souls with the Tidal Claws...if doing that it would make sense to replace the Abyssal Sacrifice with something else)
<img width="459" height="187" alt="image" src="https://github.com/user-attachments/assets/546f7c68-9c53-4bef-a610-1be2d8408e75" />
Eldritch/Celestial Chalice from Occultism instead of the Loot Bag for the Runic Star Altar
<img width="771" height="340" alt="image" src="https://github.com/user-attachments/assets/602e1c5e-fe7c-4acd-963b-dde326374510" />
<img width="708" height="353" alt="image" src="https://github.com/user-attachments/assets/36f9a143-47d7-4815-96fe-53501a878dc9" />
<img width="512" height="343" alt="image" src="https://github.com/user-attachments/assets/d29d7c6c-ddf1-4137-93dc-6cea7c4fd2cc" />
<img width="545" height="312" alt="image" src="https://github.com/user-attachments/assets/3e97b72b-15d0-448d-a7d7-494407360726" />
One alternative idea I had in case you don't feel like the Eldritch Chalice is a good idea is The Immolator from Cataclysm, or, if you don't want to have 3 Cataclysm bosses be required for the altar (those being Ignis, Harbinger (though you need harbinger for other ATM Star parts anyway), and Maledictus), just The Annihilator
Soul Flowers from Oritech for Corrupt Lost Souls in the Runic Crucible instead of Trapped Souls
<img width="647" height="140" alt="image" src="https://github.com/user-attachments/assets/33a7273e-afb4-49d6-ac35-d3ea3c917acf" />
Feel free to overrule any of these ideas, as well as suggesting alternate ones. Could even add ElementalCraft just to appease Lego and use some item from that mod.