### PR TITLE
Mention Overdrive Module power usage in quest description

### DIFF
--- a/config/ftbquests/quests/lang/en_us/chapters/mi_electric.snbt
+++ b/config/ftbquests/quests/lang/en_us/chapters/mi_electric.snbt
@@ -21,7 +21,7 @@
 	quest.1745124F83D033B9.title: "Basic Components"
 	quest.18C0EF38430C3E67.quest_subtitle: "The Digital Age"
 	quest.1A84DF4478D55C41.quest_subtitle: "Same as steam as one"
-	quest.1B4CD5AC8F6C3307.quest_desc: ["The &#4497DBOverdrive module&r preserves the efficiency of the machine even when the recipe is not currently running. In return it locks the machine for the recipe."]
+	quest.1B4CD5AC8F6C3307.quest_desc: ["The &#4497DBOverdrive module&r preserves the efficiency of the machine even when the recipe is not currently running. In return, it locks the machine to its current recipe and makes it always use power."]
 	quest.1E0EF28175A7424F.quest_desc: ["Since you are already producing the steam, why not use it to make electricity. Simply slap down a &#6363DBTurbine&r and put &7steam&r in and pull &#DBDB63electricity&r out."]
 	quest.1E0EF28175A7424F.quest_subtitle: "Steam -> Electricity"
 	quest.1F21B578FAF4CCAC.quest_subtitle: "Same as steam as one"


### PR DESCRIPTION
MI machines locked to a recipe with Overdrive Modules always use power even if they are not running, but that was not mentioned in the quest description.