### PR TITLE
Fix #4322: Some quest typos

### DIFF
--- a/config/ftbquests/quests/lang/en_us/chapters/allthemodium.snbt
+++ b/config/ftbquests/quests/lang/en_us/chapters/allthemodium.snbt
@@ -101,7 +101,7 @@
 	quest.5AAF6CA41209B365.title: "&3Vibranium Tools"
 	quest.5B46B5BF4ADB2BE9.quest_desc: ["Yes it can make pathways don't worry!"]
 	quest.5B46B5BF4ADB2BE9.title: "&6Allthemodium &5Alloy &3Shovel"
-	quest.5BA986D7928BF09F.quest_desc: ["The Piglich is a Boss added by &6&lAllthemodium&r. \\n\\nHas he 1000 Hearts and currently has no attacks but trust me when he does they will be devastating! \\n\\nWhen killed he'll drop his Heart which will be needed for Alloys and the ATM Star! \\n\\n(Look into ways of farming them like with HNN or EnderIO!)"]
+	quest.5BA986D7928BF09F.quest_desc: ["The Piglich is a Boss added by &6&lAllthemodium&r. \\n\\nHe has 9999 Hearts and currently has no attacks but trust me when he does they will be devastating! \\n\\nWhen killed he'll drop his Heart which will be needed for Alloys and the ATM Star! \\n\\n(Look into ways of farming them like with HNN or EnderIO!)"]
 	quest.5BA986D7928BF09F.title: "Piglich Boss"
 	quest.5FA68047A3C05E80.quest_desc: ["15 Spellslots!"]
 	quest.5FA68047A3C05E80.title: "&5Unobtainium Spell Book"

--- a/config/ftbquests/quests/lang/en_us/chapters/bounty_board.snbt
+++ b/config/ftbquests/quests/lang/en_us/chapters/bounty_board.snbt
@@ -23,7 +23,7 @@
 	quest.2CA9394459C24012.quest_desc: ["Rotbeasts are Minibosses that spawn all over the Undergarden."]
 	quest.2CA9394459C24012.title: "Kill A Rotbeast"
 	quest.3371F9248D403664.title: "&l&cThe Nether Bounty:&r&e Wither Skeletons"
-	quest.3813F5C1760C3A79.quest_desc: ["Piglin Brutes being here might cause controversey but I consider them Minibosses. \\n\\nThey spawn in Bastions with regular Piglins but these are Hostile not Neutral. Personally I hate that, especially since if you hit them all Piglins will turn Hostile on you. \\n\\nThey have 50 Hearts and a Golden Axe to hit you. Usually Golden Axes barely do any damage, but when they use it, it is god somehow! \\n\\nThey drop nothing and act more like an obstacle for Bastions!"]
+	quest.3813F5C1760C3A79.quest_desc: ["Piglin Brutes being here might cause controversy but I consider them Minibosses. \\n\\nThey spawn in Bastions with regular Piglins but these are Hostile not Neutral. Personally I hate that, especially since if you hit them all Piglins will turn Hostile on you. \\n\\nThey have 50 Hearts and a Golden Axe to hit you. Usually Golden Axes barely do any damage, but when they use it, it is god tier somehow! \\n\\nThey drop nothing and act more like an obstacle for Bastions!"]
 	quest.3813F5C1760C3A79.title: "Kill A Piglin Brute"
 	quest.41C0948CD9D50322.quest_desc: ["Here you'll find all of the rewards you can get by slaying enemies."]
 	quest.41C0948CD9D50322.quest_subtitle: "Killing All The Things"

