### PR TITLE
Blacklist Neo Vitae Imprisonment Array from certain mobs

### DIFF
--- a/kubejs/server_scripts/Tweaks/tags.js
+++ b/kubejs/server_scripts/Tweaks/tags.js
@@ -194,6 +194,11 @@ ServerEvents.tags('entity_type', allthemods => {
   allthemods.add('ars_additions:source_spawner_denylist', '#allthemods:jank_blacklist')
   allthemods.add('oritech:spawner_blacklist', '#allthemods:jank_blacklist')
   allthemods.add('occultism:soul_shattered_deny_list', '#allthemods:jank_blacklist')  
+  
+  allthemods.add('neovitae:deny_imprisonment', [
+	"#c:capturing_not_supported",
+	"#apothic_spawners:blacklisted_from_spawners"
+  ])
 
 })
 


### PR DESCRIPTION
- The blacklist includes all uncapturable mobs, as per #c:capturing_not_supported, as well as all mobs part of the Apothic Spawners blacklist tag