### PR TITLE
Add missing Mekanism Crusher recipe: Dark Gem → Crushed Dark Gem (EvilCraft)

### DIFF
--- a/kubejs/server_scripts/mods/Mekanism/Evilcraft.js
+++ b/kubejs/server_scripts/mods/Mekanism/Evilcraft.js
@@ -1,0 +1,3 @@
+ServerEvents.recipes(e => {
+	e.custom({"type":"mekanism:crushing","input":{"count":1,"item":"evilcraft:dark_gem"},"output":{"count":1,"id":"evilcraft:dark_gem_crushed"}})
+})


### PR DESCRIPTION
## Summary

Adds a Mekanism Crusher recipe that converts EvilCraft's `dark_gem` into `dark_gem_crushed`.

## Motivation

Currently, `evilcraft:dark_gem` can be processed into `evilcraft:dark_gem_crushed` through **multiple** processing paths across the pack:

- Ars Nouveau — Crush Glyph
- Integrated Dynamics (Compat) — Mechanical Squeezer
- Occultism — Crusher Spirit
- Oritech — Fragmenting

However, the **Mekanism Crusher** — one of the pack's primary ore-processing machines — has **no corresponding recipe**. This is inconsistent with the rest of the pack's processing lines and forces players invested in a Mekanism-based factory to route Dark Gems through a different mod's machine just to get the crushed variant.

## Changes

Added a custom `mekanism:crushing` recipe via KubeJS (`e.custom`), since ATM10 doesn't ship the KubeJS Mekanism addon:
```js
js
ServerEvents.recipes(e => {
e.custom({
"type": "mekanism:crushing",
"input": { "count": 1, "item": "evilcraft:dark_gem" },
"output": { "count": 1, "id": "evilcraft:dark_gem_crushed" }
})
})
```

The recipe follows Mekanism's native `mekanism:crushing` JSON schema (`type` + `input` + `output`).

## Testing

- Verified the recipe appears in JEI when hovering over the Mekanism Crusher
- Confirmed in-game: inserting `evilcraft:dark_gem` into a Mekanism Crusher 
  outputs `evilcraft:dark_gem_crushed`
- No crashes or log errors on startup; recipe registers cleanly

## Pack Version

ATM10 v8.0