### PR TITLE
Update default inventory button locations

### DIFF
--- a/config/accessories.json5
+++ b/config/accessories.json5
@@ -1,0 +1,41 @@
+{
+	"useExperimentalCaching": false,
+	"clientOptions": {
+		"equipControl": "MUST_NOT_CROUCH",
+		"forceNullRenderReplacement": false,
+		"disableEmptySlotScreenError": false,
+		"showCosmeticAccessories": true,
+		"disabledDefaultRenders": []
+	},
+	"screenOptions": {
+		"selectedScreenType": "ORIGINAL",
+		"showUnusedSlots": false,
+		"allowSlotScrolling": true,
+		"inventoryButtonOffset": {
+			"x": 28,
+			"y": 57
+		},
+		"creativeInventoryButtonOffset": {
+			"x": 96,
+			"y": 6
+		},
+		"isDarkMode": false,
+		"showEquippedStackSlotType": true,
+		"entityLooksAtMouseCursor": false,
+		"allowSideBarCraftingGrid": true,
+		"showGroupTabs": true,
+		"hoveredOptions": {
+			"brightenHovered": true,
+			"cycleBrightness": true,
+			"line": false,
+			"clickbait": false
+		},
+		"unHoveredOptions": {
+			"renderUnHovered": true,
+			"darkenUnHovered": true,
+			"darkenedBrightness": 0.5,
+			"darkenedOpacity": 1.0
+		}
+	},
+	"modifiers": []
+}

--- a/config/aether-client.toml
+++ b/config/aether-client.toml
@@ -1,0 +1,5 @@
+[Gui]
+	#The x-coordinate of the accessories button in the inventory and accessories menus
+	"Button x-coordinate in inventory menus" = 28
+	#The x-coordinate of the accessories button in the accessories menu
+	"Button x-coordinate in accessories menu" = 10

--- a/config/cosmeticarmorreworked-client.toml
+++ b/config/cosmeticarmorreworked-client.toml
@@ -1,0 +1,18 @@
+#These settings only affects client
+[Client]
+	#The vertical pixel distance from the origin point of player inventoy gui
+	# Default: 67
+	# Range: > -2147483648
+	CosArmorGuiButton_Top = 68
+	#The horizontal pixel distance from the origin point of player inventory gui
+	# Default: 59
+	# Range: > -2147483648
+	CosArmorToggleButton_Left = 60
+	#The horizontal pixel distance from the origin point of creative inventory gui
+	# Default: 95
+	# Range: > -2147483648
+	CosArmorCreativeGuiButton_Left = 96
+	#The vertical pixel distance from the origin point of creative inventoy gui
+	# Default: 38
+	# Range: > -2147483648
+	CosArmorCreativeGuiButton_Top = 40

--- a/config/curios-client.toml
+++ b/config/curios-client.toml
@@ -1,0 +1,10 @@
+#Client only settings, mostly things related to rendering
+[client]
+	#The X-Offset for the Creative Curios GUI button
+	# Default: 0
+	# Range: -100 ~ 100
+	creativeButtonXOffset = -1
+	#The Y-Offset for the Creative Curios GUI button
+	# Default: 0
+	# Range: -100 ~ 100
+	creativeButtonYOffset = -1


### PR DESCRIPTION
Fixes #3818.

This change moves the default positions for several inventory buttons. The main difference is that the Accessories button is moved to just above the Aether button so that it no longer overlaps with the Apothic Attributes button. Some other button locations are adjusted slightly to improve spacing.

Screenshots showcasing the differences can be seen below.

### Before:

<img width="3840" height="2019" alt="2026-03-25_16 32 49" src="https://github.com/user-attachments/assets/639fe826-a06d-4a6c-ac1b-a15f80342fb2" />
<img width="3840" height="2019" alt="2026-03-25_16 33 01" src="https://github.com/user-attachments/assets/2e6a5162-da7d-4342-8153-758e75b0f7af" />
<img width="3840" height="2019" alt="2026-03-25_16 33 08" src="https://github.com/user-attachments/assets/80eb86ff-d3c6-4a99-b886-e585b5084759" />
<img width="3840" height="2019" alt="2026-03-25_16 33 19" src="https://github.com/user-attachments/assets/559ad650-bb31-4f40-8cb8-43d49b625648" />
<img width="3840" height="2019" alt="2026-03-25_16 33 26" src="https://github.com/user-attachments/assets/01ae773d-6061-40e5-bb70-47daf3543b75" />
<img width="3840" height="2019" alt="2026-03-25_16 33 38" src="https://github.com/user-attachments/assets/bcae9357-cc1a-4505-aabc-72de0d6368b9" />
<img width="3840" height="2019" alt="2026-03-25_16 34 47" src="https://github.com/user-attachments/assets/22b047fc-1193-4886-b384-c18437ef82e1" />


### After:

<img width="3840" height="2019" alt="2026-03-25_16 42 33" src="https://github.com/user-attachments/assets/880d6622-5449-424a-8ef4-9f0cc7efbadb" />
<img width="3840" height="2019" alt="2026-03-25_16 42 41" src="https://github.com/user-attachments/assets/a3a0e8ab-c214-4eef-ac39-d3bab64899c3" />
<img width="3840" height="2019" alt="2026-03-25_16 42 48" src="https://github.com/user-attachments/assets/1f7b6178-7528-4443-b7f9-f276c7376beb" />
<img width="3840" height="2019" alt="2026-03-25_16 43 01" src="https://github.com/user-attachments/assets/aefbe6b8-113c-4e96-93c2-3951cd4390e5" />
<img width="3840" height="2019" alt="2026-03-25_16 43 09" src="https://github.com/user-attachments/assets/77ff154b-7eed-483a-b5f2-45ed5b00d518" />
<img width="3840" height="2019" alt="2026-03-25_16 43 17" src="https://github.com/user-attachments/assets/f8a51efd-7ea5-4789-988c-8f7a23e2c8ba" />
<img width="3840" height="2019" alt="2026-03-25_16 43 31" src="https://github.com/user-attachments/assets/dc9a3530-6e17-486b-9a7b-89fc482b65ec" />