### PR TITLE
Resolve conflicting recipes in Oritech Foundry

### DIFF
--- a/kubejs/server_scripts/mods/Oritech/recipes.js
+++ b/kubejs/server_scripts/mods/Oritech/recipes.js
@@ -94,6 +94,26 @@
         // Cheaty alloys
         allthemods.remove({id: 'oritech:crafting/alloy/steel'})
         allthemods.remove({id: 'oritech:crafting/alloy/electrum'})
+		
+		// Resolve conflict between Infused Alloy and Redstone Alloy
+		allthemods.custom({
+		    "type": "oritech:foundry",
+		    "ingredients": [
+			  {
+			    "tag": "c:storage_blocks/redstone"
+			  },
+			  {
+			    "tag": "c:storage_blocks/copper"
+			  }
+		    ],
+		    "results": [
+			  {
+			    "count": 1,
+			    "id": "enderio:redstone_alloy_block"
+			  }
+		    ],
+		    "time": 1080
+		}).id("oritech:foundry/alloy/compat/enderio/redstonealloy")
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.


### PR DESCRIPTION
Particularly, with Infused Alloy and Redstone Alloy. My solution is to make the Foundry handle making Redstone Alloy Blocks.
<img width="639" height="450" alt="image" src="https://github.com/user-attachments/assets/7b3ca666-a81b-40e4-9a76-b6a8c505a42e" />