### PR TITLE
Prevent infinite electrode durability via Mahou Tsukai Strengthening

### DIFF
--- a/config/mahoutsukai-server.toml
+++ b/config/mahoutsukai-server.toml
@@ -213,7 +213,12 @@
 
 	[projection.strengthening]
 		#Items that Strengthening won't work on
-		STRENGTHENING_ITEM_BLACKLIST = []
+		STRENGTHENING_ITEM_BLACKLIST = [
+			"modularbees:electrode_copper",
+			"modularbees:electrode_iron",
+			"modularbees:electrode_gold",
+			"modularbees:electrode_netherite",
+		]
 		#This is the cost of using the scroll
 		#Range: 0 ~ 100000000
 		STRENGTHENING_MANA_COST = 200


### PR DESCRIPTION
## Summary

Mahou Tsukai's Strengthening spell grants items with durability, such as tools and weapons, temporary protection from durability loss. This protection is normally limited by a finite number of uses, with the remaining uses being consumed when the strengthened item performs an applicable action.

## Issue

Modular Bees electrodes are consumed inside the Overclocker rather than used directly by a player. Consequently, their operation does not trigger the actions that consume Strengthening uses. At the same time, the Unbreakable property applied by Strengthening prevents the Overclocker from damaging the electrode.

This interaction effectively gives strengthened electrodes infinite durability, bypassing their intended consumption and replacement mechanics.

## Changes

Added all four Modular Bees electrodes to Mahou Tsukai's `STRENGTHENING_ITEM_BLACKLIST`:

- Copper Electrode
- Iron Electrode
- Gold Electrode
- Netherite Electrode

Strengthening can no longer be applied to these electrodes, closing the unintended cross-mod interaction without affecting its use on other items.