### PR TITLE
Protect Robit from Amber Bees and Ars Containment Jars

### DIFF
--- a/kubejs/server_scripts/Tweaks/tags.js
+++ b/kubejs/server_scripts/Tweaks/tags.js
@@ -151,6 +151,8 @@ ServerEvents.tags('entity_type', allthemods => {
       "eternal_starlight:the_gatekeeper"
     ])
   }
+
+  allthemods.add('c:capturing_not_supported', 'mekanism:robit');
     
   allthemods.add('allthemods:jank_blacklist', [
     "@iceandfire",


### PR DESCRIPTION
~~Please protect my little friend. He has committed no crimes.~~

## Description
Mekanism’s Robit is immune to various effects by default. However, interactions with other mods can still lead to some unintended—and rather unfortunate—situations. This PR addresses two such cases:

- If a Robit following a player encounters an Amber Bee, it can become trapped in amber. However, no bee makes use of an amber-encased Robit, and since Robits have no relevant drops, Wannabees have no reason to target them either.
~~Only my poor little friend suffers.~~
- If a player performs the Ritual of Containment while a Robit is following them, the Robit can accidentally become trapped in a Containment Jar. It can, of course, be released using Dispel—but chances are, the Robit was not the player’s intended target in the first place.

This PR protects Robits from these forms of containment, allowing them to continue following their players without being unexpectedly imprisoned. 