### PR TITLE
fix: prevent Loot Pinata from duplicating soul shards

### DIFF
--- a/kubejs/server_scripts/mods/Occultism/fix_soul_shattered_duplication.js
+++ b/kubejs/server_scripts/mods/Occultism/fix_soul_shattered_duplication.js
@@ -1,0 +1,25 @@
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
+
+// Fix for AllTheMods/ATM-10 issue 4311.
+// Loot Pinata (Apotheosis) copies occultism:soul_shattered drops from Fracture Soul.
+// Each copy can resurrect a full mob, so one kill makes many mobs.
+// This handler removes every shard copy after the first. It touches no other item.
+
+if (!Platform.isClientEnvironment()) {
+  NativeEvents.onEvent("LOWEST", "net.neoforged.neoforge.event.entity.living.LivingDropsEvent", event => {
+    let shardSeen = false
+    let drops = event.getDrops()
+    let iterator = drops.iterator()
+    while (iterator.hasNext()) {
+      let stack = iterator.next().getItem()
+      if (stack.getId() == "occultism:soul_shattered") {
+        if (shardSeen) {
+          iterator.remove()
+        } else {
+          shardSeen = true
+        }
+      }
+    }
+  })
+}


### PR DESCRIPTION
## What

Adds a KubeJS server script that prevents the Apotheosis Loot Pinata affix from duplicating `occultism:soul_shattered` drops.

## Why

Issue #4311: a sword with the Loot Pinata affix and Occultism's Fracture Soul enchantment duplicates any mob with data. Fracture Soul drops one `occultism:soul_shattered` that stores the full entity NBT. When the pinata roll passes, it copies that shard up to 20 times. Each shard can be used in Ritual: Resurrect Mob to spawn a full mob, so one kill yields 20+ mobs.

## How

The script hooks `LivingDropsEvent` at `LOWEST` priority. The FestiveAffix runs at `LOW` priority and adds the pinata copies, so by `LOWEST` the copies are present. The handler removes every `occultism:soul_shattered` copy after the first. The single legitimate shard from Fracture Soul survives, but the duplication is broken. No other drop is touched.

## Scope

- New file: `kubejs/server_scripts/mods/Occultism/fix_soul_shattered_duplication.js`
- No existing file is modified.

If this helped, RawNuke welcomes sponsorship: https://github.com/sponsors/RawNuke