--- a/config/ftbquests/quests/lang/en_us/chapters/building_tips.snbt
+++ b/config/ftbquests/quests/lang/en_us/chapters/building_tips.snbt
@@ -55,7 +55,7 @@
 	quest.1FDC8725105D822A.quest_desc: ["The Kitchen holds many Blocks that can hold, preserve, and Cook Food! \\n\\nMost the Blocks that cook or prepare Food do need Energy, so check out the Electrical Set to learn more!"]
 	quest.1FDC8725105D822A.title: "Kitchen Set"
 	quest.2094D1CE4BA66091.quest_desc: ["Light is a very important part of any Base. \\n\\nIt keeps Monsters from Spawning, helps to see, and even adds more Color and life to your Builds! \\n\\nOr you can just use Night Vision but where's the fun in that!"]
-	quest.22D2CFDDB06C720C.quest_desc: ["Tools are very important in &2&lMinecraft&r but so is inventory space. So why not clear some space up by making a Paxel! \\nPaxels are a combination of Pickaxes (P), Axes (axe), and Shovels (els). \\n\\nThey can strip wood, make paths, and mine any blocks that same pickaxe/axe/shovel tier can!"]
+	quest.22D2CFDDB06C720C.quest_desc: ["Tools are very important in &2&lMinecraft&r but so is inventory space. So why not clear some space up by making a Paxel! \\nPaxels are a combination of Pickaxes (P), Axes (axe), and Shovels (els). \\n\\nThey can strip wood, make paths, and mine any blocks a pickaxe/axe/shovel of its tier can!"]
 	quest.22D2CFDDB06C720C.title: "Paxel"
 	quest.22E007025C19EC0A.quest_desc: ["&l&7Railcraft&r, along with Trains, adds some Stones for Decoration! \\n\\nQuarried and Abyssal Stone can be crafted together to make Polished, Chiseled, or Brick versions! \\n\\nAlso don't forget Stairs and Slabs! "]
 	quest.22E007025C19EC0A.title: "&l&7Railcraft&r Stones"

--- a/config/ftbquests/quests/lang/uk_ua/chapters/building_tips.snbt
+++ b/config/ftbquests/quests/lang/uk_ua/chapters/building_tips.snbt
@@ -55,7 +55,7 @@
 	quest.1FDC8725105D822A.quest_desc: ["The Kitchen holds many Blocks that can hold, preserve, and Cook Food! \\n\\nMost the Blocks that cook or prepare Food do need Energy, so check out the Electrical Set to learn more!"]
 	quest.1FDC8725105D822A.title: "Kitchen Set"
 	quest.2094D1CE4BA66091.quest_desc: ["Light is a very important part of any Base. \\n\\nIt keeps Monsters from Spawning, helps to see, and even adds more Color and life to your Builds! \\n\\nOr you can just use Night Vision but where's the fun in that!"]
-	quest.22D2CFDDB06C720C.quest_desc: ["Tools are very important in &2&lMinecraft&r but so is inventory space. So why not clear some space up by making a Paxel! \\nPaxels are a combination of Pickaxes (P), Axes (axe), and Shovels (els). \\n\\nThey can strip wood, make paths, and mine any blocks that same pickaxe/axe/shovel tier can!"]
+	quest.22D2CFDDB06C720C.quest_desc: ["Tools are very important in &2&lMinecraft&r but so is inventory space. So why not clear some space up by making a Paxel! \\nPaxels are a combination of Pickaxes (P), Axes (axe), and Shovels (els). \\n\\nThey can strip wood, make paths, and mine any blocks a pickaxe/axe/shovel of its tier can!"]
 	quest.22D2CFDDB06C720C.title: "Paxel"
 	quest.22E007025C19EC0A.quest_desc: ["&l&7Railcraft&r, along with Trains, adds some Stones for Decoration! \\n\\nQuarried and Abyssal Stone can be crafted together to make Polished, Chiseled, or Brick versions! \\n\\nAlso don't forget Stairs and Slabs! "]
 	quest.22E007025C19EC0A.title: "&l&7Railcraft&r Stones"


### PR DESCRIPTION
Fixed all typos mentioned in #4322, plus a couple more nearby I found, including an incorrect Piglich HP value.