### PR TITLE
Prevent Potential ATM Ore Progression Bypasses Through Neo Vitae

### DIFF
--- a/config/neovitae/materials.json
+++ b/config/neovitae/materials.json
@@ -248,7 +248,7 @@
     "raw_tag": "c:raw_materials/allthemodium",
     "ingot_tag": "c:ingots/allthemodium",
     "dust_yield_from_ore": 3,
-    "generative": true,
+    "generative": false,
     "gen_ore": "",
     "gen_raw": ""
   },
@@ -1323,7 +1323,7 @@
     "raw_tag": "c:raw_materials/unobtainium",
     "ingot_tag": "c:ingots/unobtainium",
     "dust_yield_from_ore": 3,
-    "generative": true,
+    "generative": false,
     "gen_ore": "",
     "gen_raw": ""
   },
@@ -1439,7 +1439,7 @@
     "raw_tag": "c:raw_materials/vibranium",
     "ingot_tag": "c:ingots/vibranium",
     "dust_yield_from_ore": 3,
-    "generative": true,
+    "generative": false,
     "gen_ore": "",
     "gen_raw": ""
   },


### PR DESCRIPTION
## Before We Begin

I am not deeply experienced with Neo Vitae, and Java mod development is not my primary area of expertise. However, while reviewing the available code, configuration, and documentation, I noticed an interaction that appears capable of bypassing the intended acquisition progression for ATM ores. I am therefore submitting this pull request to address that possibility.

I have included direct references wherever reasonably possible so that the behavior described below can be checked against the relevant implementation. Nevertheless, this analysis is primarily based on my reading of the code rather than exhaustive in-game testing of every Neo Vitae mechanic and every possible mod interaction. I would greatly appreciate a careful review from contributors who are more familiar with Neo Vitae, AllTheModium, or the relevant Java implementation details. If I have misunderstood any part of the interaction, please feel free to correct me.

## Reason

### All three ATM progression materials are currently generative

ATM10 currently registers **Allthemodium, Vibranium, and Unobtainium** as Neo Vitae materials with `generative` set to `true`. Each definition also supplies an `ore_tag` for the corresponding ore blocks and a `raw_tag` for the corresponding raw-material items:

