### PR TITLE
Move DarkModeEverywhere button to prevent overlap

### DIFF
--- a/config/darkmodeeverywhere-client.toml
+++ b/config/darkmodeeverywhere-client.toml
@@ -58,10 +58,10 @@ METHOD_SHADER_DUMP = false
 ["Inventory Button"]
 	#Pixels away from the left of the GUI in the x axis
 	#Range: > 0
-	X = 2
+	X = 50
 	#Pixels away from the bottom of the GUI in the y axis
 	#Range: > 0
-	Y = 32
+	Y = 7
 
 ["Main Menu Button"]
 	#Enabled


### PR DESCRIPTION
When using JEI's lookup history menu, the Dark Mode button overlaps with the history, instead, moving the button down next to the other JEI button is probably best.

With these new values it looks like this in the inventory:
<img width="449" height="181" alt="image" src="https://github.com/user-attachments/assets/f071337c-09c5-4db4-9047-8f901aa7a93a" />
