### PR TITLE
More Expensive Create Infuser

### DIFF
--- a/kubejs/server_scripts/mods/Create Enchantment Industry/recipes.js
+++ b/kubejs/server_scripts/mods/Create Enchantment Industry/recipes.js
@@ -1,0 +1,40 @@
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
+
+ServerEvents.recipes(allthemods => {
+   if (Item.exists("apotheosis:god_fused_pearl")) {
+    allthemods
+      .shaped(Item.of(`create_enchantment_industry:infuser`), [" B ", " S ", "NGN"], {
+        B: `#c:plates/brass`,
+		S: `create:spout`,
+		N: `create:nixie_tube`,
+		G: `apotheosis:god_fused_pearl`
+      })
+      .id("create_enchantment_industry:crafting/infuser")
+    }
+	else { 
+		allthemods.custom({
+			"type": "apothic_enchanting:infusion",
+			"input": {
+				"item": "create:spout"
+			},
+			"max_requirements": {
+				"arcana": 60.0,
+				"eterna": 100.0,
+				"quanta": 11.0
+			},
+			"requirements": {
+				"arcana": 58.75,
+				"eterna": 100.0,
+				"quanta": 9.65
+			},
+			"result": {
+				"count": 1,
+				"id": "create_enchantment_industry:infuser"
+			}
+		}).id("create_enchantment_industry:crafting/infuser")
+	}
+})
+
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.


### PR DESCRIPTION
Intended to push Create: Enchantment Industry's Infuser to late game Apothic Enchanting, roughly around where you'd get the Enchanting Table of the Raven in ATM11 (ATM10 may have this too if the update isn't intentionally held off). Doing this because I felt like it was too cheap for being able to bypass the maximum requirements of infusions, plus can bypass Max Eterna set by World Tiers in the A World in Tiers backport of Apotheosis (an update currently not in the pack)

Offers two possible options
- Primary way, make the Infuser cost a God-Fused Pearl to craft (requires the same updates as #4254)
<img width="447" height="197" alt="image" src="https://github.com/user-attachments/assets/1aa3d608-acfc-42bc-b3e8-9b21db70f4c9" />

- Fallback way, make the Infuser require an Infusion with the same conditions as God-Fused Pearl if God-Fused Pearl doesn't exist 
<img width="567" height="197" alt="image" src="https://github.com/user-attachments/assets/901ae1a2-4155-4aad-9531-0390f9cc688a" />
If preferred, you may instead use the fallback way even if God-Fused Pearl exists