### PR TITLE
Blacklist Ore Hammers from Eternal Stella and allow Bone Keys to reset Trial Vaults

### DIFF
--- a/kubejs/server_scripts/Tweaks/tags.js
+++ b/kubejs/server_scripts/Tweaks/tags.js
@@ -119,8 +119,11 @@ ServerEvents.tags('item', allthemods => {
     "modern_industrialization:runic_enchanter"
   ])
   
-  // Trial Vault Repeatability for Decrepit Keys
-  allthemods.add("repeatable_trial_vaults:can_reset_trial_vaults","irons_spellbooks:decrepit_key")
+  // Trial Vault Repeatability for Iron's Spellbooks Boss Keys
+  allthemods.add("repeatable_trial_vaults:can_reset_trial_vaults", [
+	"irons_spellbooks:decrepit_key",
+	"irons_spellbooks:bone_key"
+  ])
 })
 
 ServerEvents.tags('entity_type', allthemods => {

--- a/kubejs/server_scripts/Tweaks/tags.js
+++ b/kubejs/server_scripts/Tweaks/tags.js
@@ -107,7 +107,8 @@ ServerEvents.tags('item', allthemods => {
     "modern_industrialization:iron_hammer",
     "modern_industrialization:steel_hammer",
     "modern_industrialization:netherite_hammer",
-    "modern_industrialization:diamond_hammer"
+    "modern_industrialization:diamond_hammer",
+	"#alltheores:ore_hammers"
   ])
 
   // Overdrive


### PR DESCRIPTION
The time has come for the Ore Hammers to be blacklisted.
Also, I considered removing Decrepit Key from the trial vault reset tag, considering Iron's Spellbooks added its own item to reset Trial Vaults (the Tincture of Forgetfulness), but I ultimately decided on staying consistent with the Repeatable Trial Vaults mod.