### PR TITLE
Reduce cobblestone and netherrack output from the ATM drills

### DIFF
--- a/kubejs/data/modern_industrialization/recipe/quarry/allthemodium.json
+++ b/kubejs/data/modern_industrialization/recipe/quarry/allthemodium.json
@@ -10,7 +10,8 @@
     "item_outputs": [
       {
         "item": "minecraft:cobblestone",
-        "amount": 64
+        "amount": 32,
+        "probability": 0.5
       },
       {
         "item": "minecraft:diorite",

--- a/kubejs/data/modern_industrialization/recipe/quarry/unobtainium.json
+++ b/kubejs/data/modern_industrialization/recipe/quarry/unobtainium.json
@@ -10,7 +10,8 @@
     "item_outputs": [
       {
         "item": "minecraft:netherrack",
-        "amount": 64
+        "amount": 32,
+        "probability": 0.5
       },
       {
         "item": "minecraft:blackstone",
@@ -60,7 +61,8 @@
       },
       {
         "item": "minecraft:cobblestone",
-        "amount": 64
+        "amount": 32,
+        "probability": 0.5
       },
       {
         "item": "minecraft:diorite",

--- a/kubejs/data/modern_industrialization/recipe/quarry/vibranium.json
+++ b/kubejs/data/modern_industrialization/recipe/quarry/vibranium.json
@@ -15,7 +15,8 @@
       },
       {
         "item": "minecraft:netherrack",
-        "amount": 64
+        "amount": 32,
+        "probability": 0.5
       },
       {
         "item": "minecraft:blackstone",


### PR DESCRIPTION
The old values, set when the ATM drills were first added, were based on an old version of Modern Industrialization where the copper and gold drills always output 64 cobblestone and 64 netherrack each per cycle.

When MI version 2.2.27 reduced the cobblestone and netherrack outputs from their own copper and gold drills to a 50% chance of 32 cobblestone and netherrack respectively, the output from the ATM drills was not adjusted.

This PR adjusts the cobblestone and netherrack outputs from ATM's Allthemodium, Vibranium, and Unobtainium drills to match the reduced output from MI's own drills.