### PR TITLE
Prevent progression bypasses and remove invalid Neo Vitae material integrations

### DIFF
--- a/config/neovitae/materials.json
+++ b/config/neovitae/materials.json
@@ -373,21 +373,6 @@
     "gen_raw": ""
   },
   {
-    "name": "bauxite",
-    "color": "#743A00",
-    "stages": [
-      "fragment",
-      "gravel",
-      "dust"
-    ],
-    "smelt_xp": 0.0,
-    "ore_tag": "c:ores/bauxite",
-    "dust_yield_from_ore": 3,
-    "generative": true,
-    "gen_ore": "",
-    "gen_raw": ""
-  },
-  {
     "name": "benitoite",
     "color": "#652828",
     "stages": [
@@ -533,7 +518,7 @@
     "raw_tag": "c:raw_materials/cloggrum",
     "ingot_tag": "c:ingots/cloggrum",
     "dust_yield_from_ore": 3,
-    "generative": true,
+    "generative": false,
     "gen_ore": "",
     "gen_raw": ""
   },
@@ -586,7 +571,7 @@
     "raw_tag": "c:raw_materials/deepsilver",
     "ingot_tag": "c:ingots/deepsilver",
     "dust_yield_from_ore": 3,
-    "generative": true,
+    "generative": false,
     "gen_ore": "",
     "gen_raw": ""
   },
@@ -653,7 +638,7 @@
     "raw_tag": "c:raw_materials/froststeel",
     "ingot_tag": "c:ingots/froststeel",
     "dust_yield_from_ore": 3,
-    "generative": true,
+    "generative": false,
     "gen_ore": "",
     "gen_raw": ""
   },
@@ -686,24 +671,6 @@
     "smelt_xp": 0.7,
     "ore_tag": "c:ores/heliodor",
     "ingot_tag": "c:gems/heliodor",
-    "dust_yield_from_ore": 3,
-    "generative": true,
-    "gen_ore": "",
-    "gen_raw": ""
-  },
-  {
-    "name": "iesnium",
-    "color": "#A2CBCC",
-    "stages": [
-      "fragment",
-      "gravel",
-      "dust"
-    ],
-    "smelt_to": "occultism:iesnium_ingot",
-    "smelt_xp": 0.7,
-    "ore_tag": "c:ores/iesnium",
-    "raw_tag": "c:raw_materials/iesnium",
-    "ingot_tag": "c:ingots/iesnium",
     "dust_yield_from_ore": 3,
     "generative": true,
     "gen_ore": "",
@@ -826,7 +793,7 @@
     "ore_tag": "c:ores/malarite",
     "ingot_tag": "c:gems/malarite",
     "dust_yield_from_ore": 3,
-    "generative": true,
+    "generative": false,
     "gen_ore": "",
     "gen_raw": ""
   },
@@ -1015,7 +982,7 @@
     "ore_tag": "c:ores/regalium",
     "ingot_tag": "c:gems/regalium",
     "dust_yield_from_ore": 3,
-    "generative": true,
+    "generative": false,
     "gen_ore": "",
     "gen_raw": ""
   },
@@ -1032,7 +999,7 @@
     "ore_tag": "c:ores/rogdorium",
     "ingot_tag": "c:ingots/rogdorium",
     "dust_yield_from_ore": 3,
-    "generative": true,
+    "generative": false,
     "gen_ore": "",
     "gen_raw": ""
   },
@@ -1168,7 +1135,7 @@
     "ore_tag": "c:ores/starcore",
     "ingot_tag": "c:gems/starcore",
     "dust_yield_from_ore": 3,
-    "generative": true,
+    "generative": false,
     "gen_ore": "",
     "gen_raw": ""
   },
@@ -1185,7 +1152,7 @@
     "ore_tag": "c:ores/starlit_diamond",
     "ingot_tag": "c:gems/starlit_diamond",
     "dust_yield_from_ore": 3,
-    "generative": true,
+    "generative": false,
     "gen_ore": "",
     "gen_raw": ""
   },
@@ -1240,24 +1207,6 @@
     "gen_raw": ""
   },
   {
-    "name": "titanium",
-    "color": "#C44AD1",
-    "stages": [
-      "fragment",
-      "gravel",
-      "dust"
-    ],
-    "smelt_to": "modern_industrialization:titanium_ingot",
-    "smelt_xp": 0.7,
-    "ore_tag": "c:ores/titanium",
-    "raw_tag": "c:raw_materials/titanium",
-    "ingot_tag": "c:ingots/titanium",
-    "dust_yield_from_ore": 3,
-    "generative": true,
-    "gen_ore": "",
-    "gen_raw": ""
-  },
-  {
     "name": "topaz",
     "color": "#7B2200",
     "stages": [
@@ -1269,24 +1218,6 @@
     "smelt_xp": 0.7,
     "ore_tag": "c:ores/topaz",
     "ingot_tag": "c:gems/topaz",
-    "dust_yield_from_ore": 3,
-    "generative": true,
-    "gen_ore": "",
-    "gen_raw": ""
-  },
-  {
-    "name": "tungsten",
-    "color": "#323455",
-    "stages": [
-      "fragment",
-      "gravel",
-      "dust"
-    ],
-    "smelt_to": "modern_industrialization:tungsten_ingot",
-    "smelt_xp": 0.7,
-    "ore_tag": "c:ores/tungsten",
-    "raw_tag": "c:raw_materials/tungsten",
-    "ingot_tag": "c:ingots/tungsten",
     "dust_yield_from_ore": 3,
     "generative": true,
     "gen_ore": "",
@@ -1421,7 +1352,7 @@
     "ore_tag": "c:ores/utherium",
     "ingot_tag": "c:gems/utherium",
     "dust_yield_from_ore": 3,
-    "generative": true,
+    "generative": false,
     "gen_ore": "",
     "gen_raw": ""
   },
@@ -1461,25 +1392,8 @@
     "gen_raw": ""
   },
   {
-    "name": "xychorium",
-    "color": "#808080",
-    "stages": [
-      "fragment",
-      "gravel",
-      "dust"
-    ],
-    "smelt_to": "xycraft_world:xychorium_gem_blue",
-    "smelt_xp": 0.7,
-    "ore_tag": "c:ores/xychorium",
-    "ingot_tag": "c:gems/xychorium",
-    "dust_yield_from_ore": 3,
-    "generative": true,
-    "gen_ore": "",
-    "gen_raw": ""
-  },
-  {
     "name": "xychorium_blue",
-    "color": "#808080",
+    "color": "#19CFE0",
     "stages": [
       "fragment",
       "gravel",
@@ -1487,6 +1401,7 @@
     ],
     "smelt_xp": 0.0,
     "ore_tag": "c:ores/xychorium_blue",
+    "display_name": "Blue Xychorium",
     "dust_yield_from_ore": 3,
     "generative": true,
     "gen_ore": "",
@@ -1494,7 +1409,7 @@
   },
   {
     "name": "xychorium_dark",
-    "color": "#808080",
+    "color": "#39345F",
     "stages": [
       "fragment",
       "gravel",
@@ -1502,6 +1417,7 @@
     ],
     "smelt_xp": 0.0,
     "ore_tag": "c:ores/xychorium_dark",
+    "display_name": "Dark Xychorium",
     "dust_yield_from_ore": 3,
     "generative": true,
     "gen_ore": "",
@@ -1509,7 +1425,7 @@
   },
   {
     "name": "xychorium_green",
-    "color": "#808080",
+    "color": "#69D84D",
     "stages": [
       "fragment",
       "gravel",
@@ -1517,6 +1433,7 @@
     ],
     "smelt_xp": 0.0,
     "ore_tag": "c:ores/xychorium_green",
+    "display_name": "Green Xychorium",
     "dust_yield_from_ore": 3,
     "generative": true,
     "gen_ore": "",
@@ -1524,7 +1441,7 @@
   },
   {
     "name": "xychorium_light",
-    "color": "#808080",
+    "color": "#E8D2CC",
     "stages": [
       "fragment",
       "gravel",
@@ -1532,6 +1449,7 @@
     ],
     "smelt_xp": 0.0,
     "ore_tag": "c:ores/xychorium_light",
+    "display_name": "Light Xychorium",
     "dust_yield_from_ore": 3,
     "generative": true,
     "gen_ore": "",
@@ -1539,7 +1457,7 @@
   },
   {
     "name": "xychorium_red",
-    "color": "#808080",
+    "color": "#E85A68",
     "stages": [
       "fragment",
       "gravel",
@@ -1547,22 +1465,7 @@
     ],
     "smelt_xp": 0.0,
     "ore_tag": "c:ores/xychorium_red",
-    "dust_yield_from_ore": 3,
-    "generative": true,
-    "gen_ore": "",
-    "gen_raw": ""
-  },
-  {
-    "name": "yellorite",
-    "color": "#BDBD00",
-    "stages": [
-      "fragment",
-      "gravel",
-      "dust"
-    ],
-    "smelt_to": "alltheores:uranium_ingot",
-    "smelt_xp": 0.7,
-    "ore_tag": "c:ores/yellorite",
+    "display_name": "Red Xychorium",
     "dust_yield_from_ore": 3,
     "generative": true,
     "gen_ore": "",


### PR DESCRIPTION
## Background and Goals

This PR expands on #4350, which disabled Neo Vitae's generative behavior for the three ATM progression ores. While that PR was a narrow hotfix, this PR reviews the broader material configuration, prevents additional progression and processing bypasses, and cleans up invalid material definitions and integrations for resources whose world generation is intentionally disabled in ATM10.

## Summary of Changes

| Change | Materials |
|---|---|
| Set `generative` to `false` | Eternal Starlight ores and Undergarden ores |
| Remove the Neo Vitae material definition | Iesnium, Titanium, Tungsten, generic Xychorium, Bauxite, and Yellorite |
| Keep the material definitions and correct their metadata | The five actual Xychorium variants |

## Affected Materials and Rationale

### 1. Resource with special acquisition requirements

- Occultism — Iesnium

Iesnium is intended to be found and mined through Occultism's progression. The player must have the Third Eye effect to see the ore and must use an Infused Pickaxe to mine it properly.

Including Iesnium in Neo Vitae's material system allows it to be obtained outside its intended discovery and mining process. Since searching for and obtaining Iesnium is itself part of Occultism's content, this PR removes the Iesnium material definition entirely rather than retaining it as a generic Neo Vitae processing material.

### 2. Resources requiring dedicated processing

- Modern Industrialization — Titanium and Tungsten

Titanium and Tungsten are designed to be processed through Modern Industrialization's dedicated high-temperature machinery rather than through a normal furnace.

However, Neo Vitae generates fragment, gravel, and dust processing stages for both materials, along with recipes that allow their dusts to be smelted directly into MI ingots in a normal furnace. This completely bypasses MI's intended processing chain.

Titanium also presents an additional progression concern because it does not naturally generate as an Overworld ore in ATM10.

The material definitions for Titanium and Tungsten are therefore removed entirely.

### 3. Dimension-exclusive resources

- Eternal Starlight — Deepsilver, Malarite, Starcore, and Starlit Diamond
- The Undergarden — Cloggrum, Froststeel, Regalium, Rogdorium, and Utherium

These resources are normally obtained by visiting and exploring their respective modded dimensions. Allowing Neo Vitae's generative systems to provide them elsewhere bypasses that exploration.

Their material definitions and Neo Vitae processing variants are retained, allowing players to process the resources after obtaining them normally. Only their `generative` value is changed to `false` so that Neo Vitae cannot bypass the dimension-specific acquisition process.

### 4. Invalid generic material definition

- XyCraft — generic Xychorium

The material named `xychorium` uses the `c:ores/xychorium` tag. This tag is only an umbrella containing the five actual Xychorium variants: Blue, Dark, Green, Light, and Red. There is no separate sixth generic Xychorium resource.

The current definition creates an additional generic Xychorium processing path that resolves to Blue Xychorium, even though generic Xychorium is only an umbrella tag for the five real variants. This PR removes that invalid generic material definition while retaining all five actual Xychorium materials.

### 5. Resources with world generation disabled in ATM10

- Modern Industrialization — Bauxite
- Extreme Reactors — Yellorite

ATM10 explicitly disables Modern Industrialization's Bauxite world generation. Allowing Neo Vitae to place Bauxite Ore through its generative systems unintentionally reintroduces a resource that the pack deliberately removed from normal world generation.

- [Disabled Bauxite biome modifier](https://github.com/AllTheMods/ATM-10/blob/main/kubejs/data/modern_industrialization/neoforge/biome_modifier/ore_generator_bauxite.json)

ATM10 also disables normal Yellorite world generation and unifies reactor fuel resources around Uranium. However, Neo Vitae still registers Yellorite as a generative material, allowing Yellorite Ore to reappear through Neo Vitae's resource-generation systems.

- [Disabled Yellorite biome modifier](https://github.com/AllTheMods/ATM-10/blob/main/kubejs/data/bigreactors/neoforge/biome_modifier/yellorite.json)

The Bauxite and Yellorite material definitions are removed entirely so that Neo Vitae does not reintroduce these ores or expose unnecessary generated intermediate items and JEI entries for them.

## Implementation Approach

This PR uses two different approaches depending on the nature of each problem.

### Setting `generative` to `false`

This is used for the Eternal Starlight and Undergarden resources. It prevents Neo Vitae's generative systems from bypassing dimension exploration while preserving the ability to process resources that the player obtained normally.

### Removing the complete material definition

This is used when `generative: false` is not sufficient:

- **Iesnium:** The resource is intentionally kept tied to Occultism's discovery and acquisition process instead of being retained as a generic Neo Vitae material.
- **Titanium and Tungsten:** Their generated processing stages and direct dust-to-ingot smelting recipes would remain, continuing to bypass MI's dedicated machinery.
- **Bauxite and Yellorite:** Their generated intermediate variants and JEI entries would remain even though ATM10 disables their normal world generation.
- **Generic Xychorium:** The invalid sixth material path would continue to exist because the issue is the material definition itself, not only its generative behavior.

For material definitions that are removed, setting `generative` to `false` only removes them from Neo Vitae's generative pool. It does not remove the automatically generated item variants or processing recipes. This behavior was confirmed with both Neo Vitae 1.1.15, included in ATM10 8.1, and Neo Vitae 1.1.17.

## Impact

This removes the generated Neo Vitae item variants for Iesnium, Titanium, Tungsten, generic Xychorium, Bauxite, and Yellorite.

Existing stacks of those generated items may be lost when updating, so this is a potentially world-affecting configuration change.

The Eternal Starlight and Undergarden resources changed only to `generative: false` retain their existing Neo Vitae processing variants.

## Known Unresolved Case

### Powah Uraninite variants

Neo Vitae currently creates separate material definitions for Uraninite and its Poor, Regular, and Dense ore variants. These are different grades of the same resource and are intended to have different yields, but I have not found a clean way to represent those yield differences without creating redundant Neo Vitae material variants.

They are therefore intentionally left unchanged in this PR.

## Deferred Issue

### Coal and Lignite Coal

Smelting Neo Vitae's Coal Dust or Lignite Coal Dust back into the original fuel creates a somewhat questionable processing path, and I initially considered addressing it in this PR.

However, removing those material definitions would also remove Coal and Lignite Coal from meteor generation, even though obtaining coal from a meteor is not inherently inappropriate. Neo Vitae also contains a separate recipe that assumes the Coal material and `neovitae:coal_dust` exist.

Addressing this cleanly requires a separate change, so Coal and Lignite Coal are intentionally left unchanged in this PR.

## Additional Changes

- Corrected the displayed material names of the five actual Xychorium variants so that they match the original XyCraft material names.
- Updated their representative colors to match the corresponding Xychorium variants.

## Testing

- Confirmed that the game starts successfully with the modified material configuration.
- Confirmed that KubeJS and Kube Tweaks report no data-loading errors related to these changes.
- Confirmed that Iesnium's generated Neo Vitae variants and JEI processing entries are removed.
- Confirmed that the Eternal Starlight and Undergarden materials are excluded from `neovitae:generative_ores` while retaining their fragment, gravel, and dust processing variants.
- Confirmed that the generated Titanium and Tungsten variants and their direct dust-to-ingot furnace recipes are removed from JEI.
- Confirmed that the additional generic Xychorium processing path is removed.
- Confirmed that the generated Bauxite and Yellorite variants are removed.
- Confirmed that all five actual Xychorium variants remain available and that their corrected names and representative colors match the corresponding materials.
