### PR TITLE
Support using EvilCraft blood on Irons recipes (fix #4296)

### DIFF
--- a/kubejs/server_scripts/mods/Irons Spells Spellbooks/Recipes.js
+++ b/kubejs/server_scripts/mods/Irons Spells Spellbooks/Recipes.js
@@ -1,11 +1,76 @@
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
 
+ServerEvents.tags('fluid', allthemods => {
+  allthemods.add('atm10:blood', ['evilcraft:blood', 'irons_spellbooks:blood']);
+});
+
 ServerEvents.recipes(allthemods => {
-    let fill = allthemods.recipes.irons_spellbooks.alchemist_cauldron_fill
-	
-	fill("1000x minecraft:water", "reliquary:emperor_chalice", "reliquary:emperor_chalice", false, "irons_spellbooks:cast.generic.lightning")
-})
+  let fill = allthemods.recipes.irons_spellbooks.alchemist_cauldron_fill;
+
+  fill("1000x minecraft:water", "reliquary:emperor_chalice", "reliquary:emperor_chalice", false, "irons_spellbooks:cast.generic.lightning");
+
+  allthemods
+    .custom({
+      type: 'irons_spellbooks:alchemist_cauldron_empty',
+      fluid: {
+        amount: 250,
+        id: 'evilcraft:blood',
+      },
+      input: {
+        item: 'minecraft:glass_bottle',
+      },
+      result: {
+        count: 1,
+        id: 'irons_spellbooks:blood_vial',
+      },
+    })
+    .id('allthemods:irons_spellbooks/alchemist_cauldron/empty_blood_vial');
+
+  allthemods
+    .custom({
+      type: 'irons_spellbooks:alchemist_cauldron_brew',
+      base_fluid: {
+        amount: 1000,
+        id: 'evilcraft:blood',
+      },
+      byproduct: {
+        id: 'irons_spellbooks:bloody_vellum',
+      },
+      input: {
+        item: 'irons_spellbooks:hogskin',
+      },
+      results: [],
+    })
+    .id('allthemods:irons_spellbooks/alchemist_cauldron/soak_bloody_vellum');
+
+  allthemods
+    .custom({
+      'neoforge:conditions': [
+        {
+          type: 'neoforge:mod_loaded',
+          modid: 'create',
+        },
+      ],
+      type: 'create:filling',
+      ingredients: [
+        {
+          item: 'minecraft:glass_bottle',
+        },
+        {
+          type: 'neoforge:tag',
+          tag: 'atm10:blood',
+          amount: 250,
+        },
+      ],
+      results: [
+        {
+          id: 'irons_spellbooks:blood_vial',
+        },
+      ],
+    })
+    .id('irons_spellbooks:create_compat/create_fill_blood_vial');
+});
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.


### PR DESCRIPTION
This PR allows the Cauldron from Iron's Spells 'n Spellbooks to work as expected when it contains blood fluids from other mods.

Although blood cannot be inserted into the Cauldron directly with a bucket, it can still be transferred using fluid pipes. However, the Cauldron currently does not function unless the fluid is the blood provided by Iron's Spells 'n Spellbooks.

This PR resolves the compatibility issue through KubeJS code, allowing blood fluids from other mods to be recognized and processed correctly.

This is particularly useful since players already have large amounts of blood from EvilCraft for the Runic Multiblock. 

## See Also
- #4296