### PR TITLE
Disable Glyph of Nullify Defense and hide it from recipe viewers

### DIFF
--- a/config/ars_elemental/glyph_nullify_defense.toml
+++ b/config/ars_elemental/glyph_nullify_defense.toml
@@ -1,0 +1,27 @@
+#General settings
+[general]
+	#Is Enabled?
+	enabled = false
+	#Cost
+	# Default: 1000
+	# Range: > -2147483648
+	cost = 1000
+	#Is Starter Glyph?
+	starter = false
+	#The maximum number of times this glyph may appear in a single spell
+	# Default: 2147483647
+	# Range: > 1
+	per_spell_limit = 2147483647
+	#The tier of the glyph
+	# Default: 3
+	# Range: 1 ~ 99
+	glyph_tier = 3
+	#Limits the number of times a given augment may be applied to a given effect
+	#Example entry: "glyph_amplify=5"
+	augment_limits = []
+	#How much an augment should cost when used on this effect or form. This overrides the default cost in the augment config.
+	#Example entry: "glyph_amplify=50"
+	augment_cost_overrides = []
+	#Prevents the given glyph from being used in the same spell as the given glyph
+	#Example entry: "glyph_burst"
+	invalid_combos = []

--- a/kubejs/client_scripts/RecipeViewer.js
+++ b/kubejs/client_scripts/RecipeViewer.js
@@ -50,6 +50,8 @@ RecipeViewerEvents.removeEntriesCompletely('item', allthemods => {
     allthemods.remove(/mekmm:.*rolling_mill.*/)
 
     allthemods.remove("supplementaries:faucet")
+
+    allthemods.remove('ars_elemental:glyph_nullify_defense')
 })
 
 // RecipeViewerEvents.removeEntriesCompletely('mekanism:chemical', allthemods => {


### PR DESCRIPTION
## Background

Glyph of Nullify Defense is a Tier 3 glyph from Ars Elemental. Its recipe is disabled in ATM10, so players cannot unlock or craft it, and it does not appear as an available glyph in the Spell Book or Scribe's Table.

However, it remains visible in recipe viewers with the tooltip:

> You have not unlocked this glyph.

This can mislead players into thinking that the glyph is obtainable through an undocumented progression step or another special acquisition method.

## Changes

This PR:

- Adds a glyph configuration file for Glyph of Nullify Defense and sets `enabled` to `false`.
- Completely hides the disabled glyph from recipe viewers.

This avoids displaying conflicting availability messages for a glyph that cannot be obtained or used.

## Behavior Comparison

| Behavior | Before this PR | After this PR |
|:---|:---:|:---:|
| Obtainable | No | No |
| Visible in Spell Book search | No | No |
| Visible in Scribe's Table | No | No |
| Visible in recipe viewers | Yes | No |
| Recipe viewer tooltip | `You have not unlocked this glyph.` | Not shown |
| Tattered Tome entry | Present | Present, with no configurable options |

## Result

This does not change the glyph's gameplay availability. It makes its disabled state explicit in the configuration and removes its misleading entry from recipe viewers.