### PR TITLE
Rebalance Oritech Generators

### DIFF
--- a/config/oritech-config.json5
+++ b/config/oritech-config.json5
@@ -62,25 +62,25 @@
 			"energyCapacity": 50000,
 			"maxEnergyInsertion": 0,
 			"maxEnergyExtraction": 256,
-			"energyPerTick": 32
+			"energyPerTick": 64
 		},
 		"bioGeneratorData": {
-			"energyCapacity": 100000,
-			"maxEnergyInsertion": 0,
-			"maxEnergyExtraction": 512,
-			"energyPerTick": 64
-		},
-		"lavaGeneratorData": {
-			"energyCapacity": 100000,
-			"maxEnergyInsertion": 0,
-			"maxEnergyExtraction": 512,
-			"energyPerTick": 64
-		},
-		"fuelGeneratorData": {
-			"energyCapacity": 250000,
+			"energyCapacity": 400000,
 			"maxEnergyInsertion": 0,
 			"maxEnergyExtraction": 2048,
 			"energyPerTick": 256
+		},
+		"lavaGeneratorData": {
+			"energyCapacity": 400000,
+			"maxEnergyInsertion": 0,
+			"maxEnergyExtraction": 2048,
+			"energyPerTick": 256
+		},
+		"fuelGeneratorData": {
+			"energyCapacity": 1000000,
+			"maxEnergyInsertion": 0,
+			"maxEnergyExtraction": 16000,
+			"energyPerTick": 2048
 		},
 		"steamEngineData": {
 			"energyCapacity": 100000,
@@ -91,10 +91,10 @@
 			"stopOnWaterFull": true
 		},
 		"solarGeneratorData": {
-			"energyCapacity": 100000,
+			"energyCapacity": 1000000,
 			"maxEnergyInsertion": 0,
-			"maxEnergyExtraction": 256,
-			"energyPerTick": 32
+			"maxEnergyExtraction": 25600,
+			"energyPerTick": 1600
 		}
 	},
 	"laserArmConfig": {


### PR DESCRIPTION
## Goal of This PR
- Adjust Oritech generators so that ATM10 players can consider them as one viable option during the mid-game stage.


## Non-Goals of This PR
- Making Oritech generators overpowered
- Changing the energy consumption of all Oritech machines
- Adjusting the balance of other mods


## Item-Fuel-Based Generators

### Current Values

| Mod + Name | FE/t | Capacity | Transfer Rate |
| :-: | -: | -: | -: |
| Oritech Basic Generator | 32 | 50000 | 256 |
| Powah Starter Furnator | 80 | 20000 | 240 |
| Powah Basic Furnator | 160 | 80000 | 480 |

### Desired Direction for Improvement

I do not think these need to outperform the Powah Starter Furnator. However, considering that they use the same fuel, Coal, their FE/t output is currently too low. Therefore, I believe it would be best to increase only their energy output while leaving the other factors as their respective unique characteristics.

### Proposed Changes Included in This PR

| Mod + Name | FE/t | Capacity | Transfer Rate |
| :-: | -: | -: | -: |
| Oritech Basic Generator | **64** | 50000 | 256 |
| Powah Starter Furnator | 80 | 20000 | 240 |
| Powah Basic Furnator | 160 | 80000 | 480 |


## Lava-Based Generators

### Current Values

| Mod + Name | FE/t | Capacity | Transfer Rate |
| :-: | -: | -: | -: |
| Oritech Lava Generator | 64 | 100000 | 512 |
| Powah Starter Magmator | 80 | 20000 | 240 |
| Powah Basic Magmator | 160 | 80000 | 480 |
| Powah Hardened Magmator | 400 | 200000 | 1600 |

### Desired Direction for Improvement

From this point onward, all Oritech generators discussed are fundamentally multiblock structures. This means they are less space-efficient compared to other generators.

The Oritech Lava Generator has a size of 1x1x2. From that perspective, I believe it should be more efficient than the Powah Basic Magmator.

### Proposed Changes Included in This PR

| Mod + Name | FE/t | Capacity | Transfer Rate |
| :-: | -: | -: | -: |
| Oritech Lava Generator | **256** | **400000** | **2048** |
| Powah Starter Magmator | 80 | 20000 | 240 |
| Powah Basic Magmator | 160 | 80000 | 480 |
| Powah Hardened Magmator | 400 | 200000 | 1600 |

### Notes

1. The Oritech Lava Generator and the Oritech Bio Generator are essentially twin counterparts; they simply use different fuels. For that reason, I have adjusted the Oritech Bio Generator to the same values as well.
1. By adding data, it is possible to allow the Oritech Lava Generator to accept fluids other than Lava. For example, something like Allthemodium’s Soul Lava could be added. However, in Oritech, when the fuel quality changes, the amount of FE generated per tick remains the same; only the number of ticks for which energy is generated—in other words, the burn time—changes.


## Solar-Based Generators

### Current Values

| Mod + Name | FE/t | Capacity | Transfer Rate |
| :-: | -: | -: | -: |
| Oritech Solar Generator (core 3) | 32*3=96 | 100000 | 256 |
| Powah Hardened Solar Panel | 400 | 200000 | 1600 |
| Oritech Solar Generator (core 4) | 32*4=128 | 100000 | 256 |
| Powah Blazing Solar Panel | 1500 | 800000 | 6000 |
| Oritech Solar Generator (core 5) | 32*5=160 | 100000 | 256 |
| Oritech Solar Generator (core 6) | 32*6=192 | 100000 | 256 |
| Oritech Solar Generator (core 7) | 32*7=224 | 100000 | 256 |
| Powah Niotic Solar Panel | 5000 | 2000000 | 20000 |
| Powah Spirited Solar Panel | 16000 | 8000000 | 64000 |
| Powah Nitro Solar Panel | 50000 | 40000000 | 200000 |

### Desired Direction for Improvement

The Oritech Solar Generator is fundamentally a 3x3x2 multiblock structure. In the same amount of space required to place one Oritech Solar Generator, a player could place nine Powah Solar Panels.

In addition, Oritech has seven tiers of machine cores, and each Oritech Solar Generator requires 16 of them. The energy output is calculated by multiplying the shared base value by the average tier value of the installed machine cores.

Of course, each player may approach progression differently, but I would assume that by the time a player has progressed far enough to build an Oritech Solar Generator, they would likely be using tier 3 or tier 4 machine cores. For that reason, the current-value table above only lists values starting from tier 3.

The balance direction I had in mind is as follows:

An Oritech Solar Generator with tier 3 cores should be roughly on par with, or slightly better than, a Powah Hardened Solar Panel. Starting from tier 4 cores, it should be better. However, from tier 5 cores onward, I think it would be preferable for the cost-efficiency to fall off, making Powah the more appealing option at that point.

### Proposed Changes Included in This PR

| Mod + Name | FE/t | Capacity | Transfer Rate |
| :-: | -: | -: | -: |
| Oritech Solar Generator (core 3) | **1600**\*3=4800 | **1000000** | **25600** |
| Powah Hardened Solar Panel | 400 | 200000 | 1600 |
| Oritech Solar Generator (core 4) | **1600**\*4=6400 | **1000000** | **25600** |
| Powah Blazing Solar Panel | 1500 | 800000 | 6000 |
| Oritech Solar Generator (core 5) | **1600**\*5=8000 | **1000000** | **25600** |
| Oritech Solar Generator (core 6) | **1600**\*6=9600 | **1000000** | **25600** |
| Oritech Solar Generator (core 7) | **1600**\*7=11200 | **1000000** | **25600** |
| Powah Niotic Solar Panel | 5000 | 2000000 | 20000 |
| Powah Spirited Solar Panel | 16000 | 8000000 | 64000 |
| Powah Nitro Solar Panel | 50000 | 40000000 | 200000 |

For the solar generator, my comparison is based on the same footprint rather than a 1:1 block comparison, since the Oritech Solar Generator is a 3x3x2 multiblock.

Same-footprint comparison:
- 9x Powah Hardened Solar Panels: 3600 FE/t
- 1x Oritech Solar Generator with tier 3 cores: 4800 FE/t

This makes the Oritech option slightly stronger for the same footprint, while still requiring a multiblock setup and 16 machine cores.


## Fuel-Based Generators

### Current Values

| Mod + Name | FE/t | Capacity | Transfer Rate |
| :-: | -: | -: | -: |
| Oritech Fuel Generator | 256 | 250000 | 2048 |

### Desired Direction for Improvement

The first thing to note is that there is no clear control group for this generator. If I had to choose a similar generator, it would be Mekanism’s Gas-Burning Generator. However, while the Gas-Burning Generator’s efficiency differs depending on whether it uses Hydrogen or Ethene, the Oritech Fuel Generator has a fixed FE/t output regardless of the fuel used; only the burn time changes.

The Mekanism Gas-Burning Generator also changes its behavior depending on the amount of fuel remaining in its internal buffer, which makes a direct comparison difficult. For that reason, I did not include it in the comparison table.

The Oritech Fuel Generator is a 3x4x2 multiblock structure. It is significantly larger than the Lava Generator, but it also produces a corresponding amount of energy, which is why it can serve as a strong power-generation option before nuclear power.

Therefore, I believe the Oritech Fuel Generator should receive at least the same relative increase in performance as the Lava Generator.

### Proposed Changes Included in This PR

| Mod + Name | FE/t | Capacity | Transfer Rate |
| :-: | -: | -: | -: |
| Oritech Fuel Generator | **2048** | **1000000** | **16000** |

The Fuel Generator increase is larger than the Lava Generator increase because it is a much larger 3x4x2 multiblock and is positioned later in progression. However, I am open to lowering it to 1024 FE/t if 2048 FE/t is considered too high.


## Nuclear Power

### Current Values

```json
	"rfPerPulse": 1100,
```

### Opinion

This value has already been adjusted to be significantly higher than Oritech’s default value of 64. Since it already appears to have been balanced for ATM10, I will only mention it in this PR and will not propose any changes.


## Black Hole

### Current Values

```json
	"collectorEnergyStorage": 1000000,
	"blackHoleTachyonEnergy": 50000,
```

### Opinion

My assumption is that the Oritech developer designed this as something beyond even end-game content. However, given its extreme risk, the current return is so low that almost no one would want to use it.

Adjusting this value could make black-hole-based power generation into additional content for players who are looking for something unusual or experimental. However, as the person submitting this PR, I cannot know whether that aligns with the ATM10 development team’s intended direction, so I will simply mention it here and move on.

---

The exact numbers are not something I am strongly attached to. My main goal is to make Oritech generators a viable mid-game option in ATM10. If the team feels that some of these values are too high, I would be happy to adjust them.