- [Allthemodium material definition: `ore_tag`, `raw_tag`, and `generative: true`](https://github.com/AllTheMods/ATM-10/blob/main/config/neovitae/materials.json#L237-L253)
- [Vibranium material definition: `ore_tag`, `raw_tag`, and `generative: true`](https://github.com/AllTheMods/ATM-10/blob/main/config/neovitae/materials.json#L1428-L1444)
- [Unobtainium material definition: `ore_tag`, `raw_tag`, and `generative: true`](https://github.com/AllTheMods/ATM-10/blob/main/config/neovitae/materials.json#L1312-L1328)

Neo Vitae's `getGenerativeMaterials()` method returns only materials for which `MaterialDefinition::isGenerative` is true. Consequently, the current ATM10 configuration makes all three ATM materials eligible for mechanics that consume Neo Vitae's shared generative-material pool.

- [`getGenerativeMaterials()` filtering the material registry by `isGenerative`](https://github.com/breakinblocks/NeoVitae/blob/main/src/main/java/com/breakinblocks/neovitae/common/material/MaterialRegistry.java#L514-L520)

This concerns **all three materials**, not only Vibranium and Unobtainium. ATM10 itself presents them as a sequential mining progression:

1. Allthemodium requires at least Netherite-tier mining capability.
2. Vibranium requires at least Allthemodium-tier mining capability.
3. Unobtainium requires at least Vibranium-tier mining capability.

These requirements and their intended locations are stated directly in ATM10's ore tooltips:

- [Allthemodium requires at least Netherite and is associated with the Deep Dark and Mining Dimension](https://github.com/AllTheMods/ATM-10/blob/main/kubejs/client_scripts/tooltips.js#L7-L11)
- [Vibranium requires at least Allthemodium and is associated with the Nether and The Other](https://github.com/AllTheMods/ATM-10/blob/main/kubejs/client_scripts/tooltips.js#L12-L16)
- [Unobtainium requires at least Vibranium and is associated with the End Highlands](https://github.com/AllTheMods/ATM-10/blob/main/kubejs/client_scripts/tooltips.js#L17-L20)

Allthemodium is therefore not an ordinary preliminary resource that can be omitted from this concern. It is the first gated step of the same progression chain and already requires Netherite-tier mining capability. An alternative path that creates Raw Allthemodium without mining Allthemodium Ore can bypass that first gate just as alternative paths to Raw Vibranium or Raw Unobtainium can bypass the later gates.

### Prismatic Demonite creates raw-material items without mining the corresponding ore blocks

Prismatic Demonite does not use ordinary block drops for this reward. Its overridden `getDrops()` method returns an empty list, while `getRandomRawOre()` separately constructs a list of candidate raw-material `ItemStack`s.

- [Prismatic Demonite requiring the correct tool and returning no ordinary drops](https://github.com/breakinblocks/NeoVitae/blob/main/src/main/java/com/breakinblocks/neovitae/common/block/dungeon/BlockPrismaticDemonite.java#L24-L33)
- [`getRandomRawOre()` creating a candidate list and iterating over generative materials](https://github.com/breakinblocks/NeoVitae/blob/main/src/main/java/com/breakinblocks/neovitae/common/block/dungeon/BlockPrismaticDemonite.java#L34-L37)

For each generative material, Neo Vitae first checks whether `gen_raw` explicitly identifies a preferred item. If it does, the item is looked up in the item registry and a new `ItemStack` is added to the candidate list.

- [Resolving `gen_raw` and adding a newly constructed `ItemStack` to the candidates](https://github.com/breakinblocks/NeoVitae/blob/main/src/main/java/com/breakinblocks/neovitae/common/block/dungeon/BlockPrismaticDemonite.java#L37-L45)

If `gen_raw` is empty, Neo Vitae instead reads the material's `raw_tag`, resolves that item tag, and adds a new `ItemStack` for every item found in the tag.

- [Reading and resolving a material's `raw_tag`](https://github.com/breakinblocks/NeoVitae/blob/main/src/main/java/com/breakinblocks/neovitae/common/block/dungeon/BlockPrismaticDemonite.java#L47-L52)
- [Constructing candidate `ItemStack`s directly from the items in that tag](https://github.com/breakinblocks/NeoVitae/blob/main/src/main/java/com/breakinblocks/neovitae/common/block/dungeon/BlockPrismaticDemonite.java#L52-L54)

Neo Vitae then selects one of those candidate stacks at random and returns a copy.

- [Selecting and returning a random candidate `ItemStack`](https://github.com/breakinblocks/NeoVitae/blob/main/src/main/java/com/breakinblocks/neovitae/common/block/dungeon/BlockPrismaticDemonite.java#L56-L57)

In ATM10, `gen_raw` is empty for all three ATM materials, while their `raw_tag` values are configured as follows:

```text
c:raw_materials/allthemodium
c:raw_materials/vibranium
c:raw_materials/unobtainium
```

- [Allthemodium's `raw_tag`, `generative: true`, and empty `gen_raw`](https://github.com/AllTheMods/ATM-10/blob/main/config/neovitae/materials.json#L244-L252)
- [Vibranium's `raw_tag`, `generative: true`, and empty `gen_raw`](https://github.com/AllTheMods/ATM-10/blob/main/config/neovitae/materials.json#L1435-L1443)
- [Unobtainium's `raw_tag`, `generative: true`, and empty `gen_raw`](https://github.com/AllTheMods/ATM-10/blob/main/config/neovitae/materials.json#L1319-L1327)

Accordingly, the code permits the following general path:

```text
Prismatic Demonite
  -> Neo Vitae iterates over generative materials
  -> Allthemodium, Vibranium, or Unobtainium contributes its raw-material tag
  -> an item in that tag is added as a newly constructed ItemStack
  -> one candidate is selected and dropped
```

When Prismatic Demonite is broken, Neo Vitae's `BreakBlockEvent` handler calls `getRandomRawOre()` and places the returned stack into the world with `Block.popResource(...)`. It then cancels the ordinary block-break event.

- [Detecting a Prismatic Demonite break and calling `getRandomRawOre()`](https://github.com/breakinblocks/NeoVitae/blob/main/src/main/java/com/breakinblocks/neovitae/common/event/CommonEventHandler.java#L264-L272)
- [Dropping the returned item with `Block.popResource(...)`](https://github.com/breakinblocks/NeoVitae/blob/main/src/main/java/com/breakinblocks/neovitae/common/event/CommonEventHandler.java#L271-L274)
- [Handling depletion and cancelling the original event](https://github.com/breakinblocks/NeoVitae/blob/main/src/main/java/com/breakinblocks/neovitae/common/event/CommonEventHandler.java#L275-L281)

This path does not create and then mine any of the following blocks:

```text
allthemodium:allthemodium_ore
allthemodium:vibranium_ore
allthemodium:unobtainium_ore
```

Instead, it constructs an item from the configured raw-material tag and drops that item directly. Therefore, it is not merely an additional way to process an ATM ore that the player has already obtained. It is a separate source of the raw progression material itself.

### The AllTheModium ore protections are attached to ore-block destruction and are not reached by direct raw-item generation

AllTheModium explicitly rejects `FakePlayer` destruction for **each of the three ore blocks** in its respective `canEntityDestroy()` implementation:

- [Allthemodium Ore rejecting destruction by a `FakePlayer`](https://github.com/AllTheMods/AllTheModium/blob/1.21.x/src/main/java/com/thevortex/allthemodium/blocks/Allthemodium_Ore.java#L23-L28)
- [Vibranium Ore rejecting destruction by a `FakePlayer`](https://github.com/AllTheMods/AllTheModium/blob/1.21.x/src/main/java/com/thevortex/allthemodium/blocks/Vibranium_Ore.java#L41-L45)
- [Unobtainium Ore rejecting destruction by a `FakePlayer`](https://github.com/AllTheMods/AllTheModium/blob/1.21.x/src/main/java/com/thevortex/allthemodium/blocks/Unobtainium_Ore.java#L40-L44)

All three ore classes also use `requiresCorrectToolForDrops()` and check `hasCorrectToolForDrops(...)` while calculating player mining progress:

- [Allthemodium Ore requiring the correct tool](https://github.com/AllTheMods/AllTheModium/blob/1.21.x/src/main/java/com/thevortex/allthemodium/blocks/Allthemodium_Ore.java#L19-L20)
- [Allthemodium Ore checking `hasCorrectToolForDrops(...)`](https://github.com/AllTheMods/AllTheModium/blob/1.21.x/src/main/java/com/thevortex/allthemodium/blocks/Allthemodium_Ore.java#L32-L40)
- [Vibranium Ore requiring the correct tool](https://github.com/AllTheMods/AllTheModium/blob/1.21.x/src/main/java/com/thevortex/allthemodium/blocks/Vibranium_Ore.java#L37-L39)
- [Vibranium Ore checking `hasCorrectToolForDrops(...)`](https://github.com/AllTheMods/AllTheModium/blob/1.21.x/src/main/java/com/thevortex/allthemodium/blocks/Vibranium_Ore.java#L50-L58)
- [Unobtainium Ore requiring the correct tool](https://github.com/AllTheMods/AllTheModium/blob/1.21.x/src/main/java/com/thevortex/allthemodium/blocks/Unobtainium_Ore.java#L37-L39)
- [Unobtainium Ore checking `hasCorrectToolForDrops(...)`](https://github.com/AllTheMods/AllTheModium/blob/1.21.x/src/main/java/com/thevortex/allthemodium/blocks/Unobtainium_Ore.java#L49-L57)

These protections are meaningful when an entity attempts to destroy an actual ATM ore block. However, the Prismatic Demonite path does not attempt to destroy one of those blocks. It constructs an item from the material's `raw_tag` instead.

For that reason, this interaction should not be described as Neo Vitae directly overriding or disabling AllTheModium's `FakePlayer` check. More precisely, it **skips the ore-breaking stage where AllTheModium's protections would normally be evaluated and directly creates the resulting raw-material item**.

As a consequence, the following ore-level checks do not have an opportunity to govern the Prismatic Demonite reward path:

- the ore block's `canEntityDestroy(...)` implementation;
- its explicit `player instanceof FakePlayer` rejection;
- its correct-tool requirement;
- and its ordinary loot behavior.

The distinction is important because strengthening the ore block's `FakePlayer` protection would not address a system that never destroys that ore block in the first place.

The Prismatic Demonite event handler itself visibly checks whether the event is client-side and whether the player is in Creative mode, but it does not contain an explicit `FakePlayer` exclusion in this branch.

- [The early-return conditions in the Prismatic Demonite block-break handler](https://github.com/breakinblocks/NeoVitae/blob/main/src/main/java/com/breakinblocks/neovitae/common/event/CommonEventHandler.java#L264-L271)

This suggests that automatic breaking of Prismatic Demonite may warrant separate testing if a machine can operate in the relevant dungeon environment and fires the expected `BreakBlockEvent`. However, I have not treated that as a prerequisite for this PR. Actual automation behavior may depend on the machine implementation, event semantics, dungeon restrictions, and other runtime conditions. The central issue established by the code is narrower: **Prismatic Demonite can source raw ATM materials through the generative pool without invoking the corresponding ATM ore blocks.**

### The same `generative` flag also makes all three ATM ore tags eligible for generative meteors

The `generative` setting is not used only by Prismatic Demonite. Neo Vitae also builds the `neovitae:generative_ores` block tag by iterating over the material registry and skipping every material for which `isGenerative()` is false.

- [`writeGenerativeOreTag()` iterating over all registered materials](https://github.com/breakinblocks/NeoVitae/blob/main/src/main/java/com/breakinblocks/neovitae/common/material/MaterialRegistry.java#L220-L223)
- [Excluding materials for which `isGenerative()` is false](https://github.com/breakinblocks/NeoVitae/blob/main/src/main/java/com/breakinblocks/neovitae/common/material/MaterialRegistry.java#L222-L224)

For an included material, Neo Vitae adds the explicit `gen_ore` block when one is configured. Otherwise, it adds the material's `ore_tag` as an optional nested tag entry.

- [Adding an explicit `gen_ore` entry when present](https://github.com/breakinblocks/NeoVitae/blob/main/src/main/java/com/breakinblocks/neovitae/common/material/MaterialRegistry.java#L224-L228)
- [Falling back to the material's `ore_tag`](https://github.com/breakinblocks/NeoVitae/blob/main/src/main/java/com/breakinblocks/neovitae/common/material/MaterialRegistry.java#L228-L234)
- [Writing the resulting values to `tags/block/generative_ores.json`](https://github.com/breakinblocks/NeoVitae/blob/main/src/main/java/com/breakinblocks/neovitae/common/material/MaterialRegistry.java#L236-L240)

ATM10 leaves `gen_ore` empty for Allthemodium, Vibranium, and Unobtainium. Since all three are currently generative, their configured ore tags are therefore eligible to be added to `neovitae:generative_ores`:

```text
#c:ores/allthemodium
#c:ores/vibranium
#c:ores/unobtainium
```

- [Allthemodium's `ore_tag`, `generative: true`, and empty `gen_ore`](https://github.com/AllTheMods/ATM-10/blob/main/config/neovitae/materials.json#L244-L252)
- [Vibranium's `ore_tag`, `generative: true`, and empty `gen_ore`](https://github.com/AllTheMods/ATM-10/blob/main/config/neovitae/materials.json#L1435-L1443)
- [Unobtainium's `ore_tag`, `generative: true`, and empty `gen_ore`](https://github.com/AllTheMods/ATM-10/blob/main/config/neovitae/materials.json#L1319-L1327)

Neo Vitae's generated meteor recipes use `#neovitae:generative_ores` as a weighted block entry. This occurs, for example, in the Stone, Iron, and Diamond meteor recipes:

- [Stone Meteor using `#neovitae:generative_ores`](https://github.com/breakinblocks/NeoVitae/blob/main/src/generated/resources/data/neovitae/recipe/meteor/stone.json#L10-L22)
- [Iron Meteor using `#neovitae:generative_ores`](https://github.com/breakinblocks/NeoVitae/blob/main/src/generated/resources/data/neovitae/recipe/meteor/iron.json#L9-L29)
- [Diamond Meteor using `#neovitae:generative_ores`](https://github.com/breakinblocks/NeoVitae/blob/main/src/generated/resources/data/neovitae/recipe/meteor/diamond.json#L13-L25)

Therefore, the current configuration appears to expose all three ATM ore tags to two distinct generative paths:

1. **Prismatic Demonite** uses the material's `raw_tag` and can construct a raw-material item directly.
2. **Generative meteors** use `neovitae:generative_ores`, into which the material's `ore_tag` can be added.

The meteor path differs from the Prismatic Demonite path because it deals with ore blocks rather than directly returning a raw-material item. Nevertheless, it still introduces a supply route outside the locations and sequence communicated by ATM10's normal ore progression. In particular, making an ATM ore eligible for placement by a general-purpose meteor system is not equivalent to finding that ore under its intended dimension and location conditions.

### Why this is a progression issue rather than only a processing or yield interaction

This interaction does not merely increase the output of an ATM ore that the player has already mined. Prismatic Demonite does not require an Allthemodium, Vibranium, or Unobtainium ore block as its input. It derives candidates from Neo Vitae's generative material registry and directly constructs stacks from `gen_raw` or `raw_tag`.

- [The complete Prismatic Demonite candidate-generation path](https://github.com/breakinblocks/NeoVitae/blob/main/src/main/java/com/breakinblocks/neovitae/common/block/dungeon/BlockPrismaticDemonite.java#L34-L57)

This matters because ATM10 explicitly presents the material ladder as:

```text
Netherite-tier mining
  -> Allthemodium
  -> Allthemodium-tier mining
  -> Vibranium
  -> Vibranium-tier mining
  -> Unobtainium
```

- [ATM10's tooltip requirements for all three ore tiers](https://github.com/AllTheMods/ATM-10/blob/main/kubejs/client_scripts/tooltips.js#L7-L20)

A player who obtains Raw Allthemodium through a separate generative system has not necessarily completed the Netherite-to-Allthemodium mining step. Likewise, a player who obtains Raw Vibranium or Raw Unobtainium through that system has not necessarily completed the preceding ATM material tier or visited the intended ore location.

The configured material definitions also connect these raw-material tags to the corresponding ATM ingots through their `smelt_to` fields:

- [Raw Allthemodium material configuration leading to `allthemodium:allthemodium_ingot`](https://github.com/AllTheMods/ATM-10/blob/main/config/neovitae/materials.json#L237-L252)
- [Raw Vibranium material configuration leading to `allthemodium:vibranium_ingot`](https://github.com/AllTheMods/ATM-10/blob/main/config/neovitae/materials.json#L1428-L1443)
- [Raw Unobtainium material configuration leading to `allthemodium:unobtainium_ingot`](https://github.com/AllTheMods/ATM-10/blob/main/config/neovitae/materials.json#L1312-L1327)

Smithing templates and later crafting requirements may still impose additional gates on specific equipment upgrades. However, those later gates do not undo the early acquisition of the base raw materials or ingots. The player can retain, process, or stockpile the materials before completing the intended mining step, and the materials may also participate in recipes outside the equipment-upgrade path.

For this reason, I believe the issue is best understood as an **alternative acquisition path for progression-gated resources**, rather than merely a production-efficiency interaction.

### Why the ATM10 Neo Vitae configuration is the appropriate place for this change

AllTheModium's protection logic is located on the three ATM ore blocks. That logic can govern attempts to destroy those blocks, but it cannot directly govern another mod constructing an item from a conventional raw-material tag.

- [Allthemodium Ore's protection being implemented in the ore block's `canEntityDestroy()` method](https://github.com/AllTheMods/AllTheModium/blob/1.21.x/src/main/java/com/thevortex/allthemodium/blocks/Allthemodium_Ore.java#L23-L28)
- [Vibranium Ore's protection being implemented in the ore block's `canEntityDestroy()` method](https://github.com/AllTheMods/AllTheModium/blob/1.21.x/src/main/java/com/thevortex/allthemodium/blocks/Vibranium_Ore.java#L41-L45)
- [Unobtainium Ore's protection being implemented in the ore block's `canEntityDestroy()` method](https://github.com/AllTheMods/AllTheModium/blob/1.21.x/src/main/java/com/thevortex/allthemodium/blocks/Unobtainium_Ore.java#L40-L44)
- [Neo Vitae constructing raw-material candidates from `raw_tag`](https://github.com/breakinblocks/NeoVitae/blob/main/src/main/java/com/breakinblocks/neovitae/common/block/dungeon/BlockPrismaticDemonite.java#L47-L54)

Similarly, the meteor path places blocks through Neo Vitae's generative-ore system rather than first attempting to mine an existing ATM ore. Ore-block destruction checks are therefore not the appropriate control point for excluding those ores from the meteor selection pool.

Neo Vitae already provides the `generative` property as the common control for these mechanics:

- Prismatic Demonite reads `getGenerativeMaterials()`, which filters by `isGenerative()`.
- `writeGenerativeOreTag()` also filters by `isGenerative()` before adding `gen_ore` or `ore_tag` entries.

- [The generative-material filter used by Prismatic Demonite](https://github.com/breakinblocks/NeoVitae/blob/main/src/main/java/com/breakinblocks/neovitae/common/material/MaterialRegistry.java#L514-L520)
- [The generative-material filter used to build the meteor ore tag](https://github.com/breakinblocks/NeoVitae/blob/main/src/main/java/com/breakinblocks/neovitae/common/material/MaterialRegistry.java#L220-L240)

For that reason, setting `generative` to `false` in ATM10's Neo Vitae material configuration appears to be the narrowest and most direct way to exclude these pack-specific progression resources from Neo Vitae's general random-generation pool.

## Proposed Change

Set `generative` to `false` for **all three** ATM progression materials in `config/neovitae/materials.json`:

- Allthemodium
- Vibranium
- Unobtainium

```diff
- "generative": true
+ "generative": false
```

This change intentionally includes Allthemodium itself. Allthemodium is the first gated resource in the sequence, requires at least Netherite-tier mining capability according to ATM10's own tooltip, and unlocks the next material tier. Excluding only Vibranium and Unobtainium would leave the first progression gate exposed to the same generative behavior.

The expected effect is to remove all three materials from Neo Vitae's generative-material selection:

- Prismatic Demonite should no longer include their `raw_tag` contents in its random raw-material candidate pool.
- The generated `neovitae:generative_ores` block tag should no longer receive their `ore_tag` entries through these material definitions.
- Other Neo Vitae mechanics that rely on the same generative-material filter should likewise stop selecting them as generic generative resources.

This is deliberately a narrow configuration change. It does **not**:

- remove Allthemodium, Vibranium, or Unobtainium support from Neo Vitae as a whole;
- remove their material definitions, tags, fragments, gravels, dusts, or processing integration;
- alter AllTheModium's normal world generation;
- change legitimate player mining of the three ores;
- change their normal processing routes after they have been acquired;
- or modify AllTheModium's own ore-block protection logic.

It only changes whether Neo Vitae may select these three progression-gated ATM materials through mechanics controlled by the `generative` flag.

The purpose of this PR is therefore not to reduce Neo Vitae's ordinary rewards unnecessarily. It is to keep **Allthemodium, Vibranium, and Unobtainium** out of a general-purpose random resource-generation pool so that all three remain aligned with ATM10's intended Netherite → Allthemodium → Vibranium → Unobtainium acquisition progression.
