### PR TITLE
Disable new silver ore from Mekanism: More Machine

### DIFF
--- a/kubejs/data/mekmm/neoforge/biome_modifier/silver.json
+++ b/kubejs/data/mekmm/neoforge/biome_modifier/silver.json
@@ -1,0 +1,3 @@
+{
+    "type": "neoforge:none"
+}


### PR DESCRIPTION
This PR disables world generation for the Silver Ore added in the latest update of Mekanism: More Machine.

### Requirements
The following mod must be updated:

- Mekanism: More Machine 1.4.0 or later

### See Also
- https://github.com/AllTheMods/ATM-10/pull/4344
- https://github.com/AllTheMods/ATM-10-a/pull/32
- https://github.com/AllTheMods/All-the-Mons/pull/729

### References
- Mekanism: More Machine 1.4.0 changelog: https://www.curseforge.com/minecraft/mc-mods/mekanism-more-machine/files/8659501
- Original data file: https://github.com/lostmyself8/Mekanism-MoreMachine/blob/1.21.1/src/main/resources/data/mekmm/neoforge/biome_modifier/silver.json