### PR TITLE
Fix Ice and Fire configs

### DIFF
--- a/config/iceandfire/iaf-common.json
+++ b/config/iceandfire/iaf-common.json
@@ -1,186 +1,181 @@
 {
   "dragon": {
-    "iceandfire.dragon.maxHealth": 1500.0,
-    "iceandfire.dragon.eggBornTime": 7200,
-    "iceandfire.dragon.maxPathingNodes": 5000,
-    "iceandfire.dragon.villagersFear": true,
-    "iceandfire.dragon.animalsFear": true,
-    "": {},
-    "iceandfire.dragon.generate.skeletons": true,
-    "iceandfire.dragon.generate.skeletonChance": 0.0033333333333333335,
-    "iceandfire.dragon.generate.denGoldAmount": 0.99,
-    "iceandfire.dragon.generate.oreRatio": 0.022222222222222223,
-    "iceandfire.dragon.griefing": true,
-    "iceandfire.dragon.tamedGriefing": false,
-    "iceandfire.dragon.flapNoiseDistance": 4,
-    "iceandfire.dragon.fluteDistance": 8,
-    "iceandfire.dragon.attackDamage": 37,
-    "iceandfire.dragon.attackDamageFire": 7.0,
-    "iceandfire.dragon.attackDamageIce": 6.5,
-    "iceandfire.dragon.attackDamageLightning": 5.5,
-    "iceandfire.dragon.maxFlight": 256,
-    "iceandfire.dragon.goldSearchLength": 30,
-    "iceandfire.dragon.canHealFromBiting": true,
-    "iceandfire.dragon.canDespawn": true,
-    "iceandfire.dragon.sleep": true,
-    "iceandfire.dragon.digWhenStuck": true,
-    "iceandfire.dragon.breakBlockCooldown": 5,
-    "iceandfire.dragon.targetSearchLength": 128,
-    "iceandfire.dragon.wanderFromHomeDistance": 40,
-    "iceandfire.dragon.hungerTickRate": 3000,
-    "iceandfire.dragon.blockBreakingDropChance": 0.1,
-    "iceandfire.dragon.explosiveBreath": false,
-    "iceandfire.dragon.chunkLoadSummonCrystal": true,
-    "iceandfire.dragon.dragonFlightSpeedMod": 1.0,
-    "iceandfire.dragon.maxTamedDragonAge": 128,
-    "iceandfire.dragon.maxBreathTimeMul": 2.0,
-    "iceandfire.dragon.loot.skull": true,
-    "iceandfire.dragon.loot.heart": true,
-    "iceandfire.dragon.loot.blood": true
+    "maxHealth": 1500.0,
+    "eggBornTime": 7200,
+    "maxPathingNodes": 5000,
+    "villagersFear": true,
+    "animalsFear": true,
+    "generate.skeletons": true,
+    "generate.skeletonChance": 0.0033333333333333335,
+    "generate.denGoldAmount": 0.99,
+    "generate.oreRatio": 0.022222222222222223,
+    "griefing": true,
+    "tamedGriefing": false,
+    "flapNoiseDistance": 4,
+    "fluteDistance": 8,
+    "attackDamage": 37,
+    "attackDamageFire": 7.0,
+    "attackDamageIce": 6.5,
+    "attackDamageLightning": 5.5,
+    "maxFlight": 256,
+    "goldSearchLength": 30,
+    "canHealFromBiting": true,
+    "canDespawn": true,
+    "sleep": true,
+    "digWhenStuck": true,
+    "breakBlockCooldown": 5,
+    "targetSearchLength": 128,
+    "wanderFromHomeDistance": 40,
+    "hungerTickRate": 3000,
+    "blockBreakingDropChance": 0.1,
+    "explosiveBreath": false,
+    "chunkLoadSummonCrystal": true,
+    "dragonFlightSpeedMod": 1.0,
+    "maxTamedDragonAge": 128,
+    "maxBreathTimeMul": 2.0,
+    "neutralToPlayer": false,
+    "enableBrushDragonScales": true,
+    "maxBrushScalesDropPerTime": 2,
+    "brushTimesMul": 1.0,
+    "loot.skull": true,
+    "loot.heart": true,
+    "loot.blood": true
   },
   "hippogryphs": {
-    "iceandfire.hippogryphs.spawn": true,
-    "iceandfire.hippogryphs.spawnWeight": 2,
-    "iceandfire.hippogryphs.fightSpeedMod": 1.0
+    "spawn": true,
+    "spawnWeight": 2,
+    "fightSpeedMod": 1.0
   },
   "pixie": {
-    "iceandfire.pixie.size": 5,
-    "iceandfire.pixie.stealItems": true
+    "size": 5,
+    "stealItems": true
   },
   "cyclops": {
-    "iceandfire.cyclops.spawnWanderingChance": 0.0011111111111111111,
-    "iceandfire.cyclops.sheepSearchLength": 17,
-    "iceandfire.cyclops.maxHealth": 650.0,
-    "iceandfire.cyclops.attackDamage": 25.0,
-    "iceandfire.cyclops.biteDamage": 50.0,
-    "iceandfire.cyclops.griefing": true
+    "spawnWanderingChance": 0.0011111111111111111,
+    "sheepSearchLength": 17,
+    "maxHealth": 650.0,
+    "attackDamage": 25.0,
+    "biteDamage": 50.0,
+    "griefing": true
   },
   "siren": {
-    "iceandfire.siren.maxHealth": 150.0,
-    "iceandfire.siren.maxSingTime": 12000,
-    "iceandfire.siren.timeBetweenSongs": 2000
+    "maxHealth": 150.0,
+    "maxSingTime": 12000,
+    "timeBetweenSongs": 2000
   },
   "gorgon": {
-    "iceandfire.gorgon.maxHealth": 300.0
+    "maxHealth": 300.0
   },
   "deathworm": {
-    "iceandfire.deathworm.spawnChance": 0.03333333333333333,
-    "iceandfire.deathworm.targetSearchLength": 48,
-    "iceandfire.deathworm.maxHealth": 100.0,
-    "iceandfire.deathworm.attackDamage": 5.0,
-    "iceandfire.deathworm.attackMonsters": true
+    "spawnChance": 0.03333333333333333,
+    "targetSearchLength": 48,
+    "maxHealth": 100.0,
+    "attackDamage": 5.0,
+    "attackMonsters": true
   },
   "cockatrice": {
-    "iceandfire.cockatrice.spawn": true,
-    "iceandfire.cockatrice.spawnWeight": 4,
-    "iceandfire.cockatrice.chickenSearchLength": 32,
-    "iceandfire.cockatrice.eggChance": 0.03333333333333333,
-    "iceandfire.cockatrice.maxHealth": 140.0,
-    "iceandfire.cockatrice.chickensLayRottenEggs": true
+    "spawn": true,
+    "spawnWeight": 4,
+    "chickenSearchLength": 32,
+    "eggChance": 0.03333333333333333,
+    "maxHealth": 140.0,
+    "chickensLayRottenEggs": true
   },
   "bird": {
-    "iceandfire.bird.spawnChance": 0.0125,
-    "iceandfire.bird.targetSearchLength": 48,
-    "iceandfire.bird.featherDropChance": 0.04,
-    "iceandfire.bird.featherAttackDamage": 1.0,
-    "iceandfire.bird.flockLength": 40,
-    "iceandfire.bird.flightHeight": 80,
-    "iceandfire.bird.attackAnimals": false
+    "spawnChance": 0.0125,
+    "targetSearchLength": 48,
+    "featherDropChance": 0.04,
+    "featherAttackDamage": 1.0,
+    "flockLength": 40,
+    "flightHeight": 80,
+    "attackAnimals": false
   },
   "troll": {
-    "iceandfire.troll.spawn": true,
-    "iceandfire.troll.spawnWeight": 60,
-    "iceandfire.troll.dropWeapon": true,
-    "iceandfire.troll.maxHealth": 500.0,
-    "iceandfire.troll.attackDamage": 20.0
-  },
-  "myrmex": {
-    "iceandfire.myrmex.pregnantTicks": 2500,
-    "iceandfire.myrmex.eggTicks": 3000,
-    "iceandfire.myrmex.larvaTicks": 35000,
-    "iceandfire.myrmex.colonySize": 80,
-    "iceandfire.myrmex.maximumWanderRadius": 50,
-    "iceandfire.myrmex.hiveIgnoreDaytime": false,
-    "iceandfire.myrmex.baseAttackDamage": 3.0
+    "spawn": true,
+    "spawnWeight": 60,
+    "dropWeapon": true,
+    "maxHealth": 500.0,
+    "attackDamage": 20.0
   },
   "amphithere": {
-    "iceandfire.amphithere.spawn": true,
-    "iceandfire.amphithere.spawnWeight": 50,
-    "iceandfire.amphithere.villagerSearchLength": 48.0,
-    "iceandfire.amphithere.tameTime": 400,
-    "iceandfire.amphithere.flightSpeed": 1.75,
-    "iceandfire.amphithere.maxHealth": 50.0,
-    "iceandfire.amphithere.attackDamage": 7.0
+    "spawn": true,
+    "spawnWeight": 50,
+    "villagerSearchLength": 48.0,
+    "tameTime": 400,
+    "flightSpeed": 1.75,
+    "maxHealth": 50.0,
+    "attackDamage": 7.0
   },
   "seaSerpent": {
-    "iceandfire.seaSerpent.spawnChance": 0.004,
-    "iceandfire.seaSerpent.griefing": true,
-    "iceandfire.seaSerpent.baseHealth": 20.0,
-    "iceandfire.seaSerpent.attackDamage": 4.0
+    "spawnChance": 0.004,
+    "griefing": true,
+    "baseHealth": 20.0,
+    "attackDamage": 4.0
   },
   "lich": {
-    "iceandfire.lich.spawn": true,
-    "iceandfire.lich.spawnWeight": 4,
-    "iceandfire.lich.spawnChance": 0.03333333333333333
+    "spawn": true,
+    "spawnWeight": 4,
+    "spawnChance": 0.03333333333333333
   },
   "hydra": {
-    "iceandfire.hydra.maxHealth": 450.0
+    "maxHealth": 450.0
   },
   "hippocampus": {
-    "iceandfire.hippocampus.spawnChance": 0.025,
-    "iceandfire.hippocampus.swimSpeedMod": 1.0
+    "spawnChance": 0.025,
+    "swimSpeedMod": 1.0
   },
   "ghost": {
-    "iceandfire.ghost.maxHealth": 140.0,
-    "iceandfire.ghost.attackDamage": 13.0,
-    "iceandfire.ghost.fromPlayerDeaths": true
+    "maxHealth": 140.0,
+    "attackDamage": 13.0,
+    "fromPlayerDeaths": true,
+    "alwaysSpawnFromChest": false
   },
   "tools": {
-    "iceandfire.tools.dragonFireAbility": true,
-    "iceandfire.tools.dragonIceAbility": true,
-    "iceandfire.tools.dragonLightningAbility": true,
-    "iceandfire.tools.dragonsteelFireDuration": 15,
-    "iceandfire.tools.dragonBloodFireDuration": 5,
-    "iceandfire.tools.dragonsteelFrozenDuration": 300,
-    "iceandfire.tools.dragonBloodFrozenDuration": 100,
-    "iceandfire.tools.phantasmalBladeAbility": true
+    "dragonFireAbility": true,
+    "dragonIceAbility": true,
+    "dragonLightningAbility": true,
+    "dragonsteelFireDuration": 15,
+    "dragonBloodFireDuration": 5,
+    "dragonsteelFrozenDuration": 300,
+    "dragonBloodFrozenDuration": 100,
+    "phantasmalBladeAbility": true,
+    "dragonLightningSearchRange": 10.0,
+    "dragonLightningDamageReduction": 0.5,
+    "dragonLightningMaxSearchCount": 10
   },
   "armors": {
-    "iceandfire.armors.dragonSteelBaseDamage": 45.0,
-    "iceandfire.armors.dragonsteelArmorToughness": 16.0,
-    "iceandfire.armors.dragonsteelHelmetArmor": 17,
-    "iceandfire.armors.dragonsteelHelmetDurability": 2760,
-    "iceandfire.armors.dragonsteelChestplateArmor": 22,
-    "iceandfire.armors.dragonsteelChestplateDurability": 4560,
-    "iceandfire.armors.dragonsteelLeggingsArmor": 19,
-    "iceandfire.armors.dragonsteelLeggingsDurability": 4400,
-    "iceandfire.armors.dragonsteelBootsArmor": 16,
-    "iceandfire.armors.dragonsteelBootsDurability": 4080,
-    "iceandfire.armors.dragonsteelArmorEnchantability": 130,
-    "iceandfire.armors.dragonsteelArmorKnockbackResistance": 0.25,
-    "iceandfire.armors.dragonSteelBaseDurability": 8000
+    "dragonSteelBaseDamage": 45.0,
+    "dragonSteelBaseDurability": 8000,
+    "dragonsteelArmorToughness": 16.0,
+    "dragonsteelHelmetArmor": 17,
+    "dragonsteelHelmetDurability": 2760,
+    "dragonsteelChestplateArmor": 22,
+    "dragonsteelChestplateDurability": 4560,
+    "dragonsteelLeggingsArmor": 19,
+    "dragonsteelLeggingsDurability": 4400,
+    "dragonsteelBootsArmor": 16,
+    "dragonsteelBootsDurability": 4080,
+    "dragonsteelArmorEnchantability": 130,
+    "dragonsteelArmorKnockbackResistance": 0.25
   },
   "worldgen": {
-    "iceandfire.worldgen.dangerousDistanceLimit": 1000.0,
-    "iceandfire.worldgen.generateFireDragonCaveChance": 1.0,
-    "iceandfire.worldgen.generateFireDragonRoostChance": 1.0,
-    "iceandfire.worldgen.generateIceDragonCaveChance": 1.0,
-    "iceandfire.worldgen.generateIceDragonRoostChance": 1.0,
-    "iceandfire.worldgen.generateLightningDragonCaveChance": 1.0,
-    "iceandfire.worldgen.generateLightningDragonRoostChance": 1.0,
-    "iceandfire.worldgen.generateCyclopsCaveChance": 1.0,
-    "iceandfire.worldgen.generateGorgonTempleChance": 1.0,
-    "iceandfire.worldgen.generateGraveYardChance": 1.0,
-    "iceandfire.worldgen.generateHydraCaveChance": 1.0,
-    "iceandfire.worldgen.generateMausoleumChance": 1.0,
-    "iceandfire.worldgen.generateMyemexHiveDesertChance": 1.0,
-    "iceandfire.worldgen.generateMyemexHiveJungleChance": 1.0,
-    "iceandfire.worldgen.generatePixieVillageChance": 1.0,
-    "iceandfire.worldgen.generateSirenIslandChance": 1.0
+    "dangerousDistanceLimit": 1000.0,
+    "generateFireDragonCaveChance": 1.0,
+    "generateFireDragonRoostChance": 1.0,
+    "generateIceDragonCaveChance": 1.0,
+    "generateIceDragonRoostChance": 1.0,
+    "generateLightningDragonCaveChance": 1.0,
+    "generateLightningDragonRoostChance": 1.0,
+    "generateCyclopsCaveChance": 1.0,
+    "generateGorgonTempleChance": 1.0,
+    "generateGraveYardChance": 1.0,
+    "generateHydraCaveChance": 1.0,
+    "generateMausoleumChance": 1.0,
+    "generatePixieVillageChance": 1.0,
+    "generateSirenIslandChance": 1.0
   },
   "misc": {
-    "iceandfire.misc.enableDragonSeeker": true,
-    "iceandfire.misc.dreadQueenMaxHealth": 1750.0
-  },
-  "version": 2
+    "enableDragonSeeker": true,
+    "dreadQueenMaxHealth": 1750.0
+  }
 }


### PR DESCRIPTION
At some point, Ice and Fire changed the format for their common configs. This meant that the configs applied were...not actually being applied properly, similarly to how Cataclysm configs were applied improperly, which I fixed at #4056. I am applying a similar fix here, bringing back the original configs that we had for this pack